### PR TITLE
Bug/109048 trust overview links to editable case page for closed cases

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
@@ -230,6 +230,73 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 		}
 		
 		[Test]
+		public async Task WhenOnGetAsync_WhenCaseIsClosed_RedirectsToClosedCasePage()
+		{
+			// arrange
+			var mockCaseModelService = new Mock<ICaseModelService>();
+			var mockTrustModelService = new Mock<ITrustModelService>();
+			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockRatingModelService = new Mock<IRatingModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
+			var mockLogger = new Mock<ILogger<IndexPageModel>>();
+			var mockCaseHistoryModelService = new Mock<ICaseHistoryModelService>();
+			var mockSrmaService = new Mock<ISRMAService>();
+			var mockFinancialPlanModelService = new Mock<IFinancialPlanModelService>();
+			var mockNtiUnderConsiderationModelService = new Mock<INtiUnderConsiderationModelService>();
+			var mockNtiUCStatusesCachedService = new Mock<INtiUnderConsiderationStatusesCachedService>();
+			var mockNtiWLModelService = new Mock<INtiWarningLetterModelService>();
+			var mockNtiModelService = new Mock<INtiModelService>();
+			var closedStatusUrn = 3;
+
+			var caseModel = CaseFactory.BuildCaseModel(statusUrn:closedStatusUrn);
+			var trustCasesModel = CaseFactory.BuildListTrustCasesModel();
+			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
+			var casesHistoryModel = CaseFactory.BuildListCasesHistoryModel();
+			var recordsModel = RecordFactory.BuildListRecordModel();
+			var closedStatusModel = StatusFactory.BuildStatusDto(StatusEnum.Close.ToString(), closedStatusUrn);
+			var financialPlansModel = FinancialPlanFactory.BuildListFinancialPlanModel();
+			var ntiUnderConsiderationModels = NTIUnderConsiderationFactory.BuildListNTIUnderConsiderationModel();
+			var ntiWarningLetterModels = NTIWarningLetterFactory.BuildListNTIWarningLetterModels(3);
+			var ntiModels = NTIFactory.BuildListNTIModel();
+			
+			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(caseModel);
+			mockCaseModelService.Setup(c => c.GetCasesByTrustUkprn(It.IsAny<string>()))
+				.ReturnsAsync(trustCasesModel);
+			mockTrustModelService.Setup(t => t.GetTrustByUkPrn(It.IsAny<string>()))
+				.ReturnsAsync(trustDetailsModel);
+			mockCaseHistoryModelService.Setup(c => c.GetCasesHistory(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(casesHistoryModel);
+			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(recordsModel);
+			mockStatusCachedService.Setup(s => s.GetStatusByName(StatusEnum.Close.ToString()))
+				.ReturnsAsync(closedStatusModel);
+			mockFinancialPlanModelService.Setup(fp => fp.GetFinancialPlansModelByCaseUrn(It.IsAny<long>(), It.IsAny<string>()))
+				.ReturnsAsync(financialPlansModel);
+			mockNtiUnderConsiderationModelService.Setup(uc => uc.GetNtiUnderConsiderationsForCase(It.IsAny<long>()))
+				.ReturnsAsync(ntiUnderConsiderationModels);
+			mockNtiWLModelService.Setup(wl => wl.GetNtiWarningLettersForCase(It.IsAny<long>()))
+				.ReturnsAsync(ntiWarningLetterModels);
+			mockNtiModelService.Setup(nti => nti.GetNtisForCaseAsync(It.IsAny<long>()))
+				.ReturnsAsync(ntiModels);
+			
+			var pageModel = SetupIndexPageModel(mockCaseModelService.Object, mockTrustModelService.Object,
+					mockCaseHistoryModelService.Object, mockRecordModelService.Object, mockRatingModelService.Object, mockStatusCachedService.Object, 
+					mockSrmaService.Object, mockFinancialPlanModelService.Object, mockNtiUnderConsiderationModelService.Object, mockNtiUCStatusesCachedService.Object,
+					 mockLogger.Object, mockNtiWLModelService.Object, mockNtiModelService.Object);
+
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+			
+			// act
+			var result = await pageModel.OnGetAsync();
+			
+			// assert
+			Assert.That(result, Is.TypeOf<RedirectResult>());
+			Assert.That(((RedirectResult)result).Url, Is.EqualTo($"/case/{caseModel.Urn}/closed"));
+		}
+		
+		[Test]
 		public async Task WhenOnGetAsync_WithNoCaseActions_SetsHasOpenActionsAndHasClosedActionsToFalse()
 		{
 			// arrange

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/ViewClosedPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/ViewClosedPageModelTests.cs
@@ -13,10 +13,10 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using Service.Redis.Status;
+using Service.TRAMS.Status;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case
@@ -33,9 +33,10 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockLogger = new Mock<ILogger<ViewClosedPageModel>>();
 			var mockRecordModelService = new Mock<IRecordModelService>();
 			var mockActionsModelService = new Mock<IActionsModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
 
 			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockActionsModelService.Object,
-				mockLogger.Object);
+				mockStatusCachedService.Object, mockLogger.Object);
 
 			// act
 			await pageModel.OnGetAsync();
@@ -61,12 +62,13 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockLogger = new Mock<ILogger<ViewClosedPageModel>>();
 			var mockRecordModelService = new Mock<IRecordModelService>();
 			var mockActionsModelService = new Mock<IActionsModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
 
 			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
 				.Throws<Exception>();
 
 			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockActionsModelService.Object,
-				mockLogger.Object);
+				mockStatusCachedService.Object, mockLogger.Object);
 
 			var routeData = pageModel.RouteData.Values;
 			routeData.Add("urn", 1);
