### PR TITLE
Change heading on Create Concern page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml
@@ -32,7 +32,7 @@
 				<!-- FORM -->
 				<form role="form" method="post" id="case-details-form" novalidate>
 
-					<h2 class="govuk-heading-l govuk-!-margin-top-9">Initial case details</h2>
+					<h2 class="govuk-heading-l govuk-!-margin-top-9">Concern details</h2>
 					<div id="initial-details-hint" class="govuk-hint">
 						You only need enter the issue at this stage. Further details can be included on the case management page when you have them.
 					</div>


### PR DESCRIPTION
Rename heading on Create Concern detail page from 'Initial case details' to 'Concern details'

[DevOps User Story 108141](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/108141)