### PR TITLE
Add Actions to Closed Case page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/ActionsSummaryFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/ActionsSummaryFactory.cs
@@ -1,0 +1,14 @@
+using AutoFixture;
+using ConcernsCaseWork.Models.CaseActions;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConcernsCaseWork.Shared.Tests.Factory;
+
+public static class ActionsSummaryFactory
+{
+	private readonly static Fixture _fixture = new();
+	
+	public static IList<ActionSummary> BuildListOfActionSummaries()
+		=> _fixture.CreateMany<ActionSummary>().ToList();
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/MockHelpers/MoqActionBuilder.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/MockHelpers/MoqActionBuilder.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Linq.Expressions;
+
+namespace ConcernsCaseWork.Shared.Tests.MockHelpers;
+
+// Taken from https://adamstorr.azurewebsites.net/blog/mocking-ilogger-with-moq
+
+public static class MoqActionBuilder
+{
+	public static Mock<ILogger<T>> VerifyLogErrorWasCalled<T>(this Mock<ILogger<T>> logger, string expectedMessage)
+		=> VerifyLogError(logger, expectedMessage, Times.Once());
+
+	private static Mock<ILogger<T>> VerifyLogError<T>(this Mock<ILogger<T>> logger, string expectedMessage, Times timesCalled)
+	{
+		Func<object, Type, bool> state = (v, t) => v.ToString()?.CompareTo(expectedMessage) == 0;
+    
+		logger.Verify(
+			x => x.Log(
+				It.Is<LogLevel>(l => l == LogLevel.Error),
+				It.IsAny<EventId>(),
+				It.Is<It.IsAnyType>((v, t) => state(v, t)),
+				It.IsAny<Exception>(),
+				It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), timesCalled);
+
+		return logger;
+	}
+	
+	public static Mock<ILogger<T>> VerifyLogErrorWasNotCalled<T>(this Mock<ILogger<T>> logger)
+	{
+		logger.Verify(
+			x => x.Log(
+				It.Is<LogLevel>(l => l == LogLevel.Error),
+				It.IsAny<EventId>(),
+				It.Is<It.IsAnyType>((v, t) => true),
+				It.IsAny<Exception>(),
+				It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Never);
+
+		return logger;
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Extensions/DateExtensionTests .cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Extensions/DateExtensionTests .cs
@@ -7,23 +7,77 @@ namespace ConcernsCaseWork.Tests.Extensions
 	[Parallelizable(ParallelScope.All)]
 	public class DateExtensionTests
 	{
-		[TestCase("07/07/2021", "7 July 2021")]
-		[TestCase("11/16/2021", "16 November 2021")]
-
-		public void WhenToUserFriendlyDate_ReturnsExpected(DateTimeOffset actual, string expected)
+		[TestCase(7,7,2021, "7 July 2021")]
+		[TestCase(16, 11,2021, "16 November 2021")]
+		[TestCase(1, 8,2022, "1 August 2022")]
+		public void WhenToUserFriendlyDate_ReturnsExpected(int day, int month, int year, string expected)
 		{
+			// arrange
+			var date = new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero);
+			
+			// act
+			var result = date.ToUserFriendlyDate();
+			
 			// assert
-			Assert.That(actual.ToUserFriendlyDate(), Is.EqualTo(expected));
+			Assert.That(result, Is.EqualTo(expected));
 		}
-
-
-		[TestCase("07/07/2021", "07-07-2021")]
-		[TestCase("11/16/2021", "16-11-2021")]
-
-		public void WhenToDayMonthYear_ReturnsExpected(DateTimeOffset actual, string expected)
+		
+		[TestCase(7,7,2021, "07-07-2021")]
+		[TestCase(16, 11,2021, "16-11-2021")]
+		[TestCase(1, 8,2022, "01-08-2022")]
+		public void WhenToDayMonthYear_DateTimeOffset_ReturnsExpected(int day, int month, int year, string expected)
 		{
+			// arrange
+			var date = new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero);
+			
+			// act
+			var result = date.ToDayMonthYear();
+			
 			// assert
-			Assert.That(actual.ToDayMonthYear(), Is.EqualTo(expected));
+			Assert.That(result, Is.EqualTo(expected));
+		}
+				
+		[TestCase(7,7,2021, "07-07-2021")]
+		[TestCase(16, 11,2021, "16-11-2021")]
+		[TestCase(1, 8,2022, "01-08-2022")]
+		public void WhenToDayMonthYear_DateTime_ReturnsExpected(int day, int month, int year, string expected)
+		{
+			// arrange
+			var date = new DateTime(year, month, day, 0, 0, 0);
+			
+			// act
+			var result = date.ToDayMonthYear();
+			
+			// assert
+			Assert.That(result, Is.EqualTo(expected));
+		}
+		
+		[TestCase(7,7,2021, "07-07-2021")]
+		[TestCase(16, 11,2021, "16-11-2021")]
+		[TestCase(1, 8,2022, "01-08-2022")]
+		public void WhenToDayMonthYear_NullableDateTime_ReturnsExpected(int day, int month, int year, string expected)
+		{
+			// arrange
+			DateTime? date = new DateTime(year, month, day, 0, 0, 0);
+			
+			// act
+			var result = date.ToDayMonthYear();
+			
+			// assert
+			Assert.That(result, Is.EqualTo(expected));
+		}
+		
+		[Test]
+		public void WhenToDayMonthYear_WithNull_ReturnsNull()
+		{
+			// arrange
+			DateTime? date = null;
+			
+			// act
+			var result = date.ToDayMonthYear();
+			
+			// assert
+			Assert.That(result, Is.EqualTo(null));
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Helpers/DateTimeHelperTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Helpers/DateTimeHelperTests.cs
@@ -18,16 +18,15 @@ namespace ConcernsCaseWork.Tests.Helpers
 			Assert.That(result, Is.EqualTo(expectedResult));
 		}
 
+		[TestCase("07/04/2022")]
+		public void WhenParseExact_ReturnsExpected(string dateString)
+		{
+			// act
+			DateTime expectedResult = DateTime.Parse(dateString);
+			var result = DateTimeHelper.ParseExact(dateString);
 
-		//[TestCase("07/04/2022")]
-		//public void WhenParseExact_ReturnsExpected(string dateString)
-		//{
-		//	// act
-		//	DateTime expectedResult = DateTime.Parse(dateString);
-		//	var result = DateTimeHelper.ParseExact(dateString);
-
-		//	//assert
-		//	Assert.That(result, Is.EqualTo(expectedResult));
-		//}
+			//assert
+			Assert.That(result, Is.EqualTo(expectedResult));
+		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Helpers/DateTimeHelperTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Helpers/DateTimeHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using ConcernsCaseWork.Helpers;
 using NUnit.Framework;
 using System;
+using System.Globalization;
 
 namespace ConcernsCaseWork.Tests.Helpers
 {
@@ -18,11 +19,14 @@ namespace ConcernsCaseWork.Tests.Helpers
 			Assert.That(result, Is.EqualTo(expectedResult));
 		}
 
-		[TestCase("07/04/2022")]
-		public void WhenParseExact_ReturnsExpected(string dateString)
+		[TestCase("07/04/2022", 2022, 4, 7)]
+		[TestCase("15/12/2021", 2022, 12, 15)]
+		public void WhenParseExact_ReturnsExpected(string dateString, int expectedYear, int expectedMonth, int expectedDay)
 		{
+			// arrange
+			var expectedResult = new DateTime(expectedYear, expectedMonth,expectedDay);
+			
 			// act
-			DateTime expectedResult = DateTime.Parse(dateString);
 			var result = DateTimeHelper.ParseExact(dateString);
 
 			//assert

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Helpers/DateTimeHelperTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Helpers/DateTimeHelperTests.cs
@@ -20,7 +20,7 @@ namespace ConcernsCaseWork.Tests.Helpers
 		}
 
 		[TestCase("07/04/2022", 2022, 4, 7)]
-		[TestCase("15/12/2021", 2022, 12, 15)]
+		[TestCase("15/12/2021", 2021, 12, 15)]
 		public void WhenParseExact_ReturnsExpected(string dateString, int expectedYear, int expectedMonth, int expectedDay)
 		{
 			// arrange

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/FinancialPlanMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/FinancialPlanMappingTests.cs
@@ -1,0 +1,333 @@
+using ConcernsCaseWork.Mappers;
+using ConcernsCaseWork.Models.CaseActions;
+using NUnit.Framework;
+using Service.TRAMS.FinancialPlan;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture;
+
+namespace ConcernsCaseWork.Tests.Mappers
+{
+	[Parallelizable(ParallelScope.All)]
+	public class FinancialPlanMappingTests
+	{
+		private readonly static Fixture _fixture = new();
+
+		[Test]
+		public void WhenMapDtoToServiceModel_ReturnsCorrectModel()
+		{
+			//arrange
+			var statuses = _fixture.CreateMany<FinancialPlanStatusDto>().ToList();
+
+			var testData = new
+			{
+				Id = _fixture.Create<long>(),
+				CaseUrn = _fixture.Create<long>(),
+				CreatedAt = _fixture.Create<DateTime>(),
+				ClosedAt = _fixture.Create<DateTime>(),
+				UpdatedAt = _fixture.Create<DateTime>(),
+				CreatedBy = _fixture.Create<string>(),
+				Notes = _fixture.Create<string>(),
+				DatePlanRequested = _fixture.Create<DateTime>(),
+				Status = statuses.First(),
+				DatePlanReceived = _fixture.Create<DateTime>(),
+				ClosedStatus = new KeyValuePair<int, string>(_fixture.Create<int>(), _fixture.Create<string>()),
+			};
+
+			var dto = new FinancialPlanDto
+			(
+				testData.Id,
+				testData.CaseUrn,
+				testData.CreatedAt,
+				testData.ClosedAt,
+				testData.CreatedBy,
+				testData.Status.Id,
+				testData.DatePlanRequested,
+				testData.DatePlanReceived,
+				testData.Notes
+			);
+
+			// act
+			var serviceModel = FinancialPlanMapping.MapDtoToModel(dto, statuses);
+
+			// assert
+			Assert.That(serviceModel, Is.Not.Null);
+			Assert.Multiple(() =>
+			{
+				Assert.That(serviceModel.CaseUrn, Is.EqualTo(testData.CaseUrn));
+				Assert.That(serviceModel.Id, Is.EqualTo(testData.Id));
+				Assert.That(serviceModel.Status.Id, Is.EqualTo(testData.Status.Id));
+				Assert.That(serviceModel.Status.Name, Is.EqualTo(testData.Status.Name));
+				Assert.That(serviceModel.Notes, Is.EqualTo(testData.Notes));
+				Assert.That(serviceModel.DatePlanRequested, Is.EqualTo(testData.DatePlanRequested));
+				Assert.That(serviceModel.DateViablePlanReceived, Is.EqualTo(testData.DatePlanReceived));
+				//Assert.That(serviceModel.UpdatedAt, Is.EqualTo(testData.UpdatedAt)); // TODO: This is not currently mapped. Check if this is correct behaviour
+				Assert.That(serviceModel.ClosedAt, Is.EqualTo(testData.ClosedAt));
+				Assert.That(serviceModel.CreatedAt, Is.EqualTo(testData.CreatedAt));
+			});
+		}
+
+		[Test]
+		public void WhenMapDtoListToDbModelList_ReturnsCorrectModelList()
+		{
+			//arrange
+			var statuses = _fixture.CreateMany<FinancialPlanStatusDto>().ToList();
+
+			var testData = new
+			{
+				Id = _fixture.Create<long>(),
+				CaseUrn = _fixture.Create<long>(),
+				CreatedAt = _fixture.Create<DateTime>(),
+				ClosedAt = _fixture.Create<DateTime>(),
+				UpdatedAt = _fixture.Create<DateTime>(),
+				CreatedBy = _fixture.Create<string>(),
+				Notes = _fixture.Create<string>(),
+				DatePlanRequested = _fixture.Create<DateTime>(),
+				Status = statuses.First(),
+				DatePlanReceived = _fixture.Create<DateTime>(),
+				ClosedStatus = new KeyValuePair<int, string>(_fixture.Create<int>(), _fixture.Create<string>()),
+			};
+
+			var dtos = new List<FinancialPlanDto>
+			{
+				new
+				(
+					testData.Id,
+					testData.CaseUrn,
+					testData.CreatedAt,
+					testData.ClosedAt,
+					testData.CreatedBy,
+					testData.Status.Id,
+					testData.DatePlanRequested,
+					testData.DatePlanReceived,
+					testData.Notes
+				)
+			};
+
+			// act
+			var serviceModel = FinancialPlanMapping.MapDtoToModel(dtos, statuses);
+
+			// assert
+			Assert.That(serviceModel, Is.Not.Null);
+			Assert.Multiple(() =>
+			{
+				Assert.That(serviceModel.Count, Is.EqualTo(1));
+				Assert.That(serviceModel.Single().CaseUrn, Is.EqualTo(testData.CaseUrn));
+				Assert.That(serviceModel.Single().Id, Is.EqualTo(testData.Id));
+				Assert.That(serviceModel.Single().Status.Id, Is.EqualTo(testData.Status.Id));
+				Assert.That(serviceModel.Single().Status.Name, Is.EqualTo(testData.Status.Name));
+				Assert.That(serviceModel.Single().Notes, Is.EqualTo(testData.Notes));
+				Assert.That(serviceModel.Single().DatePlanRequested, Is.EqualTo(testData.DatePlanRequested));
+				Assert.That(serviceModel.Single().DateViablePlanReceived, Is.EqualTo(testData.DatePlanReceived));
+				//Assert.That(serviceModel.Single().UpdatedAt, Is.EqualTo(testData.UpdatedAt)); // TODO: This is not currently mapped. Check if this is correct behaviour
+				Assert.That(serviceModel.Single().ClosedAt, Is.EqualTo(testData.ClosedAt));
+				Assert.That(serviceModel.Single().CreatedAt, Is.EqualTo(testData.CreatedAt));
+			});
+		}
+		
+		[Test]
+		public void WhenMapNullDtoListToDbModelList_ReturnsEmptyModelList()
+		{
+			//arrange
+			var statuses = _fixture.CreateMany<FinancialPlanStatusDto>().ToList();
+
+			List<FinancialPlanDto> dtos = null;
+
+			// act
+			var serviceModel = FinancialPlanMapping.MapDtoToModel(dtos, statuses);
+
+			// assert
+			Assert.That(serviceModel, Is.Not.Null);
+			Assert.That(serviceModel, Is.Empty);
+		}
+				
+		[Test]
+		public void WhenMapEmptyDtoListToDbModelList_ReturnsEmptyModelList()
+		{
+			//arrange
+			var statuses = _fixture.CreateMany<FinancialPlanStatusDto>().ToList();
+
+			var dtos = new List<FinancialPlanDto>();
+
+			// act
+			var serviceModel = FinancialPlanMapping.MapDtoToModel(dtos, statuses);
+
+			// assert
+			Assert.That(serviceModel, Is.Not.Null);
+			Assert.That(serviceModel, Is.Empty);
+		}
+
+		[Test]
+		public void WhenMapPatchFinancialPlanModelToDto_ReturnsCorrectModel()
+		{
+			//arrange
+			var statuses = _fixture.CreateMany<FinancialPlanStatusDto>().ToList();
+
+			var testData = new
+			{
+				Id = _fixture.Create<long>(),
+				CaseUrn = _fixture.Create<long>(),
+				CreatedAt = _fixture.Create<DateTime>(),
+				ClosedAt = _fixture.Create<DateTime>(),
+				UpdatedAt = _fixture.Create<DateTime>(),
+				CreatedBy = _fixture.Create<string>(),
+				Notes = _fixture.Create<string>(),
+				DatePlanRequested = _fixture.Create<DateTime>(),
+				Status = statuses.First(),
+				DatePlanReceived = _fixture.Create<DateTime>(),
+				ClosedStatus = new KeyValuePair<int, string>(_fixture.Create<int>(), _fixture.Create<string>()),
+			};
+
+			var dto = new FinancialPlanDto
+			(
+				testData.Id,
+				testData.CaseUrn,
+				testData.CreatedAt,
+				_fixture.Create<DateTime>(),
+				testData.CreatedBy,
+				_fixture.Create<int>(),
+				_fixture.Create<DateTime>(),
+				_fixture.Create<DateTime>(),
+				_fixture.Create<string>()
+			);
+
+			var model = new PatchFinancialPlanModel
+			{
+				Id = testData.Id,
+				CaseUrn = testData.CaseUrn,
+				ClosedAt = testData.ClosedAt,
+				StatusId = testData.Status.Id,
+				DatePlanRequested = testData.DatePlanRequested,
+				DateViablePlanReceived = testData.DatePlanReceived,
+				Notes = testData.Notes
+			};
+
+			// act
+			var result = FinancialPlanMapping.MapPatchFinancialPlanModelToDto(model, dto, statuses);
+
+			// assert
+			Assert.That(result, Is.Not.Null);
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.CaseUrn, Is.EqualTo(testData.CaseUrn));
+				Assert.That(result.Id, Is.EqualTo(testData.Id));
+				Assert.That(result.StatusId, Is.EqualTo(testData.Status.Id));
+				Assert.That(result.Notes, Is.EqualTo(testData.Notes));
+				Assert.That(result.DatePlanRequested, Is.EqualTo(testData.DatePlanRequested));
+				Assert.That(result.DateViablePlanReceived, Is.EqualTo(testData.DatePlanReceived));
+				//Assert.That(result.UpdatedAt, Is.EqualTo(testData.UpdatedAt)); // TODO: This is not currently mapped. Check if this is correct behaviour
+				Assert.That(result.ClosedAt, Is.EqualTo(testData.ClosedAt));
+				Assert.That(result.CreatedAt, Is.EqualTo(testData.CreatedAt));
+				Assert.That(result.CreatedBy, Is.EqualTo(testData.CreatedBy));
+			});
+		}
+
+		[Test]
+		public void WhenMapPatchFinancialPlanModelToDto_WithNullValues_ReturnsCorrectModelWithExistingValues()
+		{
+			//arrange
+			var statuses = _fixture.CreateMany<FinancialPlanStatusDto>().ToList();
+
+			var originalData = new
+			{
+				Id = _fixture.Create<long>(),
+				CaseUrn = _fixture.Create<long>(),
+				CreatedAt = _fixture.Create<DateTime>(),
+				ClosedAt = _fixture.Create<DateTime>(),
+				UpdatedAt = _fixture.Create<DateTime>(),
+				CreatedBy = _fixture.Create<string>(),
+				Notes = _fixture.Create<string>(),
+				DatePlanRequested = _fixture.Create<DateTime>(),
+				Status = statuses.First(),
+				DatePlanReceived = _fixture.Create<DateTime>(),
+				ClosedStatus = new KeyValuePair<int, string>(_fixture.Create<int>(), _fixture.Create<string>()),
+			};
+
+			var originalDto = new FinancialPlanDto
+			(
+				originalData.Id,
+				originalData.CaseUrn,
+				originalData.CreatedAt,
+				originalData.ClosedAt,
+				originalData.CreatedBy,
+				originalData.Status.Id,
+				originalData.DatePlanRequested,
+				originalData.DatePlanReceived,
+				originalData.Notes
+			);
+
+			var patchModel = new PatchFinancialPlanModel
+			{
+				Id = originalData.Id,
+				CaseUrn = originalData.CaseUrn,
+				ClosedAt = null,
+				StatusId = null,
+				DatePlanRequested = null,
+				DateViablePlanReceived = null,
+				Notes = null
+			};
+
+			// act
+			var result = FinancialPlanMapping.MapPatchFinancialPlanModelToDto(patchModel, originalDto, statuses);
+
+			// assert
+			Assert.That(result, Is.Not.Null);
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.CaseUrn, Is.EqualTo(originalData.CaseUrn));
+				Assert.That(result.Id, Is.EqualTo(originalData.Id));
+				Assert.That(result.StatusId, Is.EqualTo(originalData.Status.Id));
+				Assert.That(result.Notes, Is.EqualTo(originalData.Notes));
+				Assert.That(result.DatePlanRequested, Is.EqualTo(originalData.DatePlanRequested));
+				Assert.That(result.DateViablePlanReceived, Is.EqualTo(originalData.DatePlanReceived));
+				Assert.That(result.ClosedAt, Is.EqualTo(originalData.ClosedAt));
+				Assert.That(result.CreatedAt, Is.EqualTo(originalData.CreatedAt));
+				Assert.That(result.CreatedBy, Is.EqualTo(originalData.CreatedBy));
+			});
+		}
+
+		[Test]
+		public void WhenMapDbModelToActionSummary_ReturnsCorrectModel()
+		{
+			//arrange
+			var testData = new
+			{
+				Id = _fixture.Create<long>(),
+				CaseUrn = _fixture.Create<long>(),
+				CreatedAt = _fixture.Create<DateTime>(),
+				ClosedAt = _fixture.Create<DateTime>(),
+				UpdatedAt = _fixture.Create<DateTime>(),
+				CreatedBy = _fixture.Create<string>(),
+				Notes = _fixture.Create<string>(),
+				DatePlanRequested = _fixture.Create<DateTime>(),
+				Status = _fixture.Create<FinancialPlanStatusModel>(),
+				DatePlanReceived = _fixture.Create<DateTime>()
+			};
+
+			var serviceModel = new FinancialPlanModel(
+				testData.Id,
+				testData.CaseUrn,
+				testData.CreatedAt,
+				testData.DatePlanRequested,
+				testData.DatePlanReceived,
+				testData.Notes,
+				testData.Status,
+				testData.ClosedAt
+			) { UpdatedAt = testData.UpdatedAt };
+
+			// act
+			var actionSummary = serviceModel.ToActionSummary();
+
+			// assert
+			Assert.Multiple(() =>
+			{
+				Assert.That(actionSummary.Name, Is.EqualTo("Financial Plan"));
+				Assert.That(actionSummary.ClosedDate, Is.EqualTo(testData.ClosedAt.GetFormattedDate()));
+				Assert.That(actionSummary.OpenedDate, Is.EqualTo(testData.CreatedAt.GetFormattedDate()));
+				Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/financialplan/{testData.Id}/closed"));
+				Assert.That(actionSummary.StatusName, Is.EqualTo(testData.Status.Name));
+			});
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiMappingTests.cs
@@ -1,11 +1,9 @@
-﻿using ConcernsCaseWork.Mappers;
+﻿using AutoFixture;
+using ConcernsCaseWork.Mappers;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Shared.Tests.Factory;
 using NUnit.Framework;
 using Service.TRAMS.Nti;
-using Service.TRAMS.NtiUnderConsideration;
-using Service.TRAMS.NtiWarningLetter;
-using Service.TRAMS.Trusts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,6 +13,8 @@ namespace ConcernsCaseWork.Tests.Mappers
 	[Parallelizable(ParallelScope.All)]
 	public class NtiMappingTests
 	{
+		private readonly static Fixture _fixture = new();
+
 		[Test]
 		public void WhenMapDtoToServiceModel_ReturnsCorrectModel()
 		{
@@ -161,6 +161,42 @@ namespace ConcernsCaseWork.Tests.Mappers
 			Assert.That(model, Is.Not.Null);
 			Assert.That(model.Id, Is.EqualTo(dto.Id));
 			Assert.That(model.Name, Is.EqualTo(dto.Name));
+		}
+		
+		[Test]
+		public void WhenMapDbModelToActionSummary_ReturnsCorrectModel()
+		{
+			//arrange
+			var testData = new
+			{
+				Id = _fixture.Create<int>(),
+				CaseUrn = _fixture.Create<int>(),
+				CreatedAt = _fixture.Create<DateTime>(),
+				ClosedAt = _fixture.Create<DateTime>(),
+				ClosedStatus = new KeyValuePair<int, string>(_fixture.Create<int>(), _fixture.Create<string>())
+			};
+
+			var serviceModel = new NtiModel
+			{
+				Id = testData.Id,
+				CaseUrn = testData.CaseUrn,
+				CreatedAt = testData.CreatedAt,
+				ClosedAt = testData.ClosedAt,
+				ClosedStatus = new NtiStatusModel { Id = testData.ClosedStatus.Key, Name = testData.ClosedStatus.Value },
+			};
+
+			// act
+			var actionSummary = serviceModel.ToActionSummary();
+			
+			// assert
+			Assert.Multiple(() =>
+			{
+				Assert.That(actionSummary.Name, Is.EqualTo("NTI"));
+				Assert.That(actionSummary.ClosedDate, Is.EqualTo(testData.ClosedAt.GetFormattedDate()));
+				Assert.That(actionSummary.OpenedDate, Is.EqualTo(testData.CreatedAt.GetFormattedDate()));
+				Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/nti/{testData.Id}"));
+				Assert.That(actionSummary.StatusName, Is.EqualTo(testData.ClosedStatus.Value));
+			});
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/SrmaMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/SrmaMappingTests.cs
@@ -1,0 +1,124 @@
+using AutoFixture;
+using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Mappers;
+using ConcernsCaseWork.Models.CaseActions;
+using NUnit.Framework;
+using Service.TRAMS.CaseActions;
+using System;
+
+namespace ConcernsCaseWork.Tests.Mappers;
+
+[Parallelizable(ParallelScope.All)]
+public class SrmaMappingTests
+{
+	private readonly static Fixture _fixture = new();
+
+	[Test]
+	public void WhenMapDtoToServiceModel_ReturnsCorrectModel()
+	{
+		//arrange
+		var dto = _fixture.Create<SRMADto>();
+
+		// act
+		var serviceModel = CaseActionsMapping.Map(dto);
+
+		// assert
+		Assert.That(serviceModel, Is.Not.Null);
+		Assert.Multiple(() =>
+		{
+			Assert.That(serviceModel.CaseUrn, Is.EqualTo(dto.CaseUrn));
+			Assert.That(serviceModel.Id, Is.EqualTo(dto.Id));
+			Assert.That(serviceModel.Status.ToString(), Is.EqualTo(dto.Status.ToString()));
+			Assert.That(serviceModel.Notes, Is.EqualTo(dto.Notes));
+			Assert.That(serviceModel.Reason.ToString(), Is.EqualTo(dto.Reason!.Value.ToString()));
+			Assert.That(serviceModel.DateAccepted, Is.EqualTo(dto.DateAccepted));
+			Assert.That(serviceModel.DateOffered, Is.EqualTo(dto.DateOffered));
+			Assert.That(serviceModel.DateVisitEnd, Is.EqualTo(dto.DateVisitEnd));
+			Assert.That(serviceModel.DateVisitStart, Is.EqualTo(dto.DateVisitStart));
+			Assert.That(serviceModel.ClosedAt, Is.EqualTo(dto.ClosedAt));
+			Assert.That(serviceModel.CreatedAt, Is.EqualTo(dto.CreatedAt));
+			Assert.That(serviceModel.UpdatedAt, Is.EqualTo(DateTime.MinValue)); // Not sure if this is correct behaviour??
+		});
+	}
+
+	[Test]
+	public void WhenMapModelToDto_ReturnsCorrectDto()
+	{
+		//arrange
+		var model = _fixture.Create<SRMAModel>();
+
+		// act
+		var dto = CaseActionsMapping.Map(model);
+
+		// assert
+		Assert.That(dto, Is.Not.Null);
+		Assert.Multiple(() =>
+		{
+			Assert.That(dto.CaseUrn, Is.EqualTo(model.CaseUrn));
+			Assert.That(dto.Id, Is.EqualTo(model.Id));
+			Assert.That(dto.Status.ToString(), Is.EqualTo(model.Status.ToString()));
+			Assert.That(dto.Notes, Is.EqualTo(model.Notes));
+			Assert.That(dto.Reason!.Value.ToString(), Is.EqualTo(model.Reason.ToString()));
+			Assert.That(dto.DateAccepted, Is.EqualTo(model.DateAccepted));
+			Assert.That(dto.DateOffered, Is.EqualTo(model.DateOffered));
+			Assert.That(dto.DateVisitEnd, Is.EqualTo(model.DateVisitEnd));
+			Assert.That(dto.DateVisitStart, Is.EqualTo(model.DateVisitStart));
+			Assert.That(dto.ClosedAt, Is.EqualTo(model.ClosedAt));
+			Assert.That(dto.CreatedAt, Is.EqualTo(model.CreatedAt));
+		});
+	}
+
+	[Test]
+	public void WhenMapDbModelToActionSummary_ReturnsCorrectModel()
+	{
+		//arrange
+		var testData = new
+		{
+			Id = _fixture.Create<long>(),
+			CaseUrn = _fixture.Create<long>(),
+			DateOffered = _fixture.Create<DateTime>(),
+			DateAccepted = _fixture.Create<DateTime>(),
+			DateReportSentToTrust = _fixture.Create<DateTime>(),
+			DateVisitStart = _fixture.Create<DateTime>(),
+			DateVisitEnd = _fixture.Create<DateTime>(),
+			CreatedBy = _fixture.Create<string>(),
+			Notes = _fixture.Create<string>(),
+			Status = _fixture.Create<Enums.SRMAStatus>(),
+			SRMAReasonOffered = _fixture.Create<Enums.SRMAReasonOffered>(),
+			CreatedAt = _fixture.Create<DateTime>(),
+			UpdatedAt = _fixture.Create<DateTime>(),
+			ClosedAt = _fixture.Create<DateTime>()
+		};
+
+		var serviceModel = new SRMAModel(
+			testData.Id, 
+			testData.CaseUrn, 
+			testData.DateOffered, 
+			testData.DateAccepted, 
+			testData.DateReportSentToTrust, 
+			testData.DateVisitStart, 
+			testData.DateVisitEnd, 
+			testData.Status, 
+			testData.Notes, 
+			testData.SRMAReasonOffered, 
+			testData.CreatedAt)
+		{
+			UpdatedAt = testData.UpdatedAt, 
+			ClosedAt = testData.ClosedAt,
+			Status = testData.Status
+		};
+
+		// act
+		var actionSummary = serviceModel.ToActionSummary();
+
+		// assert
+		Assert.Multiple(() =>
+		{
+			Assert.That(actionSummary.Name, Is.EqualTo("SRMA"));
+			Assert.That(actionSummary.ClosedDate, Is.EqualTo(testData.ClosedAt.GetFormattedDate()));
+			Assert.That(actionSummary.OpenedDate, Is.EqualTo(testData.CreatedAt.GetFormattedDate()));
+			Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/srma/{testData.Id}/closed"));
+			Assert.That(actionSummary.StatusName, Is.EqualTo(EnumHelper.GetEnumDescription(testData.Status)));
+		});
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/ViewClosedPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/ViewClosedPageModelTests.cs
@@ -1,9 +1,11 @@
 ﻿using ConcernsCaseWork.Extensions;
 using ConcernsCaseWork.Pages.Case;
+using ConcernsCaseWork.Services.Actions;
 using ConcernsCaseWork.Services.Cases;
 using ConcernsCaseWork.Services.Records;
 using ConcernsCaseWork.Services.Trusts;
 using ConcernsCaseWork.Shared.Tests.Factory;
+using ConcernsCaseWork.Shared.Tests.MockHelpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -12,7 +14,9 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case
@@ -21,27 +25,33 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 	public class ViewClosedPageModelTests
 	{
 		[Test]
-		public async Task WhenOnGetAsync_MissingCaseUrn_ThrowsException()
+		public async Task WhenOnGetAsync_MissingCaseUrn_ThrowsExceptionAndCallsLogger()
 		{
 			// arrange
 			var mockCaseModelService = new Mock<ICaseModelService>();
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			var mockLogger = new Mock<ILogger<ViewClosedPageModel>>();
 			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockActionsModelService = new Mock<IActionsModelService>();
 
-			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockLogger.Object);
+			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockActionsModelService.Object,
+				mockLogger.Object);
 
 			// act
 			await pageModel.OnGetAsync();
-			
+
 			// assert
-			Assert.That(pageModel.TempData["Error.Message"], Is.EqualTo("An error occurred loading the page, please try again. If the error persists contact the service administrator."));
-			
+			mockLogger.VerifyLogErrorWasCalled("ViewClosedPageModel::OnGetAsync::Exception - CaseUrn is null or invalid to parse");
+
+			Assert.That(pageModel.TempData["Error.Message"],
+				Is.EqualTo("An error occurred loading the page, please try again. If the error persists contact the service administrator."));
+
 			mockCaseModelService.Verify(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Never);
 			mockTrustModelService.Verify(c => c.GetTrustByUkPrn(It.IsAny<string>()), Times.Never);
 			mockRecordModelService.Verify(c => c.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Never);
+			mockActionsModelService.Verify(c => c.GetClosedActionsSummary(It.IsAny<string>(), It.IsAny<long>()), Times.Never);
 		}
-		
+
 		[Test]
 		public async Task WhenOnGetAsync_RouteCaseUrn_ThrowsException()
 		{
@@ -50,26 +60,31 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			var mockLogger = new Mock<ILogger<ViewClosedPageModel>>();
 			var mockRecordModelService = new Mock<IRecordModelService>();
-			
+			var mockActionsModelService = new Mock<IActionsModelService>();
+
 			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
 				.Throws<Exception>();
-			
-			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockLogger.Object);
-			
+
+			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockActionsModelService.Object,
+				mockLogger.Object);
+
 			var routeData = pageModel.RouteData.Values;
 			routeData.Add("urn", 1);
-			
+
 			// act
 			await pageModel.OnGetAsync();
-			
+
 			// assert
-			Assert.That(pageModel.TempData["Error.Message"], Is.EqualTo("An error occurred loading the page, please try again. If the error persists contact the service administrator."));
-			
+			mockLogger.VerifyLogErrorWasCalled("ViewClosedPageModel::OnGetAsync::Exception - Exception of type 'System.Exception' was thrown.");
+
+			Assert.That(pageModel.TempData["Error.Message"],
+				Is.EqualTo("An error occurred loading the page, please try again. If the error persists contact the service administrator."));
+
 			mockCaseModelService.Verify(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Once);
 			mockTrustModelService.Verify(c => c.GetTrustByUkPrn(It.IsAny<string>()), Times.Never);
 			mockRecordModelService.Verify(c => c.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Never);
 		}
-		
+
 		[Test]
 		public async Task WhenOnGetAsync_RouteCaseUrn_Returns_CaseModel()
 		{
@@ -78,10 +93,12 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockTrustModelService = new Mock<ITrustModelService>();
 			var mockLogger = new Mock<ILogger<ViewClosedPageModel>>();
 			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockActionsModelService = new Mock<IActionsModelService>();
 
 			var caseModel = CaseFactory.BuildCaseModel();
 			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
 			var recordsModel = RecordFactory.BuildListRecordModel();
+			var closedActions = ActionsSummaryFactory.BuildListOfActionSummaries();
 
 			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
 				.ReturnsAsync(caseModel);
@@ -89,16 +106,20 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 				.ReturnsAsync(trustDetailsModel);
 			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()))
 				.ReturnsAsync(recordsModel);
-			
-			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockLogger.Object);
-			
+			mockActionsModelService.Setup(a => a.GetClosedActionsSummary(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(closedActions);
+
+			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockActionsModelService.Object,
+				mockLogger.Object);
+
 			var routeData = pageModel.RouteData.Values;
 			routeData.Add("urn", 1);
-			
+
 			// act
 			await pageModel.OnGetAsync();
-			
+
 			// assert
+			mockLogger.VerifyLogErrorWasNotCalled();
 			Assert.IsNull(pageModel.TempData["Error.Message"]);
 			Assert.That(pageModel.CaseModel, Is.Not.Null);
 			Assert.That(pageModel.CaseModel.Description, Is.EqualTo(caseModel.Description));
@@ -120,7 +141,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			Assert.That(pageModel.CaseModel.DirectionOfTravel, Is.EqualTo(caseModel.DirectionOfTravel));
 			Assert.That(pageModel.CaseModel.ReasonAtReview, Is.EqualTo(caseModel.ReasonAtReview));
 			Assert.That(pageModel.CaseModel.TrustUkPrn, Is.EqualTo(caseModel.TrustUkPrn));
-			
+
 			Assert.That(pageModel.TrustDetailsModel, Is.Not.Null);
 			Assert.That(pageModel.TrustDetailsModel.GiasData.GroupName, Is.EqualTo(trustDetailsModel.GiasData.GroupName));
 			Assert.That(pageModel.TrustDetailsModel.GiasData.GroupNameTitle, Is.EqualTo(trustDetailsModel.GiasData.GroupName.ToTitle()));
@@ -133,7 +154,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 				Assert.That(expectedRecordsModel.ElementAt(index).RatingUrn, Is.EqualTo(recordsModel.ElementAt(index).RatingUrn));
 				Assert.That(expectedRecordsModel.ElementAt(index).StatusUrn, Is.EqualTo(recordsModel.ElementAt(index).StatusUrn));
 				Assert.That(expectedRecordsModel.ElementAt(index).TypeUrn, Is.EqualTo(recordsModel.ElementAt(index).TypeUrn));
-				
+
 				var expectedRecordRatingModel = expectedRecordsModel.ElementAt(index).RatingModel;
 				var actualRecordRatingModel = recordsModel.ElementAt(index).RatingModel;
 				Assert.NotNull(expectedRecordRatingModel);
@@ -143,7 +164,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 				Assert.That(expectedRecordRatingModel.Urn, Is.EqualTo(actualRecordRatingModel.Urn));
 				Assert.That(expectedRecordRatingModel.RagRating, Is.EqualTo(actualRecordRatingModel.RagRating));
 				Assert.That(expectedRecordRatingModel.RagRatingCss, Is.EqualTo(actualRecordRatingModel.RagRatingCss));
-				
+
 				var expectedRecordTypeModel = expectedRecordsModel.ElementAt(index).TypeModel;
 				var actualRecordTypeModel = recordsModel.ElementAt(index).TypeModel;
 				Assert.NotNull(expectedRecordTypeModel);
@@ -161,25 +182,26 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 				Assert.That(expectedRecordStatusModel.Urn, Is.EqualTo(actualRecordStatusModel.Urn));
 			}
 			
+			Assert.That(pageModel.CaseActions, Is.EquivalentTo(closedActions.ToList()));
+
 			mockCaseModelService.Verify(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Once);
 			mockTrustModelService.Verify(c => c.GetTrustByUkPrn(It.IsAny<string>()), Times.Once);
 			mockRecordModelService.Verify(c => c.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Once);
+			mockActionsModelService.Verify(c => c.GetClosedActionsSummary(It.IsAny<string>(), It.IsAny<long>()), Times.Once);
 		}
