### PR TITLE
forcing later version of newtonsoft

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />


### PR DESCRIPTION
**What is the change?**
The core types test project had an outdated version of newtonsoft json referenced.

**Why do we need the change?**
deployment cannot work with out dated package

**What is the impact?**
deployment will work

**Azure DevOps Ticket**
107759