### PR TITLE
Fix incorrect property name

### DIFF
--- a/ConcernsCaseWork/Service.TRAMS/Records/CreateRecordDto.cs
+++ b/ConcernsCaseWork/Service.TRAMS/Records/CreateRecordDto.cs
@@ -38,7 +38,7 @@ namespace Service.TRAMS.Records
 		[JsonProperty("statusUrn")]
 		public long StatusUrn { get; }
 		
-		[JsonProperty("means-of-referral-urn")]
+		[JsonProperty("meansOfReferralUrn")]
 		public long MeansOfReferralUrn { get; }
 		
 		[JsonConstructor]


### PR DESCRIPTION
Fix incorrect json property name for Means of Referral Urn
Bug fix - the value is not mapped & therefore not sent to TRAMS
#102939


