### PR TITLE
bug/106240-nti-uc-notes-length-validation

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/NtiUc/AddPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/NtiUc/AddPageModelTests.cs
@@ -14,6 +14,7 @@ using Service.Redis.FinancialPlan;
 using Service.Redis.NtiUnderConsideration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.NtiUc
@@ -86,6 +87,64 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.NtiUc
 			Assert.That(page, Is.Not.Null);
 			Assert.That(pageModel.TempData, Is.Not.Null);
 			Assert.That(pageModel.TempData["Error.Message"], Is.EqualTo("An error occurred posting the form, please try again. If the error persists contact the service administrator."));
+		}
+
+		[Test]
+		[TestCase(0, true)]
+		[TestCase(1, true)]
+		[TestCase(AddPageModel.NotesMaxLength, true)]
+		[TestCase(AddPageModel.NotesMaxLength + 1, false)]
+		public async Task WhenOnPostAsync_ValidateNotes(int notesLength, bool isValid)
+		{
+			// arrange
+			Mock<INtiUnderConsiderationModelService> mockNtiModelService = new Mock<INtiUnderConsiderationModelService>();
+			Mock<INtiUnderConsiderationReasonsCachedService> mockNtiReasonsCachedService = new Mock<INtiUnderConsiderationReasonsCachedService>();
+			Mock<ILogger<AddPageModel>> mockLogger = new Mock<ILogger<AddPageModel>>();
+
+			var pageModel = SetupAddPageModel(mockNtiModelService, mockNtiReasonsCachedService, mockLogger);
+
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+
+			pageModel.HttpContext.Request.Form = new FormCollection(
+			new Dictionary<string, StringValues>
+			{
+				{ "nti-notes", new StringValues(GenereateString(notesLength)) }
+			});
+
+			// act
+			var pageResponse = await pageModel.OnPostAsync();
+
+			// assert
+			if (isValid)
+			{
+				Assert.That(pageModel.TempData["NTI-UC.Message"], Is.Null);
+			}
+			else
+			{
+				Assert.That(pageModel.TempData["NTI-UC.Message"], Is.Not.Null);
+			}
+		}
+
+		private string GenereateString(int length)
+		{
+			if (length == 0)
+			{
+				return String.Empty;
+			}
+
+			var chars = Enumerable.Range(65, 50).Select(i => (char)i).ToArray();
+			var stringChars = new char[length];
+			var random = new Random();
+
+			for (int i = 0; i < stringChars.Length; i++)
+			{
+				stringChars[i] = chars[random.Next(chars.Length)];
+			}
+
+			var finalString = new String(stringChars);
+
+			return finalString;
 		}
 
 		private static AddPageModel SetupAddPageModel(

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/NtiUc/EditPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/NtiUc/EditPageModelTests.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration;
+﻿using ConcernsCaseWork.Models.CaseActions;
+using ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration;
 using ConcernsCaseWork.Services.Cases;
 using ConcernsCaseWork.Shared.Tests.Factory;
 using Microsoft.AspNetCore.Http;
@@ -14,6 +15,7 @@ using Service.Redis.FinancialPlan;
 using Service.Redis.NtiUnderConsideration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.NtiUc
@@ -107,6 +109,77 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.NtiUc
 			Assert.That(page, Is.Not.Null);
 			Assert.That(pageModel.TempData, Is.Not.Null);
 			Assert.That(pageModel.TempData["Error.Message"], Is.EqualTo("An error occurred posting the form, please try again. If the error persists contact the service administrator."));
+		}
+
+		[Test]
+		[TestCase(0, true)]
+		[TestCase(1, true)]
+		[TestCase(AddPageModel.NotesMaxLength, true)]
+		[TestCase(AddPageModel.NotesMaxLength + 1, false)]
+		public async Task WhenOnPostAsync_ValidateNotes(int notesLength, bool isValid)
+		{
+			// arrange
+			var ntiId = 123;
+			Mock<INtiUnderConsiderationModelService> mockNtiModelService = new Mock<INtiUnderConsiderationModelService>();
+			Mock<INtiUnderConsiderationReasonsCachedService> mockNtiReasonsCachedService = new Mock<INtiUnderConsiderationReasonsCachedService>();
+			Mock<ILogger<EditPageModel>> mockLogger = new Mock<ILogger<EditPageModel>>();
+
+			mockNtiModelService.Setup(ms => ms.GetNtiUnderConsideration(It.IsAny<long>()))
+				.ReturnsAsync(new NtiUnderConsiderationModel
+			{
+				Id = ntiId
+			});
+
+			mockNtiModelService.Setup(ms => ms.PatchNtiUnderConsideration(It.IsAny<NtiUnderConsiderationModel>()))
+				.ReturnsAsync(new NtiUnderConsiderationModel
+			{
+				Id = ntiId
+			});
+
+			var pageModel = SetupAddPageModel(mockNtiModelService, mockNtiReasonsCachedService, mockLogger);
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+			routeData.Add("ntiUCId", ntiId);
+
+			pageModel.HttpContext.Request.Form = new FormCollection(
+			new Dictionary<string, StringValues>
+			{
+				{ "nti-notes", new StringValues(GenereateString(notesLength)) }
+			});
+
+			// act
+			var pageResponse = await pageModel.OnPostAsync();
+
+			// assert
+			if (isValid)
+			{
+				Assert.That(pageModel.TempData["NTI-UC.Message"], Is.Null);
+			}
+			else
+			{
+				Assert.That(pageModel.TempData["NTI-UC.Message"], Is.Not.Null);
+			}
+		}
+
+		private string GenereateString(int length)
+		{
+			if (length == 0)
+			{
+				return String.Empty;
+			}
+
+			var chars = Enumerable.Range(65, 50).Select(i => (char)i).ToArray();
+			var stringChars = new char[length];
+			var random = new Random();
+
+			for (int i = 0; i < stringChars.Length; i++)
+			{
+				stringChars[i] = chars[random.Next(chars.Length)];
+			}
+
+			var finalString = new String(stringChars);
+
+			return finalString;
 		}
 
 		private static EditPageModel SetupAddPageModel(

--- a/ConcernsCaseWork/ConcernsCaseWork/Exceptions/InvalidUserInputException.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Exceptions/InvalidUserInputException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace ConcernsCaseWork.Exceptions
+{
+	/// <summary>
+	/// This introduced to use the existing exception based error propegation without accidentaly exposing 
+	/// unrelated InvalidOperationExceptions to the user
+	/// </summary>
+	public class InvalidUserInputException : Exception
+	{
+		public InvalidUserInputException() : base()
+		{ }
+
+		public InvalidUserInputException(string msg) : base(msg)
+		{ }
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Add.cshtml
@@ -75,13 +75,13 @@
                     </div>
 
                     @* Notes *@
-                    <div class="govuk-character-count govuk-!-margin-top-9" data-module="govuk-character-count" data-maxlength="@Model.NotesMaxLength">
+                    <div class="govuk-character-count govuk-!-margin-top-9" data-module="govuk-character-count" data-maxlength="@AddPageModel.NotesMaxLength">
                         <div class="govuk-form-group">
                             <h2 class="govuk-heading-m">Notes</h2>
                             <textarea class="govuk-textarea govuk-js-character-count concern-auto-resize" id="nti-notes" name="nti-notes" rows="3" aria-describedby="nti-notes-info"></textarea>
                         </div>
                         <div id="nti-notes-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
-                            You can enter up to @Model.NotesMaxLength characters
+                            You can enter up to @AddPageModel.NotesMaxLength characters
                         </div>
                     </div>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Add.cshtml.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ConcernsCaseWork.Models.CaseActions;
 using Service.Redis.NtiUnderConsideration;
+using ConcernsCaseWork.Exceptions;
 
 namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 {
@@ -24,7 +25,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 		private readonly ILogger<AddPageModel> _logger;
 		
 
-		public int NotesMaxLength => 2000;
+		public const int NotesMaxLength = 2000;
 		public IEnumerable<RadioItem> NTIReasonsToConsider;
 
 		public long CaseUrn { get; private set; }
@@ -72,10 +73,14 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 
 				return Redirect($"/case/{CaseUrn}/management");
 			}
+			catch(InvalidUserInputException ex)
+			{
+				TempData["NTI-UC.Message"] = ex.Message;
+				return RedirectToPage();
+			}
 			catch (Exception ex)
 			{
 				_logger.LogError("Case::NTI-UC::AddPageModel::OnPostAsync::Exception - {Message}", ex.Message);
-
 				TempData["Error.Message"] = ErrorOnPostPage;
 			}
 
@@ -117,7 +122,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 			{
 				if (notes.Length > NotesMaxLength)
 				{
-					throw new Exception($"Notes provided exceed maximum allowed length ({NotesMaxLength} characters).");
+					throw new InvalidUserInputException($"Notes provided exceed maximum allowed length ({NotesMaxLength} characters).");
 				}
 				else
 				{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Edit.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Edit.cshtml
@@ -69,13 +69,13 @@
                     </div>
 
                     @* Notes *@
-                    <div class="govuk-character-count govuk-!-margin-top-9" data-module="govuk-character-count" data-maxlength="@Model.NotesMaxLength">
+                    <div class="govuk-character-count govuk-!-margin-top-9" data-module="govuk-character-count" data-maxlength="@EditPageModel.NotesMaxLength">
                         <div class="govuk-form-group">
                             <h2 class="govuk-heading-m">Notes</h2>
                             <textarea class="govuk-textarea govuk-js-character-count concern-auto-resize" id="nti-notes" name="nti-notes" rows="3" aria-describedby="nti-notes-info">@(Model.NtiModel?.Notes ?? string.Empty)</textarea>
                         </div>
                         <div id="nti-notes-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
-                            You can enter up to @Model.NotesMaxLength characters
+                            You can enter up to @EditPageModel.NotesMaxLength characters
                         </div>
                     </div>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Edit.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Edit.cshtml.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ConcernsCaseWork.Models.CaseActions;
 using Service.Redis.NtiUnderConsideration;
+using ConcernsCaseWork.Exceptions;
 
 namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 {
@@ -23,7 +24,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 		private readonly INtiUnderConsiderationReasonsCachedService _ntiReasonsCachedService;
 		private readonly ILogger<EditPageModel> _logger;
 		
-		public int NotesMaxLength => 2000;
+		public const int NotesMaxLength = 2000;
 		public IEnumerable<RadioItem> NTIReasonsToConsiderForUI;
 
 		public long CaseUrn { get; private set; }
@@ -78,6 +79,11 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 				var updated = await _ntiModelService.PatchNtiUnderConsideration(freshFromDb);
 
 				return Redirect($"/case/{CaseUrn}/management/action/ntiunderconsideration/{updated.Id}");
+			}
+			catch (InvalidUserInputException ex)
+			{
+				TempData["NTI-UC.Message"] = ex.Message;
+				return RedirectToPage();
 			}
 			catch (Exception ex)
 			{
@@ -141,7 +147,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiUnderConsideration
 			{
 				if (notes.Length > NotesMaxLength)
 				{
-					throw new Exception($"Notes provided exceed maximum allowed length ({NotesMaxLength} characters).");
+					throw new InvalidUserInputException($"Notes provided exceed maximum allowed length ({NotesMaxLength} characters).");
 				}
 				else
 				{


### PR DESCRIPTION
**What is the change?**
bug fix - show validation message correctly when notes fails validation

**Why do we need the change?**
for nti-uc 

**What is the impact?**
changes to local (nti-uc) code

**Azure DevOps Ticket**
106240