### PR TITLE
Ensure original date plan requested and date viable plan received are persisted on close

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/FinancialPlanMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/FinancialPlanMapping.cs
@@ -67,9 +67,9 @@ namespace ConcernsCaseWork.Mappers
 				patchFinancialPlanModel?.ClosedAt ?? financialPlanDto.ClosedAt,
 				financialPlanDto.CreatedBy,
 				selectedStatusId,
-				patchFinancialPlanModel.DatePlanRequested,
-				patchFinancialPlanModel.DateViablePlanReceived,
-				patchFinancialPlanModel.Notes);
+				patchFinancialPlanModel?.DatePlanRequested ?? financialPlanDto.DatePlanRequested,
+				patchFinancialPlanModel?.DateViablePlanReceived ?? financialPlanDto.DateViablePlanReceived,
+				patchFinancialPlanModel?.Notes);
 
 			return updatedFinancialPlanDto;
 		}


### PR DESCRIPTION
Bugfix for 
104431 - Financial plan - Dates disappear once action is closed
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/104431

Bug was: Date Plan Requested and Date Viable Plan Received were being overwritten to null on close. 
Now they default to the original value if not submitted on any patch.


Note that I have not included tests for this as we currently don't have a standard for testing the mapping, and as this is a bug fix I wanted to push it through quickly. 
