### PR TITLE
Added app secret args to Cypress pipeline for API tests

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Npm install
         run: npm install
       - name: Run cypress
-        run: npm run cy:run -- --env username='${{ secrets.USERNAME }},password=${{ secrets.PASSWORD }},url=${{ secrets.ENDPOINT }}'
+        run: npm run cy:run -- --env username='${{ secrets.USERNAME }},password=${{ secrets.PASSWORD }},url=${{ secrets.ENDPOINT }},api=${{ secrets.TRAMS_API_ENDPOINT }},apiKey=${{ secrets.TRAMS_API_KEY }}'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:


### PR DESCRIPTION
**What is the change?**
Added apiKey and TRAMS URL app secrets to Cypress pipeline command to support API testing

**Why do we need the change?**
Increase E2E test coverage and support future api testing

**What is the impact?**
unused args have no impact

**Azure DevOps Ticket**
AB#103257