### PR TITLE
Feature/102795-select-decision-item

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.CoreTypes/ConcernsCaseWork.CoreTypes.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.CoreTypes/ConcernsCaseWork.CoreTypes.csproj
@@ -8,10 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**What is the change?**
removed coverlet collector from the core types project. it should be for test projects

**Why do we need the change?**
docker image won't start

**What is the impact?**
docker image might start

**Azure DevOps Ticket**
107759