### PR TITLE
Feature/105360 cd keep a list of users in cc

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Redis/CacheProviderIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Redis/CacheProviderIntegrationTests.cs
@@ -122,7 +122,7 @@ namespace ConcernsCaseWork.Integration.Tests.Redis
 			var cacheEntryOptions = new DistributedCacheEntryOptions()
 				.SetSlidingExpiration(TimeSpan.FromSeconds(cacheTimeToLive));
 			
-			var caseStateData = new UserState
+			var caseStateData = new UserState("test@email.com")
 			{
 				TrustUkPrn = "999999"
 			};

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Concern/AddPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Concern/AddPageModelTests.cs
@@ -30,7 +30,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 
 			var createCaseModel = CaseFactory.BuildCreateCaseModel();
 			createCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
+			var userState = new UserState("tester.one") { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
 			var expected = TrustFactory.BuildTrustDetailsModel();
 
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
@@ -77,7 +77,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 
 			var createCaseModel = CaseFactory.BuildCreateCaseModel();
 			createCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
-			var userState = new UserState { CreateCaseModel = createCaseModel };
+			var userState = new UserState("testing") { CreateCaseModel = createCaseModel };
 
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 
@@ -149,7 +149,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			var mockUserStateCachedService = new Mock<IUserStateCachedService>();
 
-			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(new UserState());
+			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(new UserState("testing"));
 			mockUserStateCachedService.Setup(c => c.StoreData(It.IsAny<string>(), It.IsAny<UserState>()));
 
 			var pageModel = SetupAddPageModel(mockTrustModelService.Object, mockUserStateCachedService.Object, mockLogger.Object, true);

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Concern/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Concern/IndexPageModelTests.cs
@@ -45,7 +45,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 			var expectedMeansOfReferralModels = MeansOfReferralFactory.BuildListMeansOfReferralModels();
 
 			mockTypeModelService.Setup(t => t.GetTypeModel()).ReturnsAsync(expectedTypeModel);
-			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(new UserState { TrustUkPrn = "trust-ukprn" });
+			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(new UserState("testing") { TrustUkPrn = "trust-ukprn" });
 			mockTrustModelService.Setup(s => s.GetTrustByUkPrn(It.IsAny<string>())).ReturnsAsync(expected);
 			mockRatingModelService.Setup(r => r.GetRatingsModel()).ReturnsAsync(expectedRatingsModel);
 			mockMeansOfReferralModelService.Setup(m => m.GetMeansOfReferrals()).ReturnsAsync(expectedMeansOfReferralModels);
@@ -169,7 +169,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 
 			var createCaseModel = CaseFactory.BuildCreateCaseModel();
 			createCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
-			var userState = new UserState { CreateCaseModel = createCaseModel };
+			var userState = new UserState("testing") { CreateCaseModel = createCaseModel };
 			
 			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 
@@ -250,7 +250,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 			var mockMeansOfReferralModelService = new Mock<IMeansOfReferralModelService>();
 			
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 
 			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 
@@ -292,7 +292,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 			var mockMeansOfReferralModelService = new Mock<IMeansOfReferralModelService>();
 			
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 
 			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 
@@ -326,7 +326,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 			var mockMeansOfReferralModelService = new Mock<IMeansOfReferralModelService>();
 
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 
 			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 
@@ -388,7 +388,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Concern
 			var mockMeansOfReferralModelService = new Mock<IMeansOfReferralModelService>();
 			
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 
 			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/DetailsPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/DetailsPageModelTests.cs
@@ -37,7 +37,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var expectedTrustDetailsModel = TrustFactory.BuildTrustDetailsModel();
 			expectedCreateCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
 			
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = "trust-ukprn", 
 				CreateCaseModel = expectedCreateCaseModel
@@ -117,7 +117,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>()))
-				.ReturnsAsync(new UserState());
+				.ReturnsAsync(new UserState("testing"));
 			
 			var pageModel = SetupDetailsModel(mockCaseModelService.Object, 
 				mockTrustModelService.Object, 
@@ -203,7 +203,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 			mockCaseModelService.Setup(c => c.PostCase(It.IsAny<CreateCaseModel>())).ReturnsAsync(1);
@@ -245,7 +245,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 
 			var expectedTrustByUkprn = TrustFactory.BuildTrustDetailsModel();
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 			mockCaseModelService.Setup(c => c.PostCase(It.IsAny<CreateCaseModel>())).ReturnsAsync(1);
@@ -279,7 +279,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 
 			var expectedTrustByUkprn = TrustFactory.BuildTrustDetailsModel();
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 			mockCaseModelService.Setup(c => c.PostCase(It.IsAny<CreateCaseModel>())).ReturnsAsync(1);

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/IndexPageModelTests.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Models;
+﻿using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Pages.Case;
 using ConcernsCaseWork.Services.Trusts;
 using ConcernsCaseWork.Shared.Tests.Factory;
@@ -17,6 +18,7 @@ using Service.TRAMS.Trusts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case
@@ -232,9 +234,12 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 		
 		private static IndexPageModel SetupIndexModel(ITrustModelService mockTrustModelService, IUserStateCachedService mockUserStateCachedService, ILogger<IndexPageModel> mockLogger, bool isAuthenticated = false)
 		{
+			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
+			mockClaimsPrincipalHelper.Setup(x => x.GetPrincipalName(It.IsAny<ClaimsPrincipal>())).Returns("Tester");
+
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 			
-			return new IndexPageModel(mockTrustModelService, mockUserStateCachedService, mockLogger)
+			return new IndexPageModel(mockTrustModelService, mockUserStateCachedService, mockLogger, mockClaimsPrincipalHelper.Object)
 			{
 				PageContext = pageContext,
 				TempData = tempData,

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/IndexPageModelTests.cs
@@ -160,7 +160,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			var mockUserStateCachedService = new Mock<IUserStateCachedService>();
 
-			var userState = new UserState();
+			var userState = new UserState("testing");
 			
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 			mockUserStateCachedService.Setup(c => c.StoreData(It.IsAny<string>(), It.IsAny<UserState>()))

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/RatingPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/RatingPageModelTests.cs
@@ -35,7 +35,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 
 			var createCaseModel = CaseFactory.BuildCreateCaseModel();
 			createCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
 			var expected = TrustFactory.BuildTrustDetailsModel();
 			var ratingsModel = RatingFactory.BuildListRatingModel();
 			
@@ -92,7 +92,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 
 			var createCaseModel = CaseFactory.BuildCreateCaseModel();
 			createCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
-			var userState = new UserState { CreateCaseModel = createCaseModel };
+			var userState = new UserState("testing") { CreateCaseModel = createCaseModel };
 			var expected = TrustFactory.BuildTrustDetailsModel();
 			var ratingsModel = RatingFactory.BuildListRatingModel();
 			
@@ -179,7 +179,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockCachedService = new Mock<IUserStateCachedService>();
 			var mockRatingModelService = new Mock<IRatingModelService>();
 			
-			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(new UserState());
+			mockCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(new UserState("testing"));
 			mockCachedService.Setup(c => c.StoreData(It.IsAny<string>(), It.IsAny<UserState>()));
 			
 			var pageModel = SetupRatingPageModel(mockTrustModelService.Object, 
@@ -234,7 +234,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockRatingModelService = new Mock<IRatingModelService>();
 			
 			var expected = CaseFactory.BuildCreateCaseModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = expected };
 			
 			mockUserStateCachedService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 			
@@ -272,7 +272,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			
 			var createCaseModel = CaseFactory.BuildCreateCaseModel();
 			createCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
 			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
 			var ratingsModel = RatingFactory.BuildListRatingModel();
 
@@ -312,7 +312,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			
 			var createCaseModel = CaseFactory.BuildCreateCaseModel();
 			createCaseModel.CreateRecordsModel = RecordFactory.BuildListCreateRecordModel();
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CreateCaseModel = createCaseModel };
 			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
 			var ratingsModel = RatingFactory.BuildListRatingModel();
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/RatingPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/RatingPageModelTests.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Models;
+﻿using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Pages.Case;
 using ConcernsCaseWork.Services.Ratings;
 using ConcernsCaseWork.Services.Trusts;
@@ -17,6 +18,7 @@ using Service.Redis.Models;
 using Service.Redis.Users;
 using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case
@@ -353,9 +355,12 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			IRatingModelService mockRatingModelService,
 			ILogger<RatingPageModel> mockLogger, bool isAuthenticated = false)
 		{
+			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
+			mockClaimsPrincipalHelper.Setup(x => x.GetPrincipalName(It.IsAny<ClaimsPrincipal>())).Returns("Tester");
+
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 			
-			return new RatingPageModel(mockTrustModelService, mockUserStateCachedService, mockRatingModelService, mockLogger)
+			return new RatingPageModel(mockTrustModelService, mockUserStateCachedService, mockRatingModelService, mockLogger, mockClaimsPrincipalHelper.Object)
 			{
 				PageContext = pageContext,
 				TempData = tempData,

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/HomePageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/HomePageModelTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Service.Redis.Security;
+using Service.Redis.Users;
 using Service.TRAMS.Status;
 using System;
 using System.Collections.Generic;
@@ -33,6 +34,7 @@ namespace ConcernsCaseWork.Tests.Pages
 			var mockCaseModelService = new Mock<ICaseModelService>();
 			var mockRbacManager = new Mock<IRbacManager>();
 			var mockLogger = new Mock<ILogger<HomePageModel>>();
+			var mockUserStateCache = new Mock<IUserStateCachedService>();
 
 			var roles = RoleFactory.BuildListRoleEnum();
 			var defaultUsers = new[] { "user1", "user2" };
@@ -47,7 +49,7 @@ namespace ConcernsCaseWork.Tests.Pages
 			mockTeamService.Setup(x => x.GetCaseworkTeam(It.IsAny<string>()))
 				.ReturnsAsync(new ConcernsCaseWork.Models.Teams.ConcernsTeamCaseworkModel("random.user", Array.Empty<string>()));
 
-			var homePageModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object);
+			var homePageModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object, mockUserStateCache.Object);
 
 			// act
 			await homePageModel.OnGetAsync();
@@ -133,6 +135,7 @@ namespace ConcernsCaseWork.Tests.Pages
 			var mockCaseModelService = new Mock<ICaseModelService>();
 			var mockRbacManager = new Mock<IRbacManager>();
 			var mockLogger = new Mock<ILogger<HomePageModel>>();
+			var mockUserStateCache = new Mock<IUserStateCachedService>();
 			var emptyList = new List<HomeModel>();
 
 			var roles = RoleFactory.BuildListUserRoleEnum();
@@ -151,7 +154,7 @@ namespace ConcernsCaseWork.Tests.Pages
 				.ReturnsAsync(new ConcernsCaseWork.Models.Teams.ConcernsTeamCaseworkModel("random.user", Array.Empty<string>()));
 
 			// act
-			var indexModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object);
+			var indexModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object, mockUserStateCache.Object);
 			await indexModel.OnGetAsync();
 
 			// assert
