### PR TITLE
Feature/105070 make case action tables always appear

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/FinancialPlanFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/FinancialPlanFactory.cs
@@ -11,23 +11,42 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 	{
 		private readonly static Fixture Fixture = new Fixture();
 
-		public static FinancialPlanModel BuildFinancialPlanModel(DateTime? closedAt = null)
+		public static FinancialPlanModel BuildClosedFinancialPlanModel(DateTime closedAt)
 		{
-			return new FinancialPlanModel(
+			var model = new FinancialPlanModel(
 				Fixture.Create<long>(),
 				Fixture.Create<long>(),
 				Fixture.Create<DateTime>(),
 				Fixture.Create<DateTime>(),
 				Fixture.Create<DateTime>(),
 				Fixture.Create<string>(),
-				Fixture.Create<FinancialPlanStatusModel>(),
+				new FinancialPlanStatusModel(Fixture.Create<string>(), Fixture.Create<long>(), true),
 				closedAt
 			);
+
+			return model;
+		} 
+		
+		public static FinancialPlanModel BuildOpenFinancialPlanModel()
+		{
+			var model = new FinancialPlanModel(
+				Fixture.Create<long>(),
+				Fixture.Create<long>(),
+				Fixture.Create<DateTime>(),
+				Fixture.Create<DateTime>(),
+				Fixture.Create<DateTime>(),
+				Fixture.Create<string>(),
+				new FinancialPlanStatusModel(Fixture.Create<string>(), Fixture.Create<long>(), false),
+				null
+			);
+			return model;
 		} 
 
 		public static List<FinancialPlanModel> BuildListFinancialPlanModel(DateTime? closedAt = null)
 		{
-			return new List<FinancialPlanModel>() { BuildFinancialPlanModel(closedAt) };
+			return closedAt.HasValue 
+				? new List<FinancialPlanModel>() { BuildClosedFinancialPlanModel((DateTime)closedAt) } 
+				: new List<FinancialPlanModel>() { BuildOpenFinancialPlanModel() };
 		}
 
 		public static List<FinancialPlanModel> BuildListFinancialPlanModel(params FinancialPlanModel[] financialPlanModels)

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
@@ -1,4 +1,6 @@
 ﻿using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Models;
+using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Case.Management;
 using ConcernsCaseWork.Services.Cases;
 using ConcernsCaseWork.Services.FinancialPlan;
@@ -16,9 +18,10 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Service.Redis.NtiUnderConsideration;
-using Service.Redis.NtiWarningLetter;
 using Service.Redis.Status;
 using Service.TRAMS.Status;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -150,6 +153,21 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 			Assert.That(pageModel.CaseModel.DirectionOfTravel, Is.EqualTo(caseModel.DirectionOfTravel));
 			Assert.That(pageModel.CaseModel.ReasonAtReview, Is.EqualTo(caseModel.ReasonAtReview));
 			Assert.That(pageModel.CaseModel.TrustUkPrn, Is.EqualTo(caseModel.TrustUkPrn));
+
+			var expectedCountCaseActions = financialPlansModel.Count + ntiUnderConsiderationModels.Count + ntiWarningLetterModels.Count + ntiModels.Count;
+			Assert.That(pageModel.CaseActions.Count, Is.EqualTo(expectedCountCaseActions));
+			
+			var expectedHasOpenCaseActions = financialPlansModel.Any(m => !m.ClosedAt.HasValue) 
+			                                   || ntiUnderConsiderationModels.Any(m => !m.ClosedAt.HasValue) 
+			                                   || ntiWarningLetterModels.Any(m => !m.ClosedAt.HasValue) 
+			                                   || ntiModels.Any(m => !m.ClosedAt.HasValue);
+			Assert.That(pageModel.HasOpenActions, Is.EqualTo(expectedHasOpenCaseActions));
+			
+			var expectedHasClosedCaseActions = financialPlansModel.Any(m => m.ClosedAt.HasValue) 
+			                                 || ntiUnderConsiderationModels.Any(m => m.ClosedAt.HasValue) 
+			                                 || ntiWarningLetterModels.Any(m => m.ClosedAt.HasValue) 
+			                                 || ntiModels.Any(m => m.ClosedAt.HasValue);
+			Assert.That(pageModel.HasClosedActions, Is.EqualTo(expectedHasClosedCaseActions));
 			
 			Assert.That(pageModel.TrustCasesModel, Is.Not.Null);
 			Assert.That(pageModel.TrustCasesModel.Count, Is.EqualTo(1));
@@ -210,6 +228,270 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 				Assert.That(expectedRecordStatusModel.Urn, Is.EqualTo(actualRecordStatusModel.Urn));
 			}
 		}