-		
+
 		private static ViewClosedPageModel SetupViewClosedPageModel(
-			ICaseModelService mockCaseModelService, 
+			ICaseModelService mockCaseModelService,
 			ITrustModelService mockTrustModelService,
 			IRecordModelService mockRecordModelService,
+			IActionsModelService mockActionsModelService,
 			ILogger<ViewClosedPageModel> mockLogger, bool isAuthenticated = false)
 		{
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
-			
-			return new ViewClosedPageModel(mockCaseModelService, mockTrustModelService, mockRecordModelService, mockLogger)
+
+			return new ViewClosedPageModel(mockCaseModelService, mockTrustModelService, mockRecordModelService, mockActionsModelService, mockLogger)
 			{
-				PageContext = pageContext,
-				TempData = tempData,
-				Url = new UrlHelper(actionContext),
-				MetadataProvider = pageContext.ViewData.ModelMetadata
+				PageContext = pageContext, TempData = tempData, Url = new UrlHelper(actionContext), MetadataProvider = pageContext.ViewData.ModelMetadata
 			};
 		}
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/TestHelpers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/TestHelpers.cs
@@ -12,7 +12,7 @@ namespace ConcernsCaseWork.Tests
 	/// A collection of useful helper methods to make writing tests easier.
 	/// If adding a new helper, ideally make it stateless.
 	/// </summary>