@@ -94,6 +96,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var mockLogger = new Mock<ILogger<ViewClosedPageModel>>();
 			var mockRecordModelService = new Mock<IRecordModelService>();
 			var mockActionsModelService = new Mock<IActionsModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
 
 			var caseModel = CaseFactory.BuildCaseModel();
 			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
@@ -108,9 +111,11 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 				.ReturnsAsync(recordsModel);
 			mockActionsModelService.Setup(a => a.GetClosedActionsSummary(It.IsAny<string>(), It.IsAny<long>()))
 				.ReturnsAsync(closedActions);
+			mockStatusCachedService.Setup(a => a.GetStatusByName(StatusEnum.Close.ToString()))
+				.ReturnsAsync(new StatusDto("Closed", DateTimeOffset.Now, DateTimeOffset.Now, caseModel.StatusUrn));
 
 			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockActionsModelService.Object,
-				mockLogger.Object);
+				mockStatusCachedService.Object, mockLogger.Object);
 
 			var routeData = pageModel.RouteData.Values;
 			routeData.Add("urn", 1);
@@ -189,17 +194,65 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			mockRecordModelService.Verify(c => c.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Once);
 			mockActionsModelService.Verify(c => c.GetClosedActionsSummary(It.IsAny<string>(), It.IsAny<long>()), Times.Once);
 		}
+		
+		
+		[Test]
+		public async Task WhenOnGetAsync_WhenCaseIsOpen_RedirectsToCaseManagementPage()
+		{
+			// arrange
+			var mockCaseModelService = new Mock<ICaseModelService>();
+			var mockTrustModelService = new Mock<ITrustModelService>();
+			var mockLogger = new Mock<ILogger<ViewClosedPageModel>>();
+			var mockRecordModelService = new Mock<IRecordModelService>();
+			var mockActionsModelService = new Mock<IActionsModelService>();
+			var mockStatusCachedService = new Mock<IStatusCachedService>();
+
+			var caseModel = CaseFactory.BuildCaseModel();
+			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
+			var recordsModel = RecordFactory.BuildListRecordModel();
+			var closedActions = ActionsSummaryFactory.BuildListOfActionSummaries();
+
+			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(caseModel);
+			mockTrustModelService.Setup(t => t.GetTrustByUkPrn(It.IsAny<string>()))
+				.ReturnsAsync(trustDetailsModel);
+			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(recordsModel);
+			mockActionsModelService.Setup(a => a.GetClosedActionsSummary(It.IsAny<string>(), It.IsAny<long>()))
+				.ReturnsAsync(closedActions);
+			mockStatusCachedService.Setup(a => a.GetStatusByName(StatusEnum.Close.ToString()))
+				.ReturnsAsync(new StatusDto("Open", DateTimeOffset.Now, DateTimeOffset.Now, 99999));
+
+			var pageModel = SetupViewClosedPageModel(mockCaseModelService.Object, mockTrustModelService.Object, mockRecordModelService.Object, mockActionsModelService.Object,
+				mockStatusCachedService.Object, mockLogger.Object);
+
+			var routeData = pageModel.RouteData.Values;
+			routeData.Add("urn", 1);
+
+			// act
+			var result = await pageModel.OnGetAsync();
+
+			// assert
+			mockLogger.VerifyLogErrorWasNotCalled();
+			Assert.That(((RedirectResult)result).Url, Is.EqualTo($"/case/{caseModel.Urn}/management"));
+
+			mockCaseModelService.Verify(c => c.GetCaseByUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Once);
+			mockTrustModelService.Verify(c => c.GetTrustByUkPrn(It.IsAny<string>()), Times.Never);
+			mockRecordModelService.Verify(c => c.GetRecordsModelByCaseUrn(It.IsAny<string>(), It.IsAny<long>()), Times.Never);
+			mockActionsModelService.Verify(c => c.GetClosedActionsSummary(It.IsAny<string>(), It.IsAny<long>()), Times.Never);
+		}
 
 		private static ViewClosedPageModel SetupViewClosedPageModel(
 			ICaseModelService mockCaseModelService,
 			ITrustModelService mockTrustModelService,
 			IRecordModelService mockRecordModelService,
 			IActionsModelService mockActionsModelService,
+			IStatusCachedService mockStatusCachedService,
 			ILogger<ViewClosedPageModel> mockLogger, bool isAuthenticated = false)
 		{
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 
-			return new ViewClosedPageModel(mockCaseModelService, mockTrustModelService, mockRecordModelService, mockActionsModelService, mockLogger)
+			return new ViewClosedPageModel(mockCaseModelService, mockTrustModelService, mockRecordModelService, mockActionsModelService, mockStatusCachedService, mockLogger)
 			{
 				PageContext = pageContext, TempData = tempData, Url = new UrlHelper(actionContext), MetadataProvider = pageContext.ViewData.ModelMetadata
 			};

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
@@ -81,7 +81,7 @@ namespace ConcernsCaseWork.Pages.Case.Management
 			_logger = logger;
 		}
 