@@ -173,11 +176,16 @@ namespace ConcernsCaseWork.Tests.Pages
 			mockCaseModelService.Verify(c => c.GetCasesByCaseworkerAndStatus(It.IsAny<string[]>(), It.IsAny<StatusEnum>()), Times.Once);
 		}
 
-		private static HomePageModel SetupHomeModel(ICaseModelService mockCaseModelService, IRbacManager mockRbacManager, ILogger<HomePageModel> mockLogger, ITeamsModelService mockTeamService, bool isAuthenticated = false)
+		private static HomePageModel SetupHomeModel(ICaseModelService mockCaseModelService,
+			IRbacManager mockRbacManager,
+			ILogger<HomePageModel> mockLogger,
+			ITeamsModelService mockTeamService,
+			IUserStateCachedService mockUserStateCachedService,
+			bool isAuthenticated = false)
 		{
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 
-			return new HomePageModel(mockCaseModelService, mockRbacManager, mockLogger, mockTeamService)
+			return new HomePageModel(mockCaseModelService, mockRbacManager, mockLogger, mockTeamService, mockUserStateCachedService)
 			{
 				PageContext = pageContext,
 				TempData = tempData,

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/HomePageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/HomePageModelTests.cs
@@ -1,5 +1,8 @@
+using AutoFixture;
 using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Helpers;
 using ConcernsCaseWork.Models;
+using ConcernsCaseWork.Models.Teams;
 using ConcernsCaseWork.Pages;
 using ConcernsCaseWork.Security;
 using ConcernsCaseWork.Services.Cases;
@@ -11,12 +14,14 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using Service.Redis.Models;
 using Service.Redis.Security;
 using Service.Redis.Users;
 using Service.TRAMS.Status;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using ITeamsModelService = ConcernsCaseWork.Services.Teams.ITeamsModelService;
 
@@ -35,6 +40,7 @@ namespace ConcernsCaseWork.Tests.Pages
 			var mockRbacManager = new Mock<IRbacManager>();
 			var mockLogger = new Mock<ILogger<HomePageModel>>();
 			var mockUserStateCache = new Mock<IUserStateCachedService>();
+			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
 
 			var roles = RoleFactory.BuildListRoleEnum();
 			var defaultUsers = new[] { "user1", "user2" };
@@ -49,7 +55,7 @@ namespace ConcernsCaseWork.Tests.Pages
 			mockTeamService.Setup(x => x.GetCaseworkTeam(It.IsAny<string>()))
 				.ReturnsAsync(new ConcernsCaseWork.Models.Teams.ConcernsTeamCaseworkModel("random.user", Array.Empty<string>()));
 
-			var homePageModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object, mockUserStateCache.Object);
+			var homePageModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object, mockUserStateCache.Object, mockClaimsPrincipalHelper.Object);
 
 			// act
 			await homePageModel.OnGetAsync();
