### PR TITLE
Add image build and push GitHub action for Development

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -1,0 +1,44 @@
+name: Continuous delivery
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-push-image-development:
+    name: Build and push image development
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Azure Container Registry login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DEVELOPMENT_AZURE_ACR_CLIENTID }}
+          password: ${{ secrets.DEVELOPMENT_AZURE_ACR_SECRET }}
+          registry: ${{ secrets.DEVELOPMENT_ACR_URL }}
+
+      - name: Prepare tags
+        id: prepare-tags
+        run: |
+          DOCKER_IMAGE=${{ secrets.DEVELOPMENT_ACR_URL }}/amsd-app
+          VERSION=latest
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION=sha-${GITHUB_SHA}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=deploy-version::${VERSION}
+
+      - name: Push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            RAILS_ENV=development
+          push: true
+          tags: ${{ steps.prepare-tags.outputs.tags }}


### PR DESCRIPTION
**What is the change?**

* Adds a GitHub action to build and push the image to Azure Container Registry
* The `development` environment will have a new image built and pushed on every push/merge into the GitHub `main` branch
