### PR TITLE
Ensure index page copes if all values are not set, in particular Date…

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
@@ -55,7 +55,7 @@
                         <th scope="row" class="govuk-table-case-details__header">Current status</th>
                         <td class="govuk-table__cell">
                             @{
-                                RenderValue(Model.NtiWarningLetterModel.Status.Name);
+                                RenderValue(Model.NtiWarningLetterModel.Status?.Name);
                             }
                         </td>
                     }
@@ -64,22 +64,27 @@
                         <th scope="row" class="govuk-table-case-details__header">Status</th>
                         <td class="govuk-table__cell">
                             @{
-                                RenderValue(Model.NtiWarningLetterModel.ClosedStatus.Name);
+                                RenderValue(Model.NtiWarningLetterModel.ClosedStatus?.Name);
                             }
                         </td>
                     }
-
                 </tr>
 
-                @* Date sent *@
-                <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table-case-details__header">Date sent</th>
-                    <td class="govuk-table__cell">
-                        @{
-                            RenderValue(DateExtension.ToDayMonthYearWithDefault(Model.NtiWarningLetterModel.SentDate.Value));
-                        }
-                    </td>
-                </tr>
+
+				@* Date sent *@
+	            <tr class="govuk-table__row">
+		            <th scope="row" class="govuk-table-case-details__header">Date sent</th>
+		            <td class="govuk-table__cell">
+			            @if(@Model.NtiWarningLetterModel.SentDate.HasValue)
+			            {
+				            RenderValue(DateExtension.ToDayMonthYearWithDefault(Model.NtiWarningLetterModel.SentDate.Value));
+			            }
+			            else
+			            {
+				            RenderEmptyLabel();
+			            }
+		            </td>
+	            </tr>
 
                 @* Reasons *@
                 <tr class="govuk-table__row">


### PR DESCRIPTION
This bug was a critical error when viewing an open NTI Warning Letter which did not have one of the following values set: Date Sent, Closed Status, or Status.
DevOps issue #106046

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/106046

The fix is to cope with null values for any of Date Sent, Closed Status, or Status, as it is valid if they are not set.

There are no tests for this as it is not currently possible to test this UI logic from this project.
