### PR TITLE
default to http and let browser redirect to https

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Extensions/StringExtensionsTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Extensions/StringExtensionsTests.cs
@@ -50,9 +50,7 @@ namespace ConcernsCaseWork.Tests.Extensions
 		}
 
 		[TestCase("http://www.holleyparkacademy.co.uk", "http://www.holleyparkacademy.co.uk")]
-		[TestCase("www.holleyparkacademy.co.uk", "https://www.holleyparkacademy.co.uk")]
-		[TestCase("https://www.holleyparkacademy.co.uk", "https://www.holleyparkacademy.co.uk")]
-		[TestCase("www.holleyparkacademy.co.uk", "https://www.holleyparkacademy.co.uk")]
+		[TestCase("www.holleyparkacademy.co.uk", "http://www.holleyparkacademy.co.uk")]
 		public void WhenToUri_Returns_Valid_Url(string input, string expected)
 		{
 			// assert

--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/StringExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/StringExtensions.cs
@@ -36,7 +36,7 @@ namespace ConcernsCaseWork.Extensions
 
 		public static string ToUrl(this string value)
 		{
-			return Uri.TryCreate(value, UriKind.Absolute, out Uri _) ? value : $"https://{value}";
+			return Uri.TryCreate(value, UriKind.Absolute, out Uri _) ? value : $"http://{value}";
 		}
 	}
 }


### PR DESCRIPTION
**What is the change?**
default to http and let browser redirect to https

**Why do we need the change?**
defaulting to https broke the link for some establishments. ex: Branston Junior Academy

**What is the impact?**

**Azure DevOps Ticket**
76559
