### PR TITLE
Bug/103917 fin plan status buttons disappear on error

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/FinancialPlan/AddPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/FinancialPlan/AddPageModelTests.cs
@@ -97,6 +97,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<AddPageModel>>();
 
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
+			
 			var pageModel = SetupAddPageModel(mockFinancialPlanModelService.Object, mockFinancialPlanStatusService.Object, mockLogger.Object);
 
 			var routeData = pageModel.RouteData.Values;
@@ -127,6 +130,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<AddPageModel>>();
 
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
+			
 			var pageModel = SetupAddPageModel(mockFinancialPlanModelService.Object, mockFinancialPlanStatusService.Object, mockLogger.Object);
 
 			var routeData = pageModel.RouteData.Values;
@@ -155,7 +161,10 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<AddPageModel>>();
-
+			
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
+			
 			var pageModel = SetupAddPageModel(mockFinancialPlanModelService.Object, mockFinancialPlanStatusService.Object, mockLogger.Object);
 
 			var routeData = pageModel.RouteData.Values;
@@ -184,7 +193,10 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<AddPageModel>>();
-
+			
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
+			
 			var pageModel = SetupAddPageModel(mockFinancialPlanModelService.Object, mockFinancialPlanStatusService.Object, mockLogger.Object);
 
 			var routeData = pageModel.RouteData.Values;

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/FinancialPlan/EditPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/FinancialPlan/EditPageModelTests.cs
@@ -121,6 +121,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<EditPageModel>>();
 
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
+			
 			var caseUrn = 1L;
 			var financialPlanId = 2L;
 			
@@ -160,6 +163,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<EditPageModel>>();
 			
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
+			
 			var caseUrn = 1L;
 			var financialPlanId = 2L;
 			
@@ -198,6 +204,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<EditPageModel>>();
 
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
+			
 			var caseUrn = 1L;
 			var financialPlanId = 2L;
 			
@@ -236,6 +245,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.FinancialPlan
 			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
 			var mockFinancialPlanStatusService = new Mock<IFinancialPlanStatusCachedService>();
 			var mockLogger = new Mock<ILogger<EditPageModel>>();
+			
+			var statuses = FinancialPlanStatusFactory.BuildListOpenFinancialPlanStatusDto();
+			mockFinancialPlanStatusService.Setup(s => s.GetOpenFinancialPlansStatusesAsync()).ReturnsAsync(statuses);
 			
 			var caseUrn = 1L;
 			var financialPlanId = 2L;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Add.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using ConcernsCaseWork.Models.CaseActions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
@@ -75,14 +76,15 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 			catch (InvalidOperationException ex)
 			{
 				TempData["FinancialPlan.Message"] = ex.Message;
+				FinancialPlanStatuses = await GetStatusOptionsAsync();
 			}
 			catch (Exception ex)
 			{
-				_logger.LogError("Case::SRMA::AddPageModel::OnPostAsync::Exception - {Message}", ex.Message);
+				_logger.LogError("Case::FinancialPlan::AddPageModel::OnPostAsync::Exception - {Message}", ex.Message);
 
 				TempData["Error.Message"] = ErrorOnPostPage;
 			}
-
+			
 			return Page();
 		}
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Edit.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Edit.cshtml.cs
@@ -40,16 +40,20 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 				FinancialPlanModel = await _financialPlanModelService.GetFinancialPlansModelById(caseUrn, financialPlanId, loggedInUser);
 				
 				FinancialPlanStatuses = await GetStatusOptionsAsync(FinancialPlanModel.Status?.Name);
-
-				return Page();
+			}
+			catch (InvalidOperationException ex)
+			{
+				TempData["FinancialPlan.Message"] = ex.Message;
+				FinancialPlanStatuses = await GetStatusOptionsAsync();
 			}
 			catch (Exception ex)
 			{
 				_logger.LogError("Case::FinancialPlan::EditPageModel::OnGetAsync::Exception - {Message}", ex.Message);
 
 				TempData["Error.Message"] = ErrorOnGetPage;
-				return Page();
 			}
+			
+			return Page();
 		}
 
 		public async Task<IActionResult> OnPostAsync()
@@ -92,6 +96,11 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 			catch (InvalidOperationException ex)
 			{
 				TempData["FinancialPlan.Message"] = ex.Message;
+				
+				FinancialPlanModel = await _financialPlanModelService.GetFinancialPlansModelById(GetRequestedCaseUrn(), GetRequestedFinancialPlanId(), GetLoggedInUserName());
+				
+				var currentStatusName = FinancialPlanModel.Status?.Name;
+				FinancialPlanStatuses = await GetStatusOptionsAsync(currentStatusName);
 			}
 			catch (Exception ex)
 			{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Close.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Close.cshtml.cs
@@ -102,7 +102,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 			}
 			else
 			{
-				throw new InvalidOperationException("CaseUrn not found in the route");
+				throw new Exception("CaseUrn not found in the route");
 			}
 		}
 
@@ -114,7 +114,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 			}
 			else
 			{
-				throw new InvalidOperationException("CaseUrn not found in the route");
+				throw new Exception("CaseUrn not found in the route");
 			}
 		}
 


### PR DESCRIPTION
Bug fix for Financial Plan radio buttons disappearing on validation error, on add and edit. 

See ticket #103917 
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/backlog/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2025?workitem=103917