-	public class TestHelpers
+	public static class TestHelpers
 	{
 		public static void VerifyMethodEntryLogged<T>(Mock<ILogger<T>> mockLogger, string methodName, int times = 1)
 		{
@@ -25,5 +25,8 @@ namespace ConcernsCaseWork.Tests
 					It.IsAny<Func<It.IsAnyType, Exception, string>>()),
 				Times.Exactly(times));
 		}
+
+		public static string GetFormattedDate(this DateTime dateTime) => $"{PadTwoDigitDate(dateTime.Day)}-{PadTwoDigitDate(dateTime.Month)}-{PadTwoDigitDate(dateTime.Year)}";
+		private static string PadTwoDigitDate(int value) => value.ToString().PadLeft(2, '0');
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/DateExtension.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/DateExtension.cs
@@ -14,6 +14,16 @@ namespace ConcernsCaseWork.Extensions
 			return value.ToString("dd-MM-yyyy");
 		}
 		
+		public static string ToDayMonthYear(this DateTime value)
+		{
+			return value.ToString("dd-MM-yyyy");
+		}
+		
+		public static string ToDayMonthYear(this DateTime? value)
+		{
+			return value?.ToString("dd-MM-yyyy");
+		}
+		
 		public static string ToDayMonthYearWithDefault(this DateTimeOffset value)
 		{
 			return value == default(DateTime) ? string.Empty : ToDayMonthYear(value);

--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
@@ -3,6 +3,7 @@ using ConcernsCaseWork.Logging;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Validators;
 using ConcernsCaseWork.Security;
+using ConcernsCaseWork.Services.Actions;
 using ConcernsCaseWork.Services.Cases;
 using ConcernsCaseWork.Services.FinancialPlan;
 using ConcernsCaseWork.Services.MeansOfReferral;
@@ -138,6 +139,7 @@ namespace ConcernsCaseWork.Extensions
 			services.AddScoped<INtiWarningLetterModelService, NtiWarningLetterModelService>();
 			services.AddScoped<IMeansOfReferralModelService, MeansOfReferralModelService>();
 			services.AddScoped<INtiModelService, NtiModelService>();
+			services.AddScoped<IActionsModelService, ActionsModelService>();
 			services.AddScoped<ITeamsModelService, TeamsModelService>();
 			services.AddScoped<IClaimsPrincipalHelper, ClaimsPrincipalHelper>();
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/CaseActionsMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/CaseActionsMapping.cs
@@ -1,4 +1,6 @@
-﻿using ConcernsCaseWork.Models.CaseActions;
+﻿using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Models.CaseActions;
 using Service.TRAMS.CaseActions;
 using System;
 
@@ -44,5 +46,15 @@ namespace ConcernsCaseWork.Mappers
 
 			};
 		}
