### PR TITLE
Feature/108249 change titles of case action tables

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -293,7 +293,7 @@
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row tr__large">
                                 <th class="govuk-table__header govuk-table__cell__cases" scope="col">
-                                    Open actions
+                                    Active actions and decisions
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
                                 </th>
@@ -433,7 +433,7 @@
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row tr__large">
                                 <th class="govuk-table__header govuk-table__cell__cases" scope="col">
-                                    Closed actions
+                                    Closed actions and decisions
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
                                 </th>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -298,7 +298,7 @@
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
-                                    Date Opened
+                                    Date opened
                                 </th>
                             </tr>
                         </thead>
@@ -438,10 +438,10 @@
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
-                                    Date Opened
+                                    Date opened
                                 </th>
                                 <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
-                                    Date Closed
+                                    Date closed
                                 </th>
                             </tr>
                         </thead>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
@@ -14,7 +14,7 @@
             Concern Types
         </th>
         <th class="govuk-table__header govuk-table__cell__cases" scope="col">
-            Date Closed
+            Date closed
         </th>
     </tr>
 </thead>

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ dotnet user-secrets list
 Set a secret:
 dotnet user-secrets set "trams:api_endpoint" "secret_here"
 dotnet user-secrets set "trams:api_key" "secret_here"
-dotnet user-secrets set "app:username" "secret_here" --> Store a list comma separated users e.g.  dotnet user-secrets set "app:username" "Concerns.casework,e2e.cypress.test,ben.memmott,richard.machen,elijah.aremu,paul.simmons,james.cheetham,menol.razeek,christian.gleadall,philip.pybus,emma.wadsworth,israt.choudhury,chanel.diep,anthon.thomas,jane.dickinson,magdalena.bober,case.worker1,case.worker2,emma.whitcroft,chris.dexter,samantha.harbison,mara.ashraf,anne.chan"
+dotnet user-secrets set "app:username" "secret_here" --> Store a list comma separated users e.g.  dotnet user-secrets set "app:username" "Concerns.casework,e2e.cypress.test,ben.memmott,richard.machen,elijah.aremu,paul.simmons,james.cheetham,menol.razeek,christian.gleadall,philip.pybus,emma.wadsworth,israt.choudhury,chanel.diep,anthon.thomas,jane.dickinson,magdalena.bober,case.worker1,case.worker2,emma.whitcroft,chris.dexter,samantha.harbison,mara.ashraf,anne.chan,jane.dickinson"
 dotnet user-secrets set "app:password" "secret_here"
 dotnet user-secrets set "VCAP_SERVICES" "{'redis': [{'credentials': {'host': '127.0.0.1','password': 'password','port': '6379','tls_enabled': 'false'}}]}"
 


### PR DESCRIPTION
Changed the case on the Actions & Decisions table headings from Closed and Opened to closed and opened

Minimal impact

[Azure Devops 108249](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/108249)