@@ -136,6 +142,7 @@ namespace ConcernsCaseWork.Tests.Pages
 			var mockRbacManager = new Mock<IRbacManager>();
 			var mockLogger = new Mock<ILogger<HomePageModel>>();
 			var mockUserStateCache = new Mock<IUserStateCachedService>();
+			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
 			var emptyList = new List<HomeModel>();
 
 			var roles = RoleFactory.BuildListUserRoleEnum();
@@ -154,7 +161,7 @@ namespace ConcernsCaseWork.Tests.Pages
 				.ReturnsAsync(new ConcernsCaseWork.Models.Teams.ConcernsTeamCaseworkModel("random.user", Array.Empty<string>()));
 
 			// act
-			var indexModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object, mockUserStateCache.Object);
+			var indexModel = SetupHomeModel(mockCaseModelService.Object, mockRbacManager.Object, mockLogger.Object, mockTeamService.Object, mockUserStateCache.Object, mockClaimsPrincipalHelper.Object);
 			await indexModel.OnGetAsync();
 
 			// assert
@@ -176,16 +183,131 @@ namespace ConcernsCaseWork.Tests.Pages
 			mockCaseModelService.Verify(c => c.GetCasesByCaseworkerAndStatus(It.IsAny<string[]>(), It.IsAny<StatusEnum>()), Times.Once);
 		}
 