+		
+		public static ActionSummary ToActionSummary(this SRMAModel srmaModel)
+			 => new()
+				{
+					ClosedDate = srmaModel.ClosedAt.ToDayMonthYear(),
+					Name = "SRMA",
+					OpenedDate = srmaModel.CreatedAt.ToDayMonthYear(), 
+					RelativeUrl = $"/case/{srmaModel.CaseUrn}/management/action/srma/{srmaModel.Id}/closed",
+					StatusName = EnumHelper.GetEnumDescription(srmaModel.Status)
+				};
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/FinancialPlanMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/FinancialPlanMapping.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Models.CaseActions;
+﻿using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Models.CaseActions;
 using Service.TRAMS.FinancialPlan;
 using System.Collections.Generic;
 using System.Linq;
@@ -66,12 +67,22 @@ namespace ConcernsCaseWork.Mappers
 				financialPlanDto.CreatedAt,
 				patchFinancialPlanModel?.ClosedAt ?? financialPlanDto.ClosedAt,
 				financialPlanDto.CreatedBy,
-				selectedStatusId,
+				selectedStatusId ?? financialPlanDto.StatusId,
 				patchFinancialPlanModel?.DatePlanRequested ?? financialPlanDto.DatePlanRequested,
 				patchFinancialPlanModel?.DateViablePlanReceived ?? financialPlanDto.DateViablePlanReceived,
