### PR TITLE
Removed the check and excluded test for the check.

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
@@ -181,6 +181,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 		}
 
 		[Test]
+		[Ignore("Implementation related to this test has been reversed (ticket: 89799)")]
 		public async Task WhenOnGetAsync_Returns_Only_Other_Trust_Cases_ReturnsPageModel()
 		{
 			// arrange

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
@@ -84,7 +84,7 @@ namespace ConcernsCaseWork.Pages.Case.Management
 
 				CasesHistoryModel = caseHistoryTask.Result;
 				TrustDetailsModel = trustDetailsTask.Result;
-				TrustCasesModel = trustCasesTask.Result.Where(c => c.CaseUrn != caseUrn).ToList();
+				TrustCasesModel = trustCasesTask.Result;
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
**What is the change?**
A new bug has made the team to reverse a previously implemented change. The previous change used to exclude the current case from cases list on the trust overview page. (please see ticket 89799 for more details).

**Why do we need the change?**
Explained above ^^

**What is the impact?**
Minor : UI change

**Azure DevOps Ticket**
89799