-		public async Task OnGetAsync()
+		public async Task<IActionResult> OnGetAsync()
 		{
 			try
 			{
@@ -93,6 +93,11 @@ namespace ConcernsCaseWork.Pages.Case.Management
 
 				// Get Case
 				CaseModel = await _caseModelService.GetCaseByUrn(User.Identity.Name, caseUrn);
+
+				if (await IsCaseClosed())
+				{
+					return Redirect($"/case/{CaseModel.Urn}/closed");
+				}
 
 				// Check if case is editable
 				IsEditableCase = await IsCaseEditable();
@@ -125,6 +130,8 @@ namespace ConcernsCaseWork.Pages.Case.Management
 
 				TempData["Error.Message"] = ErrorOnGetPage;
 			}
+
+			return Page();
 		}
 
 		private async Task PopulateAdditionalCaseInformation()

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Models;
+﻿using ConcernsCaseWork.Extensions;
+using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Base;
 using ConcernsCaseWork.Services.Actions;
@@ -52,7 +53,7 @@ namespace ConcernsCaseWork.Pages.Case
 		{
 			try
 			{
-				_logger.LogInformation("{ClassName}::{EchoCallerName}", nameof(ViewClosedPageModel), LoggingHelpers.EchoCallerName());
+				_logger.LogMethodEntered();
 
 				var caseUrn = GetRequestedCaseUrn();
 				var userName = GetUserName();
@@ -61,6 +62,7 @@ namespace ConcernsCaseWork.Pages.Case
 
 				if (await IsCaseOpen())
 				{
+					_logger.LogInformation("Redirecting to /case/{CaseUrn}/management as this case is open", CaseModel.Urn);
 					return Redirect($"/case/{CaseModel.Urn}/management");
 				}
 				

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
@@ -8,7 +8,9 @@ using ConcernsCaseWork.Services.Trusts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Service.Redis.Status;
 using Service.TRAMS.Helpers;
+using Service.TRAMS.Status;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,6 +26,7 @@ namespace ConcernsCaseWork.Pages.Case
 		private readonly ITrustModelService _trustModelService;
 		private readonly ICaseModelService _caseModelService;
 		private readonly IActionsModelService _actionsModelService;
+		private readonly IStatusCachedService _statusCachedService;
 		private readonly ILogger<ViewClosedPageModel> _logger;
 		
 		public CaseModel CaseModel { get; private set; }
@@ -34,16 +37,18 @@ namespace ConcernsCaseWork.Pages.Case
 			ITrustModelService trustModelService,
 			IRecordModelService recordModelService,
 			IActionsModelService actionsModelService,
+			IStatusCachedService statusCachedService,
 			ILogger<ViewClosedPageModel> logger)
 		{
 			_caseModelService = caseModelService;
 			_trustModelService = trustModelService;
 			_recordModelService = recordModelService;
 			_actionsModelService = actionsModelService;
+			_statusCachedService = statusCachedService;
 			_logger = logger;
 		}
 		
-		public async Task OnGetAsync()
+		public async Task<IActionResult> OnGetAsync()
 		{
 			try
 			{
@@ -53,6 +58,12 @@ namespace ConcernsCaseWork.Pages.Case
 				var userName = GetUserName();
 
 				CaseModel = await _caseModelService.GetCaseByUrn(userName, caseUrn);
+
+				if (await IsCaseOpen())
+				{
+					return Redirect($"/case/{CaseModel.Urn}/management");
+				}
+				
 				TrustDetailsModel = await _trustModelService.GetTrustByUkPrn(CaseModel.TrustUkPrn);
 				
 				var recordsModel = await _recordModelService.GetRecordsModelByCaseUrn(userName, caseUrn);
@@ -67,6 +78,8 @@ namespace ConcernsCaseWork.Pages.Case
 
 				TempData["Error.Message"] = ErrorOnGetPage;
 			}
+
+			return Page();
 		}
 		
 		private long GetRequestedCaseUrn()
@@ -83,5 +96,16 @@ namespace ConcernsCaseWork.Pages.Case
 
 		private string GetUserName() => User.Identity?.Name;
 
+		private async Task<bool> IsCaseOpen()
+		{
+			var closedStatus = await _statusCachedService.GetStatusByName(StatusEnum.Close.ToString());
+
+			if (CaseModel.StatusUrn.CompareTo(closedStatus.Urn) != 0)
+			{
+				return true;
+			}
+
+			return false;
+		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustActiveCases.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustActiveCases.cshtml
@@ -23,7 +23,7 @@
 </thead>
 
 <tbody class="govuk-table__body">
-    @if (activeCases.Count() == 0)
+    @if (!activeCases.Any())
     {
         <tr class="govuk-table__row tr__large">
             <td class="govuk-table__cell__cases govuk-oneline-row">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
@@ -34,7 +34,7 @@
         {
             <tr class="govuk-table__row tr__large">
                 <td class="govuk-table__cell">
-                    <a class="govuk-link" href="/case/@trustCase.CaseUrn/management">@trustCase.CaseUrn</a>
+                    <a class="govuk-link" href="/case/@trustCase.CaseUrn/closed">@trustCase.CaseUrn</a>
                 </td>
                 <td class="govuk-table__cell">
                     @foreach (var record in trustCase.RecordsModel)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
@@ -34,7 +34,7 @@
         {
             <tr class="govuk-table__row tr__large">
                 <td class="govuk-table__cell">
-                    <a class="govuk-link" href="/case/@trustCase.CaseUrn/management/closed">@trustCase.CaseUrn</a>
+                    <a class="govuk-link" href="/case/@trustCase.CaseUrn/closed">@trustCase.CaseUrn</a>
                 </td>
                 <td class="govuk-table__cell">
                     @foreach (var record in trustCase.RecordsModel)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustClosedCases.cshtml
@@ -20,7 +20,7 @@
 </thead>
 
 <tbody class="govuk-table__body">
-    @if (closedCases.Count() == 0)
+    @if (!closedCases.Any())
     {
         <tr class="govuk-table__row tr__large">
             <td class="govuk-table__cell__cases govuk-oneline-row">
@@ -34,7 +34,7 @@
         {
             <tr class="govuk-table__row tr__large">
                 <td class="govuk-table__cell">
-                    <a class="govuk-link" href="/case/@trustCase.CaseUrn/closed">@trustCase.CaseUrn</a>
+                    <a class="govuk-link" href="/case/@trustCase.CaseUrn/management/closed">@trustCase.CaseUrn</a>
                 </td>
                 <td class="govuk-table__cell">
                     @foreach (var record in trustCase.RecordsModel)


### PR DESCRIPTION
Bug fix for users being able to edit a closed case.
[Azure DevOps #109048](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/109048)

Actions taken:
- Changed hyperlink on http://localhost/case/<<case urn>>/management#trust-overview 'Closed cases' table to go to  http://localhost/case/<<case urn>>/closed (rather than /management)
- Changed hyperlink on http://localhost/trust/<< trust prn >>/overview  'Closed cases' table to go to to http://localhost/case/<<case urn>>/closed (rather than /management)
Image
- Changed http://localhost/case/<< case urn>>/management page to redirect to http://localhost/case/<< case urn>>/closed if the case with urn << case urn >> is closed
- Changed http://localhost/case/<< case urn>>/closed page to redirect to http://localhost/case/<< case urn>>/management if the case with urn << case urn >> is open