### PR TITLE
Add 'created at' (opened at) date to case actions on case summary page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -432,6 +432,9 @@
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
+                                    Date Opened
+                                </th>
+                                <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
                                     Date Closed
                                 </th>
                             </tr>
@@ -446,8 +449,12 @@
                                             SRMA
                                         </a>
                                     </td>
-                                    <td class="govuk-table__cell">
-                                        @EnumHelper.GetEnumDescription(srma.Status)
+	                                <td class="govuk-table__cell">
+		                                @EnumHelper.GetEnumDescription(srma.Status)
+	                                </td>
+	                                
+                                    <td class="govuk-table__cell govuk-table__header__right">
+                                        @DateExtension.ToDayMonthYear(srma.CreatedAt)
                                     </td>
                                     <td class="govuk-table__cell govuk-table__header__right">
                                         @DateExtension.ToDayMonthYear(srma.ClosedAt.Value)
@@ -467,9 +474,12 @@
                                             Financial Plan
                                         </a>
                                     </td>
-                                    <td class="govuk-table__cell">
-                                        @EnumHelper.GetEnumDescription(statusEnum)
-                                    </td>
+	                                <td class="govuk-table__cell">
+		                                @EnumHelper.GetEnumDescription(statusEnum)
+	                                </td>
+                                    <td class="govuk-table__cell govuk-table__header__right">
+                                        @DateExtension.ToDayMonthYear(financialPlanModel.CreatedAt)
+                                    </td>    
                                     <td class="govuk-table__cell govuk-table__header__right">
                                         @DateExtension.ToDayMonthYear(financialPlanModel.ClosedAt.Value)
                                     </td>
@@ -484,8 +494,11 @@
                                             NTI: Under consideration
                                         </a>
                                     </td>
-                                    <td class="govuk-table__cell">
-                                        @(Model.NtiStatuses.SingleOrDefault(s => s.Id == nti.ClosedStatusId)?.Name ?? string.Empty)
+	                                <td class="govuk-table__cell">
+		                                @(Model.NtiStatuses.SingleOrDefault(s => s.Id == nti.ClosedStatusId)?.Name ?? string.Empty)
+	                                </td>
+                                    <td class="govuk-table__cell govuk-table__header__right">
+                                        @DateExtension.ToDayMonthYear(nti.CreatedAt)
                                     </td>
                                     <td class="govuk-table__cell govuk-table__header__right">
                                         @DateExtension.ToDayMonthYear(nti.ClosedAt.Value)
@@ -501,8 +514,11 @@
                                             NTI: Warning letter
                                         </a>
                                     </td>
-                                    <td class="govuk-table__cell">
-                                        @nti.ClosedStatus?.PastTenseName
+	                                <td class="govuk-table__cell">
+		                                @nti.ClosedStatus?.PastTenseName
+	                                </td>
+                                    <td class="govuk-table__cell govuk-table__header__right">
+                                        @DateExtension.ToDayMonthYear(nti.CreatedAt)
                                     </td>
                                     <td class="govuk-table__cell govuk-table__header__right">
                                         @DateExtension.ToDayMonthYear(nti.ClosedAt.Value)
@@ -522,6 +538,9 @@
                                         @nti.ClosedStatus?.Name
                                     </td>
                                     <td class="govuk-table__cell govuk-table__header__right">
+                                        @DateExtension.ToDayMonthYear(nti.CreatedAt)
+                                    </td>
+                                    <td class="govuk-table__cell govuk-table__header__right">
                                         @DateExtension.ToDayMonthYear(nti.ClosedAt.Value)
                                     </td>
                                 </tr>
@@ -529,9 +548,6 @@
                         </tbody>
                     </table>
                 }
-
-
-
 
 
                 <partial name="_CaseHistory" model="@Model.CasesHistoryModel" />


### PR DESCRIPTION
Add a new column called 'Date Opened' on the Closed Case Actions table on the case summary page, containing the date the action was created.

This is so that users can see when a closed action was originally opened.

[# 103986](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/103986)