-				patchFinancialPlanModel?.Notes);
+				patchFinancialPlanModel?.Notes ?? financialPlanDto.Notes);
 
 			return updatedFinancialPlanDto;
 		}
+		
+		public static ActionSummary ToActionSummary(this FinancialPlanModel model)
+			=> new()
+			{
+				ClosedDate = model.ClosedAt.ToDayMonthYear(),
+				Name = "Financial Plan",
+				OpenedDate = model.CreatedAt.ToDayMonthYear(),
+				RelativeUrl = $"/case/{model.CaseUrn}/management/action/financialplan/{model.Id}/closed",
+				StatusName = model.Status.Name
+			};
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiMappers.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Models.CaseActions;
+﻿using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Models.CaseActions;
 using Service.TRAMS.Nti;
 using System;
 using System.Collections.Generic;
@@ -85,5 +86,15 @@ namespace ConcernsCaseWork.Mappers
 				Name = ntiReasonDto.Name
 			};
 		}
+		
+		public static ActionSummary ToActionSummary(this NtiModel model)
+			=> new()
+			{
+				ClosedDate = model.ClosedAt.ToDayMonthYear(), 
+				Name = "NTI",
+				OpenedDate = model.CreatedAt.ToDayMonthYear(),
+				RelativeUrl = $"/case/{model.CaseUrn}/management/action/nti/{model.Id}",
+				StatusName = model.ClosedStatus.Name
+			};
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiUnderConsiderationMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiUnderConsiderationMappers.cs
@@ -1,5 +1,7 @@
-﻿using ConcernsCaseWork.Models.CaseActions;
+﻿using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Models.CaseActions;
 using Service.TRAMS.NtiUnderConsideration;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ConcernsCaseWork.Mappers