+		
+		[Test]
+		public async Task WhenOnGetAsync_WithNoCaseActions_SetsHasOpenActionsAndHasClosedActionsToFalse()
+		{
+			// arrange
+			var mockCaseModelService = new Mock<ICaseModelService>();
+			var mockTrustModelService = new Mock<ITrustModelService>();
+			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockRatingModelService = new Mock<IRatingModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
+			var mockLogger = new Mock<ILogger<IndexPageModel>>();
+			var mockCaseHistoryModelService = new Mock<ICaseHistoryModelService>();
+			var mockSrmaService = new Mock<ISRMAService>();
+			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
+			var mockNtiUnderConsiderationModelService = new Mock<INtiUnderConsiderationModelService>();
+			var mockNtiUCStatusesCachedService = new Mock<INtiUnderConsiderationStatusesCachedService>();
+			var mockNtiWLModelService = new Mock<INtiWarningLetterModelService>();
+			var mockNtiModelService = new Mock<INtiModelService>();
+
+			var caseModel = CaseFactory.BuildCaseModel();
+			var trustCasesModel = CaseFactory.BuildListTrustCasesModel();
+			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
+			var recordsModel = RecordFactory.BuildListRecordModel();
+			var closedStatusModel = StatusFactory.BuildStatusDto(StatusEnum.Close.ToString(), 3);
+
+			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(caseModel);
+			mockCaseModelService.Setup(c => c.GetCasesByTrustUkprn(It.IsAny<string>()))
+				.ReturnsAsync(trustCasesModel);
+			mockTrustModelService.Setup(t => t.GetTrustByUkPrn(It.IsAny<string>()))
+				.ReturnsAsync(trustDetailsModel);
+			mockCaseHistoryModelService.Setup(c => c.GetCasesHistory(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(new List<CaseHistoryModel>());
+			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(recordsModel);
+			mockStatusCachedService.Setup(s => s.GetStatusByName(It.IsAny<string>()))
+				.ReturnsAsync(closedStatusModel);
+			mockFinancialPlanModelService.Setup(fp => fp.GetFinancialPlansModelByCaseUrn(It.IsAny<long>(), It.IsAny<string>()))
+				.ReturnsAsync(new List<FinancialPlanModel>());
+			mockNtiUnderConsiderationModelService.Setup(uc => uc.GetNtiUnderConsiderationsForCase(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiUnderConsiderationModel>());
+			mockNtiWLModelService.Setup(wl => wl.GetNtiWarningLettersForCase(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiWarningLetterModel>());
+			mockNtiModelService.Setup(nti => nti.GetNtisForCaseAsync(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiModel>());
+
+			var pageModel = SetupIndexPageModel(mockCaseModelService.Object, mockTrustModelService.Object,
+					mockCaseHistoryModelService.Object, mockRecordModelService.Object, mockRatingModelService.Object, mockStatusCachedService.Object, 
+					mockSrmaService.Object, mockFinancialPlanModelService.Object, mockNtiUnderConsiderationModelService.Object, mockNtiUCStatusesCachedService.Object,
+					 mockLogger.Object, mockNtiWLModelService.Object, mockNtiModelService.Object);
+
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+			
+			// act
+			await pageModel.OnGetAsync();
+			
+			// assert
+			Assert.Multiple(() =>
+			{
+				Assert.That(pageModel.CaseActions.Count, Is.EqualTo(0));
+				Assert.That(pageModel.HasOpenActions, Is.EqualTo(false));
+				Assert.That(pageModel.HasClosedActions, Is.EqualTo(false));
+			});
+		}
+
+		[Test]
+		public async Task WhenOnGetAsync_WithOnlyOpenCaseActions_SetsHasOpenActionsToTrueAndHasClosedActionsToFalse()
+		{
+			// arrange
+			var mockCaseModelService = new Mock<ICaseModelService>();
+			var mockTrustModelService = new Mock<ITrustModelService>();
+			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockRatingModelService = new Mock<IRatingModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
+			var mockLogger = new Mock<ILogger<IndexPageModel>>();
+			var mockCaseHistoryModelService = new Mock<ICaseHistoryModelService>();
+			var mockSrmaService = new Mock<ISRMAService>();
+			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
+			var mockNtiUnderConsiderationModelService = new Mock<INtiUnderConsiderationModelService>();
+			var mockNtiUCStatusesCachedService = new Mock<INtiUnderConsiderationStatusesCachedService>();
+			var mockNtiWLModelService = new Mock<INtiWarningLetterModelService>();
+			var mockNtiModelService = new Mock<INtiModelService>();
+
+			var caseModel = CaseFactory.BuildCaseModel();
+			var trustCasesModel = CaseFactory.BuildListTrustCasesModel();
+			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
+			var recordsModel = RecordFactory.BuildListRecordModel();
+			var closedStatusModel = StatusFactory.BuildStatusDto(StatusEnum.Close.ToString(), 3);
+			var ntiWarningLetterModels = NTIWarningLetterFactory.BuildListNTIWarningLetterModels(3);
+
+			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(caseModel);
+			mockCaseModelService.Setup(c => c.GetCasesByTrustUkprn(It.IsAny<string>()))
+				.ReturnsAsync(trustCasesModel);
+			mockTrustModelService.Setup(t => t.GetTrustByUkPrn(It.IsAny<string>()))
+				.ReturnsAsync(trustDetailsModel);
+			mockCaseHistoryModelService.Setup(c => c.GetCasesHistory(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(new List<CaseHistoryModel>());
+			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(recordsModel);
+			mockStatusCachedService.Setup(s => s.GetStatusByName(It.IsAny<string>()))
+				.ReturnsAsync(closedStatusModel);
+			mockFinancialPlanModelService.Setup(fp => fp.GetFinancialPlansModelByCaseUrn(It.IsAny<long>(), It.IsAny<string>()))
+				.ReturnsAsync(new List<FinancialPlanModel>());
+			mockNtiUnderConsiderationModelService.Setup(uc => uc.GetNtiUnderConsiderationsForCase(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiUnderConsiderationModel>());
+			mockNtiWLModelService.Setup(wl => wl.GetNtiWarningLettersForCase(It.IsAny<long>()))
+				.ReturnsAsync(ntiWarningLetterModels);
+			mockNtiModelService.Setup(nti => nti.GetNtisForCaseAsync(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiModel>());
+
+			var pageModel = SetupIndexPageModel(mockCaseModelService.Object, mockTrustModelService.Object,
+					mockCaseHistoryModelService.Object, mockRecordModelService.Object, mockRatingModelService.Object, mockStatusCachedService.Object, 
+					mockSrmaService.Object, mockFinancialPlanModelService.Object, mockNtiUnderConsiderationModelService.Object, mockNtiUCStatusesCachedService.Object,
+					 mockLogger.Object, mockNtiWLModelService.Object, mockNtiModelService.Object);
+
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+			
+			// act
+			await pageModel.OnGetAsync();
+			
+			// assert
+			Assert.Multiple(() =>
+			{
+				Assert.That(pageModel.CaseActions.Count, Is.EqualTo(3));
+				Assert.That(pageModel.HasOpenActions, Is.EqualTo(true));
+				Assert.That(pageModel.HasClosedActions, Is.EqualTo(false));
+			});
+		}
+
+		[Test]
+		public async Task WhenOnGetAsync_WithOnlyClosedCaseActions_SetsHasOpenActionsToFalseAndHasClosedActionsToTrue()
+		{
+			// arrange
+			var mockCaseModelService = new Mock<ICaseModelService>();
+			var mockTrustModelService = new Mock<ITrustModelService>();
+			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockRatingModelService = new Mock<IRatingModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
+			var mockLogger = new Mock<ILogger<IndexPageModel>>();
+			var mockCaseHistoryModelService = new Mock<ICaseHistoryModelService>();
+			var mockSrmaService = new Mock<ISRMAService>();
+			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
+			var mockNtiUnderConsiderationModelService = new Mock<INtiUnderConsiderationModelService>();
+			var mockNtiUCStatusesCachedService = new Mock<INtiUnderConsiderationStatusesCachedService>();
+			var mockNtiWLModelService = new Mock<INtiWarningLetterModelService>();
+			var mockNtiModelService = new Mock<INtiModelService>();
+
+			var caseModel = CaseFactory.BuildCaseModel();
+			var trustCasesModel = CaseFactory.BuildListTrustCasesModel();
+			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
+			var recordsModel = RecordFactory.BuildListRecordModel();
+			var closedStatusModel = StatusFactory.BuildStatusDto(StatusEnum.Close.ToString(), 3);
+			var ntiWarningLetterModels = NTIWarningLetterFactory.BuildListNTIWarningLetterModels(3, DateTime.Now);
+
+			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(caseModel);
+			mockCaseModelService.Setup(c => c.GetCasesByTrustUkprn(It.IsAny<string>()))
+				.ReturnsAsync(trustCasesModel);
+			mockTrustModelService.Setup(t => t.GetTrustByUkPrn(It.IsAny<string>()))
+				.ReturnsAsync(trustDetailsModel);
+			mockCaseHistoryModelService.Setup(c => c.GetCasesHistory(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(new List<CaseHistoryModel>());
+			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(recordsModel);
+			mockStatusCachedService.Setup(s => s.GetStatusByName(It.IsAny<string>()))
+				.ReturnsAsync(closedStatusModel);
+			mockFinancialPlanModelService.Setup(fp => fp.GetFinancialPlansModelByCaseUrn(It.IsAny<long>(), It.IsAny<string>()))
+				.ReturnsAsync(new List<FinancialPlanModel>());
+			mockNtiUnderConsiderationModelService.Setup(uc => uc.GetNtiUnderConsiderationsForCase(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiUnderConsiderationModel>());
+			mockNtiWLModelService.Setup(wl => wl.GetNtiWarningLettersForCase(It.IsAny<long>()))
+				.ReturnsAsync(ntiWarningLetterModels);
+			mockNtiModelService.Setup(nti => nti.GetNtisForCaseAsync(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiModel>());
+
+			var pageModel = SetupIndexPageModel(mockCaseModelService.Object, mockTrustModelService.Object,
+					mockCaseHistoryModelService.Object, mockRecordModelService.Object, mockRatingModelService.Object, mockStatusCachedService.Object, 
+					mockSrmaService.Object, mockFinancialPlanModelService.Object, mockNtiUnderConsiderationModelService.Object, mockNtiUCStatusesCachedService.Object,
+					 mockLogger.Object, mockNtiWLModelService.Object, mockNtiModelService.Object);
+
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+			
+			// act
+			await pageModel.OnGetAsync();
+			
+			// assert
+			Assert.Multiple(() =>
+			{
+				Assert.That(pageModel.CaseActions.Count, Is.EqualTo(3));
+				Assert.That(pageModel.HasOpenActions, Is.EqualTo(false));
+				Assert.That(pageModel.HasClosedActions, Is.EqualTo(true));
+			});
+		}
+
+		[Test]
+		public async Task WhenOnGetAsync_WithOpenAndClosedCaseActions_SetsHasOpenActionsAndHasClosedActionsToTrue()
+		{
+			// arrange
+			var mockCaseModelService = new Mock<ICaseModelService>();
+			var mockTrustModelService = new Mock<ITrustModelService>();
+			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockRatingModelService = new Mock<IRatingModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
+			var mockLogger = new Mock<ILogger<IndexPageModel>>();
+			var mockCaseHistoryModelService = new Mock<ICaseHistoryModelService>();
+			var mockSrmaService = new Mock<ISRMAService>();
+			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
+			var mockNtiUnderConsiderationModelService = new Mock<INtiUnderConsiderationModelService>();
+			var mockNtiUCStatusesCachedService = new Mock<INtiUnderConsiderationStatusesCachedService>();
+			var mockNtiWLModelService = new Mock<INtiWarningLetterModelService>();
+			var mockNtiModelService = new Mock<INtiModelService>();
+
+			var caseModel = CaseFactory.BuildCaseModel();
+			var trustCasesModel = CaseFactory.BuildListTrustCasesModel();
+			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
+			var recordsModel = RecordFactory.BuildListRecordModel();
+			var closedStatusModel = StatusFactory.BuildStatusDto(StatusEnum.Close.ToString(), 3);
+			var ntiWarningLetterModels = NTIWarningLetterFactory.BuildListNTIWarningLetterModels(3);			
+			var closedNtiModels = NTIFactory.BuildClosedListNTIModel();
+
+			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(caseModel);
+			mockCaseModelService.Setup(c => c.GetCasesByTrustUkprn(It.IsAny<string>()))
+				.ReturnsAsync(trustCasesModel);
+			mockTrustModelService.Setup(t => t.GetTrustByUkPrn(It.IsAny<string>()))
+				.ReturnsAsync(trustDetailsModel);
+			mockCaseHistoryModelService.Setup(c => c.GetCasesHistory(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(new List<CaseHistoryModel>());
+			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(recordsModel);
+			mockStatusCachedService.Setup(s => s.GetStatusByName(It.IsAny<string>()))
+				.ReturnsAsync(closedStatusModel);
+			mockFinancialPlanModelService.Setup(fp => fp.GetFinancialPlansModelByCaseUrn(It.IsAny<long>(), It.IsAny<string>()))
+				.ReturnsAsync(new List<FinancialPlanModel>());
+			mockNtiUnderConsiderationModelService.Setup(uc => uc.GetNtiUnderConsiderationsForCase(It.IsAny<long>()))
+				.ReturnsAsync(new List<NtiUnderConsiderationModel>());
+			mockNtiWLModelService.Setup(wl => wl.GetNtiWarningLettersForCase(It.IsAny<long>()))
+				.ReturnsAsync(ntiWarningLetterModels);
+			mockNtiModelService.Setup(nti => nti.GetNtisForCaseAsync(It.IsAny<long>()))
+				.ReturnsAsync(closedNtiModels);
+
+			var pageModel = SetupIndexPageModel(mockCaseModelService.Object, mockTrustModelService.Object,
+					mockCaseHistoryModelService.Object, mockRecordModelService.Object, mockRatingModelService.Object, mockStatusCachedService.Object, 
+					mockSrmaService.Object, mockFinancialPlanModelService.Object, mockNtiUnderConsiderationModelService.Object, mockNtiUCStatusesCachedService.Object,
+					 mockLogger.Object, mockNtiWLModelService.Object, mockNtiModelService.Object);
+
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+			
+			// act
+			await pageModel.OnGetAsync();
+			
+			// assert
+			Assert.Multiple(() =>
+			{
+				Assert.That(pageModel.CaseActions.Count, Is.EqualTo(5));
+				Assert.That(pageModel.HasOpenActions, Is.EqualTo(true));
+				Assert.That(pageModel.HasClosedActions, Is.EqualTo(true));
+			});
+		}
 
 		[Test]
 		public async Task WhenUserHasEditCasePrivileges_ShowEditActions_Return_False()
@@ -220,7 +502,6 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 			var mockRecordModelService = new Mock<IRecordModelService>();
 			var mockRatingModelService = new Mock<IRatingModelService>();
 			var mockStatusCachedService = new Mock<IStatusCachedService>();
-			var closeStatusModel = StatusFactory.BuildStatusDto(StatusEnum.Close.ToString(), 3);
 			var mockLogger = new Mock<ILogger<IndexPageModel>>();
 			var mockCaseHistoryModelService = new Mock<ICaseHistoryModelService>();
 			var mockSrmaService = new Mock<ISRMAService>();

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -288,8 +288,7 @@
                     Add to case
                 </a>
 
-                @if (openSRMAs.Count > 0 || openFinancialPlanModels.Count > 0 || openNtiUCs.Count > 0 || openNtiWLs.Count > 0 || openNtis.Count > 0)
-                {
+
                     <table id="open-case-actions" class="govuk-table">
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row tr__large">
@@ -305,6 +304,16 @@
                         </thead>
 
                         <tbody class="govuk-table__body">
+	        
+	                        @if (!Model.HasOpenActions)
+	                        {
+	                            <tr class="govuk-table__row">
+	                                <td class="govuk-table__cell" colspan="3">
+	                                    There are no open actions or decisions added to this case.
+	                                </td>
+	                            </tr>
+	                        }
+                        
                             @foreach (SRMAModel srma in openSRMAs)
                             {
                                 <tr class="govuk-table__row">
@@ -419,11 +428,8 @@
                             }
                         </tbody>
                     </table>
-                }
 
-                @if (closedSRMAs.Count > 0 || closedFinancialPlanModels.Count > 0 || closedNtiUCs.Count > 0 || closedNtiWLs.Count > 0 || closedNtis.Count > 0)
-                {
-                    <table id="close-case-actions" class="govuk-table">
+            <table id="close-case-actions" class="govuk-table">
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row tr__large">
                                 <th class="govuk-table__header govuk-table__cell__cases" scope="col">
@@ -438,6 +444,16 @@
                         </thead>
 
                         <tbody class="govuk-table__body">
+                        
+                            @if (!Model.HasClosedActions)
+                            {
+                                <tr class="govuk-table__row">
+                                    <td class="govuk-table__cell" colspan="3">
+                                        There are no closed actions or decisions added to this case.
+                                    </td>
+                                </tr>
+                            }
+                        
                             @foreach (SRMAModel srma in closedSRMAs)
                             {
                                 <tr class="govuk-table__row">
@@ -528,10 +544,6 @@
                             }
                         </tbody>
                     </table>
-                }
-
-
-
 
 
                 <partial name="_CaseHistory" model="@Model.CasesHistoryModel" />

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
@@ -45,6 +45,8 @@ namespace ConcernsCaseWork.Pages.Case.Management
 		public IList<TrustCasesModel> TrustCasesModel { get; private set; }
 		public IList<CaseHistoryModel> CasesHistoryModel { get; private set; }
 		public bool IsEditableCase { get; private set; }
+		public bool HasOpenActions { get { return CaseActions.Any(a => !a.ClosedAt.HasValue); } }
+		public bool HasClosedActions { get { return CaseActions.Any(a => a.ClosedAt.HasValue); } }
 		public List<CaseActionModel> CaseActions { get; private set; }
 		public List<NtiUnderConsiderationStatusDto> NtiStatuses { get; set; }
 
@@ -108,7 +110,7 @@ namespace ConcernsCaseWork.Pages.Case.Management
 				var trustDetailsTask = _trustModelService.GetTrustByUkPrn(CaseModel.TrustUkPrn);
 				var trustCasesTask = _caseModelService.GetCasesByTrustUkprn(CaseModel.TrustUkPrn);
 				var caseActionsTask = PopulateCaseActions(caseUrn);
-
+				
 				Task.WaitAll(caseHistoryTask, trustDetailsTask, trustCasesTask, caseActionsTask);
 
 				CasesHistoryModel = caseHistoryTask.Result;
@@ -173,6 +175,5 @@ namespace ConcernsCaseWork.Pages.Case.Management
 
 			return false;
 		}
-
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Properties/launchSettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     "ConcernsCaseWork": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "https://localhost;http://localhost",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"


### PR DESCRIPTION
On the Case Summary page, always show the Open Actions and Closed Actions tables, but have a message in them if they are empty. 

This is because users found it confusing when the tables were sometimes there and sometimes not. 

The impact is only visual, on the Case Summary page.

[**Azure DevOps Ticket**](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/105070)
