### PR TITLE
Fix/110147 cd make decisions service use base class methods

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
@@ -261,7 +261,7 @@
                             </div>
 
                             <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="@DecisionType.OtherFinancialSupport" name="DecisionTypeOtherFinancialSupport" type="checkbox" value="true"">
+	                            <input class="govuk-checkboxes__input" id="@DecisionType.OtherFinancialSupport" name="DecisionTypeOtherFinancialSupport" type="checkbox" value="true"/>
                                 <label class="govuk-label govuk-checkboxes__label" for="@DecisionType.OtherFinancialSupport">
                                     @EnumHelper.GetEnumDescription(DecisionType.OtherFinancialSupport)
                                     <div id="@DecisionType.OtherFinancialSupport-hint" class="govuk-hint">
@@ -271,7 +271,7 @@
                             </div>
 
                             <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="@DecisionType.EstimatesFundingOrPupilNumberAdjustment" name="DecisionTypeEstimatesFundingOrPupilNumberAdjustment" type="checkbox" value="true"">
+	                            <input class="govuk-checkboxes__input" id="@DecisionType.EstimatesFundingOrPupilNumberAdjustment" name="DecisionTypeEstimatesFundingOrPupilNumberAdjustment" type="checkbox" value="true"/>
                                 <label class="govuk-label govuk-checkboxes__label" for="@DecisionType.EstimatesFundingOrPupilNumberAdjustment">
                                     @EnumHelper.GetEnumDescription(DecisionType.EstimatesFundingOrPupilNumberAdjustment)
                                     <div id="@DecisionType.EstimatesFundingOrPupilNumberAdjustment-hint" class="govuk-hint">

--- a/ConcernsCaseWork/Service.TRAMS.Tests/Decision/CreateDecisionDtoTests.cs
+++ b/ConcernsCaseWork/Service.TRAMS.Tests/Decision/CreateDecisionDtoTests.cs
@@ -1,0 +1,36 @@
+﻿using AutoFixture;
+using AutoFixture.Idioms;
+using NUnit.Framework;
+using Service.TRAMS.Decision;
+
+namespace Service.TRAMS.Tests.Decision
+{
+	public class CreateDecisionDtoTests
+	{
+		[Test]
+		public void Can_Construct_CreateDecisionDto()
+		{
+			var sut = new CreateDecisionDto();
+			Assert.That(sut, Is.Not.Null);
+		}
+
+		[Test]
+		public void Constructors_Guard_Against_Null_Arguments()
+		{
+			var fixture = new Fixture();
+			var assertion = fixture.Create<GuardClauseAssertion>();
+			assertion.Verify(typeof(CreateDecisionDto).GetConstructors());
+		}
+
+		[Test]
+		public void Writable_Properties_Work_As_Expected()
+		{
+			// Arrange
+			var fixture = new Fixture();
+			var assertion = fixture.Create<WritablePropertyAssertion>();
+
+			// Act & Assert
+			assertion.Verify(typeof(CreateDecisionDto));
+		}
+	}
+}

--- a/ConcernsCaseWork/Service.TRAMS.Tests/Decision/CreateDecisionResponseDtoTests.cs
+++ b/ConcernsCaseWork/Service.TRAMS.Tests/Decision/CreateDecisionResponseDtoTests.cs
@@ -1,0 +1,36 @@
+﻿using AutoFixture;
+using AutoFixture.Idioms;
+using NUnit.Framework;
+using Service.TRAMS.Decision;
+
+namespace Service.TRAMS.Tests.Decision
+{
+	public class CreateDecisionResponseDtoTests
+	{
+		[Test]
+		public void Can_Construct_CreateDecisionResponseDto()
+		{
+			var sut = new CreateDecisionResponseDto();
+			Assert.That(sut, Is.Not.Null);
+		}
+
+		[Test]
+		public void Constructors_Guard_Against_Null_Arguments()
+		{
+			var fixture = new Fixture();
+			var assertion = fixture.Create<GuardClauseAssertion>();
+			assertion.Verify(typeof(CreateDecisionResponseDto).GetConstructors());
+		}
+
+		[Test]
+		public void Writable_Properties_Work_As_Expected()
+		{
+			// Arrange
+			var fixture = new Fixture();
+			var assertion = fixture.Create<WritablePropertyAssertion>();
+
+			// Act & Assert
+			assertion.Verify(typeof(CreateDecisionResponseDto));
+		}
+	}
+}