@@ -57,7 +59,15 @@ namespace ConcernsCaseWork.Mappers
 			};
 		}
 
-
+		public static ActionSummary ToActionSummary(this NtiUnderConsiderationModel model, IEnumerable<NtiUnderConsiderationStatusDto> statuses)
+			=> new()
+			{
+				ClosedDate = model.ClosedAt.ToDayMonthYear(),
+				Name = "NTI Under Consideration",
+				OpenedDate = model.CreatedAt.ToDayMonthYear(),
+				RelativeUrl = $"/case/{model.CaseUrn}/management/action/ntiunderconsideration/{model.Id}",
+				StatusName = statuses.SingleOrDefault(s => s.Id == model.ClosedStatusId)?.Name ?? string.Empty
+			};
 
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiWarningLetterMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiWarningLetterMappers.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Models.CaseActions;
+﻿using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Models.CaseActions;
 using Service.TRAMS.NtiWarningLetter;
 using System;
 using System.Collections.Generic;
@@ -79,5 +80,15 @@ namespace ConcernsCaseWork.Mappers
 				Name = ntiWarningLetterReasonDto.Name
 			};
 		}
+		
+		public static ActionSummary ToActionSummary(this NtiWarningLetterModel model)
+			=> new()
+			{
+				ClosedDate = model.ClosedAt.ToDayMonthYear(),
+				Name = "NTI Warning Letter", 
+				OpenedDate = model.CreatedAt.ToDayMonthYear(),
+				RelativeUrl = $"/case/{model.CaseUrn}/management/action/ntiwarningletter/{model.Id}",
+				StatusName = model.ClosedStatus.PastTenseName
+			};
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/ActionSummary.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/ActionSummary.cs
@@ -1,0 +1,11 @@
+namespace ConcernsCaseWork.Models.CaseActions
+{
+	public record ActionSummary
+	{
+		public string RelativeUrl { get; init; }
+		public string StatusName { get; init; }
+		public string Name { get; init; }
+		public string OpenedDate { get; init; }
+		public string ClosedDate { get; init; }
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Base/AbstractPageModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Base/AbstractPageModel.cs
@@ -24,6 +24,6 @@ namespace ConcernsCaseWork.Pages.Base
 
 		protected string GetFormValue(string propertyName) => Request.Form[propertyName].ToString().GetValueOrNullIfWhitespace();
 		
-		protected string GetRouteValue(string propertyName) => RouteData.Values[propertyName].ToString().GetValueOrNullIfWhitespace();
+		protected string GetRouteValue(string propertyName) => RouteData.Values[propertyName]?.ToString().GetValueOrNullIfWhitespace();
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Closed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Closed.cshtml
@@ -7,15 +7,13 @@
 
 @{
 	ViewData["Title"] = "Financial Plan";
-	var nonce = HttpContext.GetNonce();
+	ViewData["BackButtonLabel"] = "Back to case";
 }
 
 @section BeforeMain {
-<div class="govuk-width-container">
-    <a id="back-to-case-link" class="govuk-back-link" href="/case/@RouteData.Values["urn"]/management">
-        Back to case
-    </a>
-</div>
+	<div class="govuk-width-container">
+		<partial name="_BackLink"/>
+	</div>
 }
 
 <div class="govuk-width-container">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Index.cshtml
@@ -6,15 +6,13 @@
 
 @{
     ViewData["Title"] = "NTI";
-    var nonce = HttpContext.GetNonce();
+	ViewData["BackButtonLabel"] = "Back to case";
 }
 
 @section BeforeMain {
-<div class="govuk-width-container">
-    <a id="back-to-case-link" class="govuk-back-link" href="/case/@RouteData.Values["urn"]/management">
-        Back to case
-    </a>
-</div>
+	<div class="govuk-width-container">
+		<partial name="_BackLink"/>
+	</div>
 }
 
 <div class="govuk-width-container">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Index.cshtml
@@ -3,15 +3,13 @@
 
 @{
     ViewData["Title"] = "NTI Under Consideration";
-    var nonce = HttpContext.GetNonce();
+	ViewData["BackButtonLabel"] = "Back to case";
 }
 
 @section BeforeMain {
-<div class="govuk-width-container">
-    <a id="back-to-case-link" class="govuk-back-link" href="/case/@RouteData.Values["urn"]/management">
-        Back to case
-    </a>
-</div>
+	<div class="govuk-width-container">
+		<partial name="_BackLink"/>
+	</div>
 }
 
 <div class="govuk-width-container">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
@@ -5,15 +5,13 @@
 
 @{
     ViewData["Title"] = "NTI Warning Letter";
-    var nonce = HttpContext.GetNonce();
+	ViewData["BackButtonLabel"] = "Back to case";
 }
 
 @section BeforeMain {
-<div class="govuk-width-container">
-    <a id="back-to-case-link" class="govuk-back-link" href="/case/@RouteData.Values["urn"]/management">
-        Back to case
-    </a>
-</div>
+	<div class="govuk-width-container">
+		<partial name="_BackLink"/>
+	</div>
 }
 
 <div class="govuk-width-container">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
@@ -6,7 +6,7 @@
 
 @{
 	ViewData["Title"] = "SRMA";
-	var nonce = HttpContext.GetNonce();
+	ViewData["BackButtonLabel"] = "Back to case";
 
 	var errorClass = "govuk-error-message";
 	var srmaValidationErrors = TempData["SRMA.Message"] as IEnumerable<string>;
@@ -18,11 +18,9 @@
 }
 
 @section BeforeMain {
-<div class="govuk-width-container">
-    <a id="back-to-case-link" class="govuk-back-link" href="/case/@RouteData.Values["urn"]/management">
-        Back to case
-    </a>
-</div>
+	<div class="govuk-width-container">
+		<partial name="_BackLink"/>
+	</div>
 }
 
 <div class="govuk-width-container">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -451,7 +451,7 @@
                             @if (!Model.HasClosedActions)
                             {
                                 <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell" colspan="3">
+                                    <td class="govuk-table__cell" colspan="4">
                                         There are no closed actions or decisions added to this case.
                                     </td>
                                 </tr>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
@@ -134,5 +134,8 @@
 				</script>				
 			}
 		</div>
+		<div>
+			<partial name="Shared/_ListClosedActionsForCase" model="Model.CaseActions"/>
+		</div>
 	</div>
 </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
@@ -1,12 +1,17 @@
 ﻿using ConcernsCaseWork.Models;
+using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Base;
+using ConcernsCaseWork.Services.Actions;
 using ConcernsCaseWork.Services.Cases;
 using ConcernsCaseWork.Services.Records;
 using ConcernsCaseWork.Services.Trusts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Service.TRAMS.Helpers;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Pages.Case
@@ -18,19 +23,23 @@ namespace ConcernsCaseWork.Pages.Case
 		private readonly IRecordModelService _recordModelService;
 		private readonly ITrustModelService _trustModelService;
 		private readonly ICaseModelService _caseModelService;
+		private readonly IActionsModelService _actionsModelService;
 		private readonly ILogger<ViewClosedPageModel> _logger;
 		
 		public CaseModel CaseModel { get; private set; }
 		public TrustDetailsModel TrustDetailsModel { get; private set; }
+		public List<ActionSummary> CaseActions { get; private set; }
 		
 		public ViewClosedPageModel(ICaseModelService caseModelService, 
 			ITrustModelService trustModelService,
 			IRecordModelService recordModelService,
+			IActionsModelService actionsModelService,
 			ILogger<ViewClosedPageModel> logger)
 		{
 			_caseModelService = caseModelService;
 			_trustModelService = trustModelService;
 			_recordModelService = recordModelService;
+			_actionsModelService = actionsModelService;
 			_logger = logger;
 		}
 		
@@ -38,24 +47,41 @@ namespace ConcernsCaseWork.Pages.Case
 		{
 			try
 			{
-				_logger.LogInformation("Case::ViewClosedPageModel::OnGetAsync");
+				_logger.LogInformation("{ClassName}::{EchoCallerName}", nameof(ViewClosedPageModel), LoggingHelpers.EchoCallerName());
 
-				var caseUrnValue = RouteData.Values["urn"];
-				if (caseUrnValue == null || !long.TryParse(caseUrnValue.ToString(), out var caseUrn) || caseUrn == 0)
-					throw new Exception("CaseUrn is null or invalid to parse");
+				var caseUrn = GetRequestedCaseUrn();
+				var userName = GetUserName();
 
-				CaseModel = await _caseModelService.GetCaseByUrn(User.Identity.Name, caseUrn);
+				CaseModel = await _caseModelService.GetCaseByUrn(userName, caseUrn);
 				TrustDetailsModel = await _trustModelService.GetTrustByUkPrn(CaseModel.TrustUkPrn);
 				
-				var recordsModel = await _recordModelService.GetRecordsModelByCaseUrn(User.Identity.Name, caseUrn);
+				var recordsModel = await _recordModelService.GetRecordsModelByCaseUrn(userName, caseUrn);
 				CaseModel.RecordsModel = recordsModel;
+
+				CaseActions = (await _actionsModelService.GetClosedActionsSummary(userName, caseUrn)).ToList();
 			}
 			catch (Exception ex)
 			{
-				_logger.LogError("Case::ViewClosedPageModel::OnGetAsync::Exception - {Message}", ex.Message);
+				_logger.LogError("{ClassName}::{EchoCallerName}::Exception - {Message}", 
+					nameof(ViewClosedPageModel), LoggingHelpers.EchoCallerName(), ex.Message);
 
 				TempData["Error.Message"] = ErrorOnGetPage;
 			}
 		}
+		
+		private long GetRequestedCaseUrn()
+		{
+			var caseUrnValue = GetRouteValue("urn");
+
+			if (caseUrnValue == null || !long.TryParse(caseUrnValue, out long caseUrn) || caseUrn == 0)
+			{
+				throw new Exception("CaseUrn is null or invalid to parse");
+			}
+
+			return caseUrn;
+		}
+
+		private string GetUserName() => User.Identity?.Name;
+
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Back.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Back.cshtml
@@ -1,12 +1,6 @@
 ﻿@if (BackPageModel.CanRender(Context.Request.Path.Value)) {
-	var nonce = Context.GetNonce();
 	var cssClass = BackPageModel.IsExtraWidthContainer ? "govuk-extra-width-container" : "govuk-width-container";
 	<div class="@cssClass">
-		<a id="back-link-event" class="govuk-back-link" href="#">Back</a>
-		<script nonce="@nonce">
-			$("#back-link-event").click(function() {
-				history.back();
-			});
-		</script>
+		<partial name="_BackLink" />
 	</div>
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_BackLink.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_BackLink.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+	var nonce = Context.GetNonce();
+	var label = ViewData["BackButtonLabel"] ?? "Back";
+	
+	<a id="back-link-event" class="govuk-back-link" href="#">@label</a>
+	<script nonce="@nonce">
+		$("#back-link-event").click(function() {
+			history.back();
+		});
+	</script>
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ListClosedActionsForCase.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ListClosedActionsForCase.cshtml
@@ -1,0 +1,51 @@
+﻿@using ConcernsCaseWork.Models.CaseActions
+@model IList<ConcernsCaseWork.Models.CaseActions.ActionSummary>
+
+<table id="close-case-actions" class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row tr__large">
+            <th class="govuk-table__header govuk-table__cell__cases" scope="col">
+                Closed actions
+            </th>
+	        <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
+	        </th>
+	        <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
+		        Date Opened
+	        </th>
+            <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
+                Date Closed
+            </th>
+        </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+    @if (!Model.Any())
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell" colspan="4">
+                    There are no closed actions or decisions added to this case.
+                </td>
+            </tr>
+        }
+    
+        @foreach (ActionSummary actionSummary in Model)
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <a href="@actionSummary.RelativeUrl" class="govuk-link govuk-link-no-visited-state">
+                        @actionSummary.Name
+                    </a>
+                </td>
+                <td class="govuk-table__cell">
+                    @actionSummary.StatusName
+                </td>
+                <td class="govuk-table__cell">
+                    @actionSummary.OpenedDate
+                </td>
+                <td class="govuk-table__cell govuk-table__header__right">
+                    @actionSummary.ClosedDate
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/ActionsModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/ActionsModelService.cs
@@ -1,0 +1,94 @@
+﻿using ConcernsCaseWork.Mappers;
+using ConcernsCaseWork.Models.CaseActions;
+using ConcernsCaseWork.Services.Cases;
+using ConcernsCaseWork.Services.FinancialPlan;
+using ConcernsCaseWork.Services.Nti;
+using ConcernsCaseWork.Services.NtiWarningLetter;
+using Microsoft.Extensions.Logging;
+using Service.Redis.NtiUnderConsideration;
+using Service.TRAMS.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ConcernsCaseWork.Services.Actions
+{
+	public sealed class ActionsModelService : IActionsModelService
+	{
+		private readonly ISRMAService _srmaService;
+		private readonly IFinancialPlanModelService _financialPlanModelService;
+		private readonly INtiUnderConsiderationModelService _ntiUnderConsiderationModelService;
+		private readonly INtiWarningLetterModelService _ntiWarningLetterModelService;
+		private readonly INtiModelService _ntiModelService;
+		private readonly INtiUnderConsiderationStatusesCachedService _ntiUcStatusesCachedService;
+		private readonly ILogger<ActionsModelService> _logger;
+
+		public ActionsModelService(
+			ISRMAService srmaService,
+			IFinancialPlanModelService financialPlanModelService,
+			INtiUnderConsiderationModelService ntiUnderConsiderationModelService,
+			INtiWarningLetterModelService ntiWarningLetterModelService,
+			INtiModelService ntiModelService,
+			ILogger<ActionsModelService> logger, INtiUnderConsiderationStatusesCachedService ntiUcStatusesCachedService)
+		{
+			_srmaService = srmaService;
+			_financialPlanModelService = financialPlanModelService;
+			_ntiUnderConsiderationModelService = ntiUnderConsiderationModelService;
+			_ntiWarningLetterModelService = ntiWarningLetterModelService;
+			_ntiModelService = ntiModelService;
+			_logger = logger;
+			_ntiUcStatusesCachedService = ntiUcStatusesCachedService;
+		}
+
+		public async Task<IList<ActionSummary>> GetClosedActionsSummary(string userName, long caseUrn)
+		{
+			var caseActions = new List<ActionSummary>();
+				
+			try
+			{
+				caseActions.AddRange(await GetClosedSrmas(caseUrn));
+				caseActions.AddRange(await GetClosedFinancialPlans(caseUrn, userName));
+				caseActions.AddRange(await GetClosedNtisUnderConsideration(caseUrn));
+				caseActions.AddRange(await GetClosedNtiWarningLettersForCase(caseUrn));
+				caseActions.AddRange(await GetClosedNtisForCase(caseUrn));
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError("{ClassName}::{EchoCallerName}::Exception - {Message}", 
+					nameof(ActionsModelService), LoggingHelpers.EchoCallerName(), ex.Message);
+			}
+			
+			return caseActions;
+		}
+
+		private async Task<IEnumerable<ActionSummary>> GetClosedSrmas(long caseUrn)
+			=> (await _srmaService.GetSRMAsForCase(caseUrn))
+				.Where(a => a.ClosedAt.HasValue)
+				.Select(a => a.ToActionSummary());
+		
+		private async Task<IEnumerable<ActionSummary>> GetClosedFinancialPlans(long caseUrn, string userName)
+			=> (await _financialPlanModelService.GetFinancialPlansModelByCaseUrn(caseUrn, userName))
+				.Where(a => a.ClosedAt.HasValue)
+				.Select(a => a.ToActionSummary());
+
+		private async Task<IEnumerable<ActionSummary>> GetClosedNtisUnderConsideration(long caseUrn)
+		{
+			var statuses = await _ntiUcStatusesCachedService.GetAllStatuses();
+			
+			return (await _ntiUnderConsiderationModelService.GetNtiUnderConsiderationsForCase(caseUrn))
+				.Where(a => a.ClosedAt.HasValue)
+				.Select(a => a.ToActionSummary(statuses));
+		}
+
+		private async Task<IEnumerable<ActionSummary>> GetClosedNtiWarningLettersForCase(long caseUrn)
+			=> (await _ntiWarningLetterModelService.GetNtiWarningLettersForCase(caseUrn))
+				.Where(a => a.ClosedAt.HasValue)
+				.Select(a => a.ToActionSummary());
+								
+		private async Task<IEnumerable<ActionSummary>> GetClosedNtisForCase(long caseUrn)
+			=> (await _ntiModelService.GetNtisForCaseAsync(caseUrn))
+				.Where(a => a.ClosedAt.HasValue)
+				.Select(a => a.ToActionSummary());
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/IActionsModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/IActionsModelService.cs
@@ -1,0 +1,11 @@
+using ConcernsCaseWork.Models.CaseActions;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ConcernsCaseWork.Services.Actions
+{
+	public interface IActionsModelService
+	{
+		Task<IList<ActionSummary>> GetClosedActionsSummary(string userName, long caseUrn);
+	}
+}


### PR DESCRIPTION
Add a table containing Case Actions to the Closed Case page.

This is needed so users can see the actions associated with a case when it is closed.

[User story 105080](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/105080)


