### PR TITLE
Rename title of case action tables

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -293,7 +293,7 @@
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row tr__large">
                                 <th class="govuk-table__header govuk-table__cell__cases" scope="col">
-                                    Open actions
+                                    Active actions and decisions
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
                                 </th>
@@ -433,7 +433,7 @@
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row tr__large">
                                 <th class="govuk-table__header govuk-table__cell__cases" scope="col">
-                                    Closed actions
+                                    Closed actions and decisions
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
                                 </th>


### PR DESCRIPTION
Change the titles on Case Action tables to be 'Active / Closed actions and decisions'

[Azure DevOps User Story 108249 ](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/108249)