### PR TITLE
Fix incorrect spelling of 'canceled' to 'cancelled'

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/SRMA/ResolvePageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/SRMA/ResolvePageModelTests.cs
@@ -147,7 +147,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.SRMA
 			await pageModel.OnGetAsync();
 
 			// assert
-			Assert.That(pageModel.ConfirmText, Is.EqualTo("Confirm SRMA was canceled"));
+			Assert.That(pageModel.ConfirmText, Is.EqualTo("Confirm SRMA was cancelled"));
 		}
 
 		[Test]

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
@@ -222,7 +222,7 @@
 				@Model.DeclineCompleteButtonLabel
 			</a>
 			<a data-prevent-double-click="true" asp-page-handler="Cancel" class="govuk-button govuk-button--secondary" data-module="govuk-button" role="button">
-				SRMA canceled
+				SRMA cancelled
 			</a>
 		</div>
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml.cs
@@ -53,7 +53,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Srma
 				switch (resoultion)
 				{
 					case ResolutionCanceled:
-						ConfirmText = "Confirm SRMA was canceled";
+						ConfirmText = "Confirm SRMA was cancelled";
 						break;
 					case ResolutionDeclined:
 						ConfirmText = "Confirm SRMA was declined by trust";


### PR DESCRIPTION
Fixed incorrect spelling of 'canceled' in SRMA

#102704