+		[Test]
+		public async Task OnGet_When_No_UserState_In_Cache_Records_User_Signin()
+		{
+			// arrange
+			var testBuilder = new TestBuilder()
+				.WithAuthenticatedUser()
+				.WithNoCachedUserState()
+				.WithNoTeamCaseworkModel();
+
+			// act
+			var sut = testBuilder.CreateSut();
+			await sut.OnGetAsync();
+
+			// assert
+			testBuilder.MockUserStateCache.Verify(x => x.GetData(testBuilder.CaseworkerId), Times.Once);
+			testBuilder.MockTeamService.Verify(x => x.GetCaseworkTeam(testBuilder.CaseworkerId), Times.Once);
+			testBuilder.MockTeamService.Verify(x => x.UpdateCaseworkTeam(It.Is<ConcernsTeamCaseworkModel>(m => m.OwnerId == testBuilder.CaseworkerId && m.TeamMembers.Length == 0)), Times.Once);
+			testBuilder.MockUserStateCache.Verify(x => x.StoreData(testBuilder.CaseworkerId, It.Is<UserState>(s => s.UserName == testBuilder.CaseworkerId)), Times.Once);
+		}
+
+		[Test]
+		public async Task OnGet_When_UserState_In_Cache_Does_Not_Record_User_Signin()
+		{
+			// arrange
+			var testBuilder = new TestBuilder()
+				.WithAuthenticatedUser()
+				.WithCachedUserState()
+				.WithNoTeamCaseworkModel();
+
+			// act
+			var sut = testBuilder.CreateSut();
+			await sut.OnGetAsync();
+
+			// assert
+			testBuilder.MockUserStateCache.Verify(x => x.GetData(testBuilder.CaseworkerId), Times.Once);
+			testBuilder.MockTeamService.Verify(x => x.GetCaseworkTeam(testBuilder.CaseworkerId), Times.Once);
+			testBuilder.MockTeamService.Verify(x => x.UpdateCaseworkTeam(It.Is<ConcernsTeamCaseworkModel>(m => m.OwnerId == testBuilder.CaseworkerId && m.TeamMembers.Length == 0)), Times.Never);
+			testBuilder.MockUserStateCache.Verify(x => x.StoreData(testBuilder.CaseworkerId, It.Is<UserState>(s => s.UserName == testBuilder.CaseworkerId)), Times.Never);
+		}
+		
+		private class TestBuilder
+		{
+			public TestBuilder()
+			{
+				this.Fixture = new Fixture();
+				CaseworkerId = this.Fixture.Create<string>();
+				MockCaseModelService = new Mock<ICaseModelService>();
+				MockRbacManager = new Mock<IRbacManager>();
+				MockLogger = new Mock<ILogger<HomePageModel>>();
+				MockUserStateCache = new Mock<IUserStateCachedService>();
+				MockTeamService = new Mock<ITeamsModelService>();
+				MockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
+				IsAuthenticated = false;
+			}
+
+			public string CaseworkerId { get; set; }
+
+			public Fixture Fixture { get; set; }
+
+			public Mock<ITeamsModelService> MockTeamService { get; set; }
+
+			public bool IsAuthenticated { get; set; }
+
+			public HomePageModel CreateSut()
+			{
+				(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(IsAuthenticated);
+
+				return new HomePageModel(MockCaseModelService.Object, MockRbacManager.Object, MockLogger.Object, MockTeamService.Object, MockUserStateCache.Object, MockClaimsPrincipalHelper.Object)
+				{
+					PageContext = pageContext,
+					TempData = tempData,
+					Url = new UrlHelper(actionContext),
+					MetadataProvider = pageContext.ViewData.ModelMetadata
+				};
+			}
+
+			public Mock<IClaimsPrincipalHelper> MockClaimsPrincipalHelper { get; set; }
+
+			public Mock<IUserStateCachedService> MockUserStateCache { get; set; }
+
+			public Mock<ILogger<HomePageModel>> MockLogger { get; set; }
+
+			public Mock<IRbacManager> MockRbacManager { get; set; }
+
+			public Mock<ICaseModelService> MockCaseModelService { get; set; }
+
+			public TestBuilder WithNoTeamCaseworkModel()
+			{
+				this.MockTeamService.Setup(x => x.GetCaseworkTeam(CaseworkerId))
+					.ReturnsAsync(new ConcernsCaseWork.Models.Teams.ConcernsTeamCaseworkModel(CaseworkerId, Array.Empty<string>()));
+
+				return this;
+			}
+
+			public TestBuilder WithNoCachedUserState()
+			{
+				MockUserStateCache.Setup(x => x.GetData(CaseworkerId)).ReturnsAsync(default(UserState));
+				return this;
+			}
+
+			public TestBuilder WithAuthenticatedUser()
+			{
+				MockClaimsPrincipalHelper.Setup(x => x.GetPrincipalName(It.IsAny<ClaimsPrincipal>())).Returns(CaseworkerId);
+				IsAuthenticated = true;
+				return this;
+			}
+
+			public TestBuilder WithCachedUserState()
+			{
+				MockUserStateCache.Setup(x => x.GetData(CaseworkerId)).ReturnsAsync(new UserState(CaseworkerId));
+				return this;
+			}
+		}
+
 		private static HomePageModel SetupHomeModel(ICaseModelService mockCaseModelService,
 			IRbacManager mockRbacManager,
 			ILogger<HomePageModel> mockLogger,
 			ITeamsModelService mockTeamService,
 			IUserStateCachedService mockUserStateCachedService,
+			IClaimsPrincipalHelper mockClaimsPrincipalHelper,
 			bool isAuthenticated = false)
 		{
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 
-			return new HomePageModel(mockCaseModelService, mockRbacManager, mockLogger, mockTeamService, mockUserStateCachedService)
+			return new HomePageModel(mockCaseModelService, mockRbacManager, mockLogger, mockTeamService, mockUserStateCachedService, mockClaimsPrincipalHelper)
 			{
 				PageContext = pageContext,
 				TempData = tempData,

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
@@ -160,7 +160,7 @@ namespace ConcernsCaseWork.Tests.Pages.Trust
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			var mockUserStateService = new Mock<IUserStateCachedService>();
 
-			var userState = new UserState();
+			var userState = new UserState("testing");
 			
 			mockUserStateService.Setup(c => c.GetData(It.IsAny<string>())).ReturnsAsync(userState);
 			mockUserStateService.Setup(c => c.StoreData(It.IsAny<string>(), It.IsAny<UserState>()))

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Models;
+﻿using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Pages.Trust;
 using ConcernsCaseWork.Services.Trusts;
 using ConcernsCaseWork.Shared.Tests.Factory;
@@ -17,6 +18,7 @@ using Service.TRAMS.Trusts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Trust
@@ -232,9 +234,12 @@ namespace ConcernsCaseWork.Tests.Pages.Trust
 		
 		private static IndexPageModel SetupIndexModel(ITrustModelService mockTrustModelService, IUserStateCachedService mockUSerStateCachedService, ILogger<IndexPageModel> mockLogger, bool isAuthenticated = false)
 		{
+			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
+			mockClaimsPrincipalHelper.Setup(x => x.GetPrincipalName(It.IsAny<ClaimsPrincipal>())).Returns("Tester");
+
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 			
-			return new IndexPageModel(mockTrustModelService, mockUSerStateCachedService, mockLogger)
+			return new IndexPageModel(mockTrustModelService, mockUSerStateCachedService, mockLogger, mockClaimsPrincipalHelper.Object)
 			{
 				PageContext = pageContext,
 				TempData = tempData,

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Cases/CaseModelServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Cases/CaseModelServiceTests.cs
@@ -837,7 +837,7 @@ namespace ConcernsCaseWork.Tests.Services.Cases
 			mockTrustCachedService.Setup(t => t.GetTrustByUkPrn(It.IsAny<string>())).ReturnsAsync(trustDto);
 			mockCaseCachedService.Setup(cs => cs.GetCasesByCaseworkerAndStatus(It.IsAny<string>(), It.IsAny<long>())).ReturnsAsync(casesDto);
 
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = firstCaseDto.TrustUkPrn
 			};

--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Logging;
+﻿using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Logging;
 using ConcernsCaseWork.Security;
 using ConcernsCaseWork.Services.Cases;
 using ConcernsCaseWork.Services.FinancialPlan;
@@ -139,6 +140,7 @@ namespace ConcernsCaseWork.Extensions
 			services.AddScoped<IMeansOfReferralModelService, MeansOfReferralModelService>();
 			services.AddScoped<INtiModelService, NtiModelService>();
 			services.AddScoped<ITeamsModelService, TeamsModelService>();
+			services.AddScoped<IClaimsPrincipalHelper, ClaimsPrincipalHelper>();
 
 			// Trams api services
 			services.AddScoped<ICaseService, CaseService>();

--- a/ConcernsCaseWork/ConcernsCaseWork/Helpers/ClaimsPrincipalHelper.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Helpers/ClaimsPrincipalHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Security.Claims;
+
+namespace ConcernsCaseWork.Helpers;
+
+public class ClaimsPrincipalHelper : IClaimsPrincipalHelper
+{
+	public string GetPrincipalName(ClaimsPrincipal principal)
+	{
+		if (principal?.Identity?.Name is null)
+		{
+			throw new NullReferenceException("User.Identity returned null");
+		}
+
+		return principal.Identity.Name;
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Helpers/IClaimsPrincipalHelper.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Helpers/IClaimsPrincipalHelper.cs
@@ -1,0 +1,9 @@
+﻿using System.Security.Claims;
+
+namespace ConcernsCaseWork.Helpers
+{
+	public interface IClaimsPrincipalHelper
+	{
+		public string GetPrincipalName(ClaimsPrincipal principal);
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Index.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using ConcernsCaseWork.Models;
+﻿using Ardalis.GuardClauses;
+using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Services.Trusts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -20,14 +22,16 @@ namespace ConcernsCaseWork.Pages.Case
 		private readonly ITrustModelService _trustModelService;
 		private readonly IUserStateCachedService _userStateCache;
 		private readonly ILogger<IndexPageModel> _logger;
-		
+		private readonly IClaimsPrincipalHelper _claimsPrincipalHelper;
+
 		private const int SearchQueryMinLength = 3;
 		
-		public IndexPageModel(ITrustModelService trustModelService, IUserStateCachedService userStateCache, ILogger<IndexPageModel> logger)
+		public IndexPageModel(ITrustModelService trustModelService, IUserStateCachedService userStateCache, ILogger<IndexPageModel> logger, IClaimsPrincipalHelper claimsPrincipalHelper)
 		{
-			_trustModelService = trustModelService;
-			_userStateCache = userStateCache;
-			_logger = logger;
+			_trustModelService = Guard.Against.Null(trustModelService);
+			_userStateCache = Guard.Against.Null(userStateCache);
+			_logger = Guard.Against.Null(logger);
+			_claimsPrincipalHelper = Guard.Against.Null(claimsPrincipalHelper);
 		}
 		
 		public async Task<ActionResult> OnGetTrustsSearchResult(string searchQuery)
@@ -80,14 +84,6 @@ namespace ConcernsCaseWork.Pages.Case
 			}
 		}
 
-		private string GetUserName()
-		{
-			if (User?.Identity is null)
-			{
-				throw new NullReferenceException("User.Identity returned null");
-			}
-
-			return User.Identity.Name;
-		}
+		private string GetUserName() => _claimsPrincipalHelper.GetPrincipalName(User);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Index.cshtml.cs
@@ -64,11 +64,11 @@ namespace ConcernsCaseWork.Pages.Case
 					throw new Exception($"Selected trust is incorrect - {trustUkPrn}");
 				
 				// Store CaseState into cache.
-				var userState = await _userStateCache.GetData(User.Identity?.Name) ?? new UserState();
+				var userState = await _userStateCache.GetData(GetUserName()) ?? new UserState(GetUserName());
 				userState.TrustUkPrn = trustUkPrn;
 				userState.CreateCaseModel = new CreateCaseModel();
 				
-				await _userStateCache.StoreData(User.Identity?.Name, userState);
+				await _userStateCache.StoreData(GetUserName(), userState);
 
 				return new JsonResult(new { redirectUrl = Url.Page("Concern/Index") });
 			}
@@ -78,6 +78,16 @@ namespace ConcernsCaseWork.Pages.Case
 					
 				return StatusCode((int)HttpStatusCode.InternalServerError, ex.Message);
 			}
+		}
+
+		private string GetUserName()
+		{
+			if (User?.Identity is null)
+			{
+				throw new NullReferenceException("User.Identity returned null");
+			}
+
+			return User.Identity.Name;
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Rating.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Rating.cshtml.cs
@@ -72,7 +72,7 @@ namespace ConcernsCaseWork.Pages.Case
 				userState.CreateCaseModel.RagRatingCss = RatingMapping.FetchRagCss(ragRatingName);
 				
 				// Store case model in cache for the details page
-				await _userStateCache.StoreData(User.Identity?.Name, userState);
+				await _userStateCache.StoreData(GetUserName(), userState);
 				
 				return RedirectToPage("details");
 			}
@@ -92,7 +92,7 @@ namespace ConcernsCaseWork.Pages.Case
 			{
 				var userState = await GetUserState();
 				userState.CreateCaseModel = new CreateCaseModel();
-				await _userStateCache.StoreData(User.Identity?.Name, userState);
+				await _userStateCache.StoreData(GetUserName(), userState);
 				
 				return Redirect("/");
 			}
@@ -132,11 +132,21 @@ namespace ConcernsCaseWork.Pages.Case
 		
 		private async Task<UserState> GetUserState()
 		{
-			var userState = await _userStateCache.GetData(User.Identity.Name);
+			var userState = await _userStateCache.GetData(GetUserName());
 			if (userState is null)
 				throw new Exception("Cache CaseStateData is null");
 			
 			return userState;
+		}
+
+		private string GetUserName()
+		{
+			if (User?.Identity is null)
+			{
+				throw new NullReferenceException("User.Identity returned null");
+			}
+
+			return User.Identity.Name;
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Rating.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Rating.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using ConcernsCaseWork.Mappers;
+﻿using Ardalis.GuardClauses;
+using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Mappers;
 using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Pages.Base;
 using ConcernsCaseWork.Services.Ratings;
@@ -23,7 +25,8 @@ namespace ConcernsCaseWork.Pages.Case
 		private readonly ILogger<RatingPageModel> _logger;
 		private readonly ITrustModelService _trustModelService;
 		private readonly IUserStateCachedService _userStateCache;
-		
+		private readonly IClaimsPrincipalHelper _claimsPrincipalHelper;
+
 		public TrustDetailsModel TrustDetailsModel { get; private set; }
 		public IList<CreateRecordModel> CreateRecordsModel { get; private set; }
 		public IList<RatingModel> RatingsModel { get; private set; }
@@ -31,12 +34,14 @@ namespace ConcernsCaseWork.Pages.Case
 		public RatingPageModel(ITrustModelService trustModelService, 
 			IUserStateCachedService userStateCache,
 			IRatingModelService ratingModelService,
-			ILogger<RatingPageModel> logger)
+			ILogger<RatingPageModel> logger, 
+			IClaimsPrincipalHelper claimsPrincipalHelper)
 		{
-			_ratingModelService = ratingModelService;
-			_trustModelService = trustModelService;
-			_userStateCache = userStateCache;
-			_logger = logger;
+			_ratingModelService = Guard.Against.Null(ratingModelService);
+			_trustModelService = Guard.Against.Null(trustModelService);
+			_userStateCache = Guard.Against.Null(userStateCache);
+			_logger = Guard.Against.Null(logger);
+			_claimsPrincipalHelper = Guard.Against.Null(claimsPrincipalHelper);
 		}
 		
 		public async Task OnGetAsync()
@@ -139,14 +144,6 @@ namespace ConcernsCaseWork.Pages.Case
 			return userState;
 		}
 
-		private string GetUserName()
-		{
-			if (User?.Identity is null)
-			{
-				throw new NullReferenceException("User.Identity returned null");
-			}
-
-			return User.Identity.Name;
-		}
+		private string GetUserName() => _claimsPrincipalHelper.GetPrincipalName(User);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Home.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Home.cshtml.cs
@@ -84,7 +84,7 @@ namespace ConcernsCaseWork.Pages
 		{
 			var userState = await _userStateCache.GetData(GetUserName());
 
-			if (userState is not null)
+			if (userState is not null && !String.IsNullOrWhiteSpace(userState.UserName))
 			{
 				return;
 			}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Home.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Home.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using ConcernsCaseWork.Models;
+using ConcernsCaseWork.Models.Teams;
 using ConcernsCaseWork.Security;
 using ConcernsCaseWork.Services.Cases;
 using ConcernsCaseWork.Services.Teams;
@@ -8,7 +9,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using Sentry;
+using Service.Redis.Models;
+using Service.Redis.Users;
 using Service.TRAMS.Status;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -18,6 +22,7 @@ namespace ConcernsCaseWork.Pages
 	[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 	public class HomePageModel : PageModel
 	{
+		private readonly IUserStateCachedService _userStateCache;
 		private readonly ICaseModelService _caseModelService;
 		private readonly ILogger<HomePageModel> _logger;
 		private readonly ITeamsModelService _teamsService;
@@ -26,12 +31,17 @@ namespace ConcernsCaseWork.Pages
 		public IList<HomeModel> CasesActive { get; private set; }
 		public IList<HomeModel> CasesTeamActive { get; private set; }
 
-		public HomePageModel(ICaseModelService caseModelService, IRbacManager rbacManager, ILogger<HomePageModel> logger, ITeamsModelService teamsService)
+		public HomePageModel(ICaseModelService caseModelService,
+			IRbacManager rbacManager,
+			ILogger<HomePageModel> logger,
+			ITeamsModelService teamsService,
+			IUserStateCachedService userStateCache)
 		{
 			_caseModelService = Guard.Against.Null(caseModelService);
 			_rbacManager = Guard.Against.Null(rbacManager);
 			_logger = Guard.Against.Null(logger);
 			_teamsService = Guard.Against.Null(teamsService);
+			_userStateCache = Guard.Against.Null(userStateCache);
 		}
 
 		public async Task OnGetAsync()
@@ -45,18 +55,51 @@ namespace ConcernsCaseWork.Pages
 			// And get all live cases for each caseworker
 
 			// cases belonging to this user
-			Task<IList<HomeModel>> currentUserLiveCases = _caseModelService.GetCasesByCaseworkerAndStatus(User.Identity.Name, StatusEnum.Live);
+			Task<IList<HomeModel>> currentUserLiveCases = _caseModelService.GetCasesByCaseworkerAndStatus(GetUserName(), StatusEnum.Live);
 
 			// get any team members defined
-			var team = await _teamsService.GetCaseworkTeam(User.Identity.Name);
+			var team = await _teamsService.GetCaseworkTeam(GetUserName());
 
-			var liveCasesTeamLead = _caseModelService.GetCasesByCaseworkerAndStatus(team.TeamMembers, StatusEnum.Live);
+			var liveCasesTeamLeadTask = _caseModelService.GetCasesByCaseworkerAndStatus(team.TeamMembers, StatusEnum.Live);
+			
+			var recordUserSignedTask = RecordUserSignIn(team);
 
-			await Task.WhenAll(currentUserLiveCases, liveCasesTeamLead);
+			await Task.WhenAll(currentUserLiveCases, liveCasesTeamLeadTask, recordUserSignedTask);
 
 			// Assign responses to UI public properties
 			CasesActive = currentUserLiveCases.Result;
-			CasesTeamActive = liveCasesTeamLead.Result;
+			CasesTeamActive = liveCasesTeamLeadTask.Result;
+		}
+
+		/// <summary>
+		/// This is a bit of a hack until integration with Azure AD has been completed and we are connected to the Azure GraphAPI which will then
+		/// give us users directly from Azure AD. For now we will create empty teams, and use these team owners as the list of users in the system.
+		/// Azure AD won't let us intercept the token being created and returns us to this page, so we will store that we have recorded a user having
+		/// signed in, in Redis for 9 hours (slightly more than a standard shift) to avoid unnecessary calls to the academies API.
+		/// </summary>
+		/// <exception cref="System.NotImplementedException"></exception>
+		private async Task RecordUserSignIn(Models.Teams.ConcernsTeamCaseworkModel team)
+		{
+			var userState = await _userStateCache.GetData(GetUserName()) ?? new UserState(GetUserName());
+
+			if (team.TeamMembers.Length == 0)
+			{
+				// This is a hack, but storing back an empty team will give us a 'user' for later (until GraphApi).
+				await _teamsService.UpdateCaseworkTeam(team);
+			}
+
+			// record in redis that we have recorded a user state
+			await _userStateCache.StoreData(GetUserName(), userState);
+		}
+
+		private string GetUserName()
+		{
+			if (User?.Identity is null)
+			{
+				throw new NullReferenceException("User.Identity returned null");
+			}
+
+			return User.Identity.Name;
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Index.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using ConcernsCaseWork.Models;
+﻿using Ardalis.GuardClauses;
+using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Services.Trusts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -21,14 +23,16 @@ namespace ConcernsCaseWork.Pages.Trust
 		private readonly ITrustModelService _trustModelService;
 		private readonly IUserStateCachedService _userStateCache;
 		private readonly ILogger<IndexPageModel> _logger;
-		
+		private readonly IClaimsPrincipalHelper _claimsPrincipalHelper;
+
 		private const int SearchQueryMinLength = 3;
 		
-		public IndexPageModel(ITrustModelService trustModelService, IUserStateCachedService userStateCache, ILogger<IndexPageModel> logger)
+		public IndexPageModel(ITrustModelService trustModelService, IUserStateCachedService userStateCache, ILogger<IndexPageModel> logger, IClaimsPrincipalHelper claimsPrincipalHelper)
 		{
-			_trustModelService = trustModelService;
-			_userStateCache = userStateCache;
-			_logger = logger;
+			_trustModelService = Guard.Against.Null(trustModelService);
+			_userStateCache = Guard.Against.Null(userStateCache);
+			_logger = Guard.Against.Null(logger);
+			_claimsPrincipalHelper = Guard.Against.Null(claimsPrincipalHelper);
 		}
 		
 		public async Task<ActionResult> OnGetTrustsSearchResult(string searchQuery)
@@ -82,14 +86,6 @@ namespace ConcernsCaseWork.Pages.Trust
 			}
 		}
 
-		private string GetUserName()
-		{
-			if (User?.Identity is null)
-			{
-				throw new NullReferenceException("User.Identity returned null");
-			}
-
-			return User.Identity.Name;
-		}
+		private string GetUserName() => _claimsPrincipalHelper.GetPrincipalName(User);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Index.cshtml.cs
@@ -67,10 +67,10 @@ namespace ConcernsCaseWork.Pages.Trust
 					throw new Exception($"Trust::IndexModel::OnGetSelectedTrust::Selected trust is incorrect - {trustUkPrn}");
 				
 				// Store CaseState into cache.
-				var userState = await _userStateCache.GetData(User.Identity?.Name) ?? new UserState();
+				var userState = await _userStateCache.GetData(GetUserName()) ?? new UserState(GetUserName());
 				userState.TrustUkPrn = trustUkPrn;
 				userState.CreateCaseModel = new CreateCaseModel();
-				await _userStateCache.StoreData(User.Identity?.Name, userState);
+				await _userStateCache.StoreData(GetUserName(), userState);
 
 				return new JsonResult(new { redirectUrl = Url.Page("Overview", new { id = trustUkPrn }) });
 			}
@@ -80,6 +80,16 @@ namespace ConcernsCaseWork.Pages.Trust
 					
 				return StatusCode((int)HttpStatusCode.InternalServerError, ex.Message);
 			}
+		}
+
+		private string GetUserName()
+		{
+			if (User?.Identity is null)
+			{
+				throw new NullReferenceException("User.Identity returned null");
+			}
+
+			return User.Identity.Name;
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Teams/ITeamsModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Teams/ITeamsModelService.cs
@@ -6,6 +6,6 @@ namespace ConcernsCaseWork.Services.Teams
 	public interface ITeamsModelService
 	{
 		public Task<ConcernsTeamCaseworkModel> GetCaseworkTeam(string ownerId);
-		public Task UpdateCaseworkTeam(ConcernsTeamCaseworkModel selections);
+		public Task UpdateCaseworkTeam(ConcernsTeamCaseworkModel teamCaseworkModel);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Teams/TeamsModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Teams/TeamsModelService.cs
@@ -42,14 +42,14 @@ namespace ConcernsCaseWork.Services.Teams
 			return DoWork();
 		}
 
-		public Task UpdateCaseworkTeam(ConcernsTeamCaseworkModel team)
+		public Task UpdateCaseworkTeam(ConcernsTeamCaseworkModel teamCaseworkModel)
 		{
 			_logger.LogMethodEntered();
-			Guard.Against.Null(team);
+			Guard.Against.Null(teamCaseworkModel);
 
 			async Task DoWork()
 			{
-				await _teamsServiceClient.PutTeam(new ConcernsCaseworkTeamDto(team.OwnerId, team.TeamMembers));
+				await _teamsServiceClient.PutTeam(new ConcernsCaseworkTeamDto(teamCaseworkModel.OwnerId, teamCaseworkModel.TeamMembers));
 			}
 			return DoWork();
 		}

--- a/ConcernsCaseWork/Service.Redis.Tests/Base/CachedServiceTests.cs
+++ b/ConcernsCaseWork/Service.Redis.Tests/Base/CachedServiceTests.cs
@@ -27,7 +27,7 @@ namespace Service.Redis.Tests.Base
 			var cacheService = new TestCacheService(mockCacheProvider.Object);
 
 			// act
-			await cacheService.StoreData("key", new UserState());
+			await cacheService.StoreData("key", new UserState("testing"));
 
 			// assert
 			mockCacheProvider.Verify(c => 

--- a/ConcernsCaseWork/Service.Redis.Tests/Cases/CaseCachedServiceTests.cs
+++ b/ConcernsCaseWork/Service.Redis.Tests/Cases/CaseCachedServiceTests.cs
@@ -40,7 +40,7 @@ namespace Service.Redis.Tests.Cases
 			var mockCaseSearchService = new Mock<ICaseSearchService>();
 			var mockLogger = new Mock<ILogger<CaseCachedService>>();
 
-			var caseStateModel = new UserState
+			var caseStateModel = new UserState("testing")
 			{
 				TrustUkPrn = "999999",
 				CasesDetails = { { 1, new CaseWrapper{ CaseDto = CaseFactory.BuildCaseDto() } } }
@@ -72,7 +72,7 @@ namespace Service.Redis.Tests.Cases
 			var mockLogger = new Mock<ILogger<CaseCachedService>>();
 
 			var expectedCasesDto = CaseFactory.BuildListCaseDto();
-			var caseStateModel = new UserState
+			var caseStateModel = new UserState("testing")
 			{
 				TrustUkPrn = "999999",
 				CasesDetails = { { 1, new CaseWrapper{ CaseDto = CaseFactory.BuildCaseDto() } } }
@@ -161,7 +161,7 @@ namespace Service.Redis.Tests.Cases
 
 			var mockLogger = new Mock<ILogger<CaseCachedService>>();
 
-			var caseStateModel = new UserState
+			var caseStateModel = new UserState("testing")
 			{
 				TrustUkPrn = "999999",
 				CasesDetails = { { 1, new CaseWrapper{ CaseDto = CaseFactory.BuildCaseDto() } } }
@@ -296,7 +296,7 @@ namespace Service.Redis.Tests.Cases
 			var expectedCaseDto = CaseFactory.BuildCaseDto();
 			
 			mockCacheProvider.Setup(c => c.GetFromCache<UserState>(It.IsAny<string>())).
-				ReturnsAsync(new UserState());
+				ReturnsAsync(new UserState("testing"));
 			mockCaseService.Setup(c => c.PostCase(It.IsAny<CreateCaseDto>())).ReturnsAsync(expectedCaseDto);
 			
 			var caseCachedService = new CaseCachedService(mockCacheProvider.Object, mockCaseService.Object, mockCaseSearchService.Object, mockLogger.Object);
@@ -416,7 +416,7 @@ namespace Service.Redis.Tests.Cases
 			var caseDto = CaseFactory.BuildCaseDto();
 			
 			mockCacheProvider.Setup(c => c.GetFromCache<UserState>(It.IsAny<string>())).
-				ReturnsAsync(new UserState());
+				ReturnsAsync(new UserState("testing"));
 			mockCaseService.Setup(c => c.PatchCaseByUrn(It.IsAny<CaseDto>())).ReturnsAsync(caseDto);
 			
 			var caseCachedService = new CaseCachedService(mockCacheProvider.Object, mockCaseService.Object, mockCaseSearchService.Object, mockLogger.Object);
@@ -439,7 +439,7 @@ namespace Service.Redis.Tests.Cases
 			var mockCaseSearchService = new Mock<ICaseSearchService>();
 			var mockLogger = new Mock<ILogger<CaseCachedService>>();
 
-			var userState = new UserState { CasesDetails = { { 1, new CaseWrapper { CaseDto = CaseFactory.BuildCaseDto() } } } };
+			var userState = new UserState("testing") { CasesDetails = { { 1, new CaseWrapper { CaseDto = CaseFactory.BuildCaseDto() } } } };
 			var caseDto = CaseFactory.BuildCaseDto();
 			
 			mockCacheProvider.Setup(c => c.GetFromCache<UserState>(It.IsAny<string>())).

--- a/ConcernsCaseWork/Service.Redis.Tests/Cases/CaseHistoryCachedServiceTests.cs
+++ b/ConcernsCaseWork/Service.Redis.Tests/Cases/CaseHistoryCachedServiceTests.cs
@@ -46,7 +46,7 @@ namespace Service.Redis.Tests.Cases
 			var mockLogger = new Mock<ILogger<CaseHistoryCachedService>>();
 			var mockSequence = new Mock<ISequenceCachedService>();
 			
-			var caseStateModel = new UserState
+			var caseStateModel = new UserState("testing")
 			{
 				TrustUkPrn = "999999",
 				CasesDetails = { { 1, new CaseWrapper() } }
@@ -76,7 +76,7 @@ namespace Service.Redis.Tests.Cases
 			var mockLogger = new Mock<ILogger<CaseHistoryCachedService>>();
 			var mockSequence = new Mock<ISequenceCachedService>();
 			
-			var caseStateModel = new UserState
+			var caseStateModel = new UserState("testing")
 			{
 				TrustUkPrn = "999999",
 				CasesDetails = { { 1, new CaseWrapper() } }
@@ -106,7 +106,7 @@ namespace Service.Redis.Tests.Cases
 			var mockLogger = new Mock<ILogger<CaseHistoryCachedService>>();
 			var mockSequence = new Mock<ISequenceCachedService>();
 			
-			var caseStateModel = new UserState
+			var caseStateModel = new UserState("testing")
 			{
 				TrustUkPrn = "999999",
 				CasesDetails = { { 1, new CaseWrapper{ CasesHistoryDto = CaseFactory.BuildListCasesHistoryDto() } } },

--- a/ConcernsCaseWork/Service.Redis.Tests/Records/RecordCachedServiceTests.cs
+++ b/ConcernsCaseWork/Service.Redis.Tests/Records/RecordCachedServiceTests.cs
@@ -70,7 +70,7 @@ namespace Service.Redis.Tests.Records
 			mockRecordService.Setup(r => r.PostRecordByCaseUrn(It.IsAny<CreateRecordDto>()))
 				.ReturnsAsync(newRecordDto);
 			
-			var userState = new UserState();
+			var userState = new UserState("testing");
 			
 			mockCacheProvider.Setup(c => c.GetFromCache<UserState>(It.IsAny<string>())).
 				ReturnsAsync(userState);
@@ -114,7 +114,7 @@ namespace Service.Redis.Tests.Records
 			mockRecordService.Setup(r => r.PostRecordByCaseUrn(It.IsAny<CreateRecordDto>()))
 				.ReturnsAsync(newRecordDto);
 
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				CasesDetails = { { newRecordDto.CaseUrn, new CaseWrapper() } }
 			};
@@ -161,7 +161,7 @@ namespace Service.Redis.Tests.Records
 			mockRecordService.Setup(r => r.PostRecordByCaseUrn(It.IsAny<CreateRecordDto>()))
 				.ReturnsAsync(newRecordDto);
 			
-			var userState = new UserState { TrustUkPrn = "trust-ukprn", CasesDetails = { { 1, new CaseWrapper { CaseDto = CaseFactory.BuildCaseDto(), } } } };
+			var userState = new UserState("testing") { TrustUkPrn = "trust-ukprn", CasesDetails = { { 1, new CaseWrapper { CaseDto = CaseFactory.BuildCaseDto(), } } } };
 			
 			mockCacheProvider.Setup(c => c.GetFromCache<UserState>(It.IsAny<string>())).
 				ReturnsAsync(userState);
@@ -247,7 +247,7 @@ namespace Service.Redis.Tests.Records
 			var mockRecordService = new Mock<IRecordService>();
 			var mockLogger = new Mock<ILogger<RecordCachedService>>();
 
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = "trust-ukprn",
 				CasesDetails =
@@ -294,7 +294,7 @@ namespace Service.Redis.Tests.Records
 			var mockLogger = new Mock<ILogger<RecordCachedService>>();
 
 			var recordsDto = RecordFactory.BuildListRecordDto();
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = "trust-ukprn",
 				CasesDetails =
@@ -335,7 +335,7 @@ namespace Service.Redis.Tests.Records
 			var mockRecordService = new Mock<IRecordService>();
 			var mockLogger = new Mock<ILogger<RecordCachedService>>();
 			
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = "trust-ukprn",
 				CasesDetails =
@@ -375,7 +375,7 @@ namespace Service.Redis.Tests.Records
 			var mockLogger = new Mock<ILogger<RecordCachedService>>();
 
 			var recordsDto = RecordFactory.BuildListRecordDto();
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = "trust-ukprn",
 				CasesDetails =
@@ -424,7 +424,7 @@ namespace Service.Redis.Tests.Records
 			var mockLogger = new Mock<ILogger<RecordCachedService>>();
 
 			var recordDto = RecordFactory.BuildRecordDto();
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = "trust-ukprn",
 				CasesDetails =
@@ -468,7 +468,7 @@ namespace Service.Redis.Tests.Records
 			var mockLogger = new Mock<ILogger<RecordCachedService>>();
 
 			var recordDto = RecordFactory.BuildRecordDto();
-			var userState = new UserState
+			var userState = new UserState("testing")
 			{
 				TrustUkPrn = "trust-ukprn",
 				CasesDetails =
@@ -526,7 +526,7 @@ namespace Service.Redis.Tests.Records
 			var mockLogger = new Mock<ILogger<RecordCachedService>>();
 
 			var recordDto = RecordFactory.BuildRecordDto();
-			var userState = new UserState
+			var userState = new UserState("tester.one")
 			{
 				TrustUkPrn = "trust-ukprn",
 				CasesDetails =

--- a/ConcernsCaseWork/Service.Redis/Cases/CaseCachedService.cs
+++ b/ConcernsCaseWork/Service.Redis/Cases/CaseCachedService.cs
@@ -46,7 +46,7 @@ namespace Service.Redis.Cases
 			}
 
 			userState = await GetData<UserState>(caseworker);
-			userState ??= new UserState();
+			userState ??= new UserState(caseworker);
 
 			Parallel.ForEach(casesDto, caseDto => userState.CasesDetails.TryAdd(caseDto.Urn, new CaseWrapper { CaseDto = caseDto }));
 
@@ -72,7 +72,7 @@ namespace Service.Redis.Cases
 			// Trust overview shows all cases for a trust which some aren't from the logged caseworker
 			if (!caseDto.CreatedBy.Equals(caseworker, StringComparison.OrdinalIgnoreCase)) return caseDto;
 
-			userState ??= new UserState();
+			userState ??= new UserState(caseworker);
 			userState.CasesDetails.Add(urn, new CaseWrapper { CaseDto = caseDto });
 
 			await StoreData(caseworker, userState);
@@ -91,7 +91,7 @@ namespace Service.Redis.Cases
 			var userState = await GetData<UserState>(newCase.CreatedBy);
 			if (userState is null)
 			{
-				userState = new UserState { CasesDetails = { { newCase.Urn, new CaseWrapper { CaseDto = newCase } } } };
+				userState = new UserState(createCaseDto.CreatedBy) { CasesDetails = { { newCase.Urn, new CaseWrapper { CaseDto = newCase } } } };
 			}
 			else
 			{
@@ -114,7 +114,7 @@ namespace Service.Redis.Cases
 			var userState = await GetData<UserState>(patchCaseDto.CreatedBy);
 			if (userState is null)
 			{
-				userState = new UserState { CasesDetails = { { patchCaseDto.Urn, new CaseWrapper { CaseDto = patchCaseDto } } } };
+				userState = new UserState(caseDto.CreatedBy) { CasesDetails = { { patchCaseDto.Urn, new CaseWrapper { CaseDto = patchCaseDto } } } };
 			}
 			else
 			{

--- a/ConcernsCaseWork/Service.Redis/Cases/CaseHistoryCachedService.cs
+++ b/ConcernsCaseWork/Service.Redis/Cases/CaseHistoryCachedService.cs
@@ -48,7 +48,7 @@ namespace Service.Redis.Cases
 			{
 				var caseWrapper = new CaseWrapper();
 				caseWrapper.CasesHistoryDto.Add(newCaseHistoryDto);
-				userState = new UserState { CasesDetails = { { createCaseHistoryDto.CaseUrn, caseWrapper } } };
+				userState = new UserState(caseworker) { CasesDetails = { { createCaseHistoryDto.CaseUrn, caseWrapper } } };
 			}
 			else
 			{

--- a/ConcernsCaseWork/Service.Redis/Models/UserState.cs
+++ b/ConcernsCaseWork/Service.Redis/Models/UserState.cs
@@ -7,8 +7,13 @@ namespace Service.Redis.Models
 	[Serializable]
 	public sealed class UserState
 	{
+		public UserState(string userName)
+		{
+			UserName = userName;
+		}
 		public string TrustUkPrn { get; set; }
 		public CreateCaseModel CreateCaseModel { get; set; } = new CreateCaseModel();
 		public IDictionary<long, CaseWrapper> CasesDetails { get; } = new ConcurrentDictionary<long, CaseWrapper>();
+		public string UserName { get; private set; }
 	}
 }

--- a/ConcernsCaseWork/Service.Redis/Users/UserStateCachedService.cs
+++ b/ConcernsCaseWork/Service.Redis/Users/UserStateCachedService.cs
@@ -8,6 +8,8 @@ namespace Service.Redis.Users
 {
 	public class UserStateCachedService : CachedService, IUserStateCachedService
 	{
+		private const int _defaultCacheExpiryHours = 9;
+
 		public UserStateCachedService(ICacheProvider cacheProvider) : base(cacheProvider)
 		{
 		}
@@ -26,7 +28,7 @@ namespace Service.Redis.Users
 			// no need to store nulls
 			await (userState is null
 				? ClearData(userIdentity)
-				: base.StoreData(userIdentity, userState));
+				: base.StoreData(userIdentity, userState, _defaultCacheExpiryHours));
 		}
 	}
 }


### PR DESCRIPTION
**What is the change?**
This is a temporary solution as we may not have time to fully integrate with Azure GraphAPI to retrieve a list of users in our AD groups.
What this will do is when the home page is loaded redis will be checked for a user state, if no user state is found then team information will be retrieved from the academies/trams API. If no team information was found, then an empty team will be created (via trams API) and a user state will be stored in Redis for 9 hours.

The owners of the teams will effectively become a list of known users in the system. If we choose to we can remove any users where there are no team members when we have GraphAPI integration

**Why do we need the change?**
Team casework pages are using a hard coded list of users and this is not suitable for any kind of beta/production environment.

**What is the impact?**
No new changes to trams are needed for this. High value despite being a temporary solution because users will start to be captured.

**Azure DevOps Ticket**
105360 (task 105363)