### PR TITLE
Add heading and subtext to Case Management page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -194,7 +194,10 @@
                     </tbody>
                 </table>
 
-                <!--Accordions-->
+            <h2 class="govuk-heading-m">Concern details</h2>
+            <p class="govuk-body">You only need enter the issue at this stage. Further details can be included on the case management page when you have them.</p>
+            		
+            <!--Accordions-->	
             <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
 
                     <div class="govuk-accordion__section">


### PR DESCRIPTION
Add heading of 'Concern details' and subtext para to the Case Management page. 

[DevOps 108142](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/108142)