--- a/ConcernsCaseWork/Service.TRAMS.Tests/Decision/DecisionServiceTests.cs
+++ b/ConcernsCaseWork/Service.TRAMS.Tests/Decision/DecisionServiceTests.cs
@@ -1,0 +1,95 @@
+﻿using AutoFixture;
+using AutoFixture.Idioms;
+using ConcernsCaseWork.Shared.Tests.Factory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using Service.TRAMS.Base;
+using Service.TRAMS.Decision;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Service.TRAMS.Tests.Decision
+{
+	public class DecisionServiceTests
+	{
+		[Test]
+		public void Constructors_Guard_Against_Null_Arguments()
+		{
+			Fixture fixture = CreateMockedFixture();
+			var assertion = fixture.Create<GuardClauseAssertion>();
+			assertion.Verify(typeof(DecisionService).GetConstructors());
+		}
+
+		[Test]
+		public void DecisionService_Implements_IDecisionService()
+		{
+		Fixture fixture = CreateMockedFixture();
+			fixture.Register(() => Mock.Of<IHttpClientFactory>());
+			fixture.Register(() => Mock.Of<ILogger<DecisionService>>());
+
+			var sut = fixture.Create<DecisionService>();
+			Assert.That(sut, Is.AssignableTo<IDecisionService>());
+		}
+
+		[Test]
+		public void DecisionService_IsAm_AbstractService()
+		{
+			Fixture fixture = CreateMockedFixture();
+
+			var sut = fixture.Create<DecisionService>();
+			Assert.That(sut, Is.AssignableTo<AbstractService>());
+		}
+
+		private Fixture CreateMockedFixture()
+		{
+			var fixture = new Fixture();
+			fixture.Register(() => Mock.Of<IHttpClientFactory>());
+			fixture.Register(() => Mock.Of<ILogger<DecisionService>>());
+			return fixture;
+		}
+
+		[Test]
+		public async Task DecisionService_PostDecision_When_Success_Returns_Response()
+		{
+			var httpClientFactory = new Mock<IHttpClientFactory>();
+			var mockMessageHandler = new Mock<HttpMessageHandler>();
+			
+			Fixture fixture = CreateMockedFixture();
+			fixture.Register(() => Mock.Get(httpClientFactory));
+			fixture.Register(() => Mock.Get(mockMessageHandler));
+
+			var expectedInputDto = fixture.Create<CreateDecisionDto>();
+			var expectedResponseDto = fixture.Create<CreateDecisionResponseDto>();
+			var responseWrapper = new ApiWrapper<CreateDecisionResponseDto>(expectedResponseDto);
+
+			var configuration = new ConfigurationBuilder().ConfigurationUserSecretsBuilder().Build();
+			var tramsApiEndpoint = configuration["trams:api_endpoint"];
+
+			mockMessageHandler.Protected()
+				.Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+				.ReturnsAsync(new HttpResponseMessage
+				{
+					StatusCode = HttpStatusCode.OK,
+					Content = new ByteArrayContent(JsonSerializer.SerializeToUtf8Bytes(responseWrapper))
+				});
+
+			var httpClient = new HttpClient(mockMessageHandler.Object);
+			httpClient.BaseAddress = new Uri(tramsApiEndpoint);
+			httpClientFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+			var sut = new DecisionService(httpClientFactory.Object, Mock.Of<ILogger<DecisionService>>());
+			var result = await sut.PostDecision(expectedInputDto);
+
+			Assert.That(result, Is.Not.Null);
+			Assert.That(result.ConcernsCaseUrn, Is.EqualTo(expectedResponseDto.ConcernsCaseUrn));
+			Assert.That(result.DecisionId, Is.EqualTo(expectedResponseDto.DecisionId));
+		}
+	}
+}

--- a/ConcernsCaseWork/Service.TRAMS/Decision/CreateDecisionResponseDto.cs
+++ b/ConcernsCaseWork/Service.TRAMS/Decision/CreateDecisionResponseDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Service.TRAMS.Decision;
+
+public class CreateDecisionResponseDto
+{
+	public int ConcernsCaseUrn { get; set; }
+	public int DecisionId { get; set; }
+}

--- a/ConcernsCaseWork/Service.TRAMS/Decision/IDecisionService.cs
+++ b/ConcernsCaseWork/Service.TRAMS/Decision/IDecisionService.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Service.TRAMS.Decision
 {
 	public interface IDecisionService
 	{
-		Task PostDecision(CreateDecisionDto createDecisionDto);
+		Task<CreateDecisionResponseDto> PostDecision(CreateDecisionDto createDecisionDto);
 	}
 }
 


### PR DESCRIPTION
**What is the change?**
The decisions service, in the trams client has been updated to take advantage of the base class methods that already have almost all of the code that was duplicated in the post method.

Also updated it to return the response back to the page (though it won't be used).

Also fixed 2 occurrences of a html error

**Why do we need the change?**
We need to consolidate as much duplicated code as possible so we have a chance of applying patterns, and easier maintenance.

**What is the impact?**
Should be no obvious impact to the system.

**Azure DevOps Ticket**
110147 - Update the code to use the base class for trams service, instead of duplicated code
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2029?workitem=110147