### PR TITLE
Fix: remove GitHub action Docker build-args

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -38,7 +38,5 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          build-args: |
-            RAILS_ENV=development
           push: true
           tags: ${{ steps.prepare-tags.outputs.tags }}


### PR DESCRIPTION
**What is the change?**

* This was accidently copied over from a different project. This image doesn't require any Docker build-args
