### PR TITLE
Bug/109563 back to case on srma edit journey

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Models/CaseActions/FinancialPlanModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Models/CaseActions/FinancialPlanModelTests.cs
@@ -1,0 +1,71 @@
+using AutoFixture;
+using ConcernsCaseWork.Models.CaseActions;
+using NUnit.Framework;
+using System;
+
+namespace ConcernsCaseWork.Tests.Models.CaseActions;
+
+[Parallelizable(ParallelScope.All)]
+public class CaseActionModelTests
+{
+	private readonly IFixture _fixture;
+
+	public CaseActionModelTests()
+	{
+		_fixture = new Fixture();
+	}
+	
+	[Test]
+	public void WhenClosedAtIsNull_IsClosedIsFalse()
+	{
+		// arrange
+		var caseActionModel = new CaseActionModel { ClosedAt = null };
+
+		// act
+		var result = caseActionModel.IsClosed;
+			
+		// assert
+		Assert.That(result, Is.False);
+	}
+	
+	[Test]
+	public void WhenClosedAtIsNotNull_IsClosedIsTrue()
+	{
+		// arrange
+		var closedAt = _fixture.Build<DateTime?>().Create();
+		var caseActionModel = new CaseActionModel { ClosedAt = closedAt };
+
+		// act
+		var result = caseActionModel.IsClosed;
+			
+		// assert
+		Assert.That(result, Is.True);
+	}
+	
+	[Test]
+	public void WhenClosedAtIsNull_IsOpenIsTrue()
+	{
+		// arrange
+		var caseActionModel = new CaseActionModel { ClosedAt = null };
+
+		// act
+		var result = caseActionModel.IsOpen;
+			
+		// assert
+		Assert.That(result, Is.True);
+	}
+	
+	[Test]
+	public void WhenClosedAtIsNotNull_IsOpenIsFalse()
+	{
+		// arrange
+		var closedAt = _fixture.Build<DateTime?>().Create();
+		var caseActionModel = new CaseActionModel { ClosedAt = closedAt };
+
+		// act
+		var result = caseActionModel.IsOpen;
+			
+		// assert
+		Assert.That(result, Is.False);
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/CaseActionModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/CaseActionModel.cs
@@ -9,5 +9,10 @@ namespace ConcernsCaseWork.Models.CaseActions
 		public DateTime CreatedAt { get; set; }
 		public DateTime UpdatedAt { get; set; }
 		public DateTime? ClosedAt { get; set; }
+
+		public bool IsOpen { get => !IsClosed; }
+
+		public bool IsClosed { get => ClosedAt != null; }
+
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Close.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Close.cshtml.cs
@@ -39,6 +39,11 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 				
 				FinancialPlanModel = await _financialPlanModelService.GetFinancialPlansModelById(caseUrn, financialPlanId, loggedInUserName);
 				
+				if (FinancialPlanModel.IsClosed)
+				{
+					return Redirect($"/case/{caseUrn}/management/action/financialplan/{financialPlanId}/closed");
+				}
+				
 				var currentStatusName = FinancialPlanModel.Status?.Name;
 				FinancialPlanStatuses = await GetStatusOptionsAsync(currentStatusName);
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Edit.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Edit.cshtml.cs
@@ -38,6 +38,11 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 				var loggedInUser = GetLoggedInUserName();
 				
 				FinancialPlanModel = await _financialPlanModelService.GetFinancialPlansModelById(caseUrn, financialPlanId, loggedInUser);
+
+				if (FinancialPlanModel.IsClosed)
+				{
+					return Redirect($"/case/{caseUrn}/management/action/financialplan/{financialPlanId}/closed");
+				}
 				
 				FinancialPlanStatuses = await GetStatusOptionsAsync(FinancialPlanModel.Status?.Name);
 			}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/FinancialPlanBasePageModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/FinancialPlanBasePageModel.cs
@@ -18,6 +18,16 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 		public FinancialPlanModel FinancialPlanModel { get; set; }
 		public IEnumerable<RadioItem> FinancialPlanStatuses { get; set; } = new List<RadioItem>();
 		
+		protected abstract Task<IList<FinancialPlanStatusDto>> GetAvailableStatusesAsync();
+		
+		protected virtual async Task<FinancialPlanStatusModel> GetOptionalStatusByNameAsync(string statusName)
+		{
+			var status = (await GetAvailableStatusesAsync())
+				.FirstOrDefault(s => s.Name.Equals(statusName));
+			
+			return status is null ? null : FinancialPlanStatusMapping.MapDtoToModel(status);
+		}
+				
 		protected async Task<IEnumerable<RadioItem>> GetStatusOptionsAsync(string selectedStatusName = null)
 			=> (await GetAvailableStatusesAsync())
 				.Select(s => new RadioItem
@@ -26,14 +36,6 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 					Text = s.Description,
 					IsChecked = selectedStatusName == s.Name
 				});
-
-		protected virtual async Task<FinancialPlanStatusModel> GetOptionalStatusByNameAsync(string statusName)
-		{
-			var status = (await GetAvailableStatusesAsync())
-				.FirstOrDefault(s => s.Name.Equals(statusName));
-			
-			return status is null ? null : FinancialPlanStatusMapping.MapDtoToModel(status);
-		}
 		
 		protected async Task<FinancialPlanStatusModel> GetRequiredStatusByNameAsync(string statusName)
 		{
@@ -109,7 +111,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 		
 		protected string CreateDateString(string day, string month, string year)
 			=> (string.IsNullOrEmpty(day) && string.IsNullOrEmpty(month) && string.IsNullOrEmpty(year)) ? String.Empty : $"{day}-{month}-{year}";
-
-		protected abstract Task<IList<FinancialPlanStatusDto>> GetAvailableStatusesAsync();
+		
+		protected string GetUrlForClosedPlan(long caseUrn, long financialPlanId) => $"/case/{caseUrn}/management/action/financialplan/{financialPlanId}/closed";
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Index.cshtml.cs
@@ -24,7 +24,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 			_logger = logger;
 		}
 
-		public async Task OnGetAsync()
+		public async Task<IActionResult> OnGetAsync()
 		{
 			long caseUrn = 0;
 			long financialPlanId = 0;
@@ -41,13 +41,19 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 				{
 					throw new Exception("Could not load this Financial Plan");
 				}
-
+				
+				if (FinancialPlanModel.IsClosed)
+				{
+					return Redirect($"/case/{caseUrn}/management/action/financialplan/{financialPlanId}/closed");
+				}
 			}
 			catch (Exception ex)
 			{
 				_logger.LogError("Case::Action::FinancialPlan::IndexPageModel::OnGetAsync::Exception - {Message}", ex.Message);
 				TempData["Error.Message"] = ErrorOnGetPage;
 			}
+
+			return Page();
 		}
 
 		private (long caseUrn, long financialPlanId) GetRouteData()

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
@@ -7,6 +7,7 @@
 @{
 	ViewData["Title"] = "SRMA";
 	ViewData["BackButtonLabel"] = "Back to case";
+	ViewData["BackButtonLink"] = $"/case/{Model.CaseUrn}/management";
 
 	var errorClass = "govuk-error-message";
 	var srmaValidationErrors = TempData["SRMA.Message"] as IEnumerable<string>;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml.cs
@@ -28,6 +28,9 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA
 
 		public SRMAModel SRMAModel { get; set; }
 		public string DeclineCompleteButtonLabel { get; private set; }
+		
+		[BindProperty(Name = "Urn", SupportsGet = true)]
+		public long CaseUrn { get; set; }
 
 		public IndexPageModel(ISRMAService srmaService, ILogger<IndexPageModel> logger)
 		{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_BackLink.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_BackLink.cshtml
@@ -1,11 +1,18 @@
 ﻿@{
 	var nonce = Context.GetNonce();
 	var label = ViewData["BackButtonLabel"] ?? "Back";
-	
+
+	var backLink = Convert.ToString(ViewData["BackButtonLink"]);
+}
+@if (string.IsNullOrWhiteSpace(backLink))
+{
 	<a id="back-link-event" class="govuk-back-link" href="#">@label</a>
 	<script nonce="@nonce">
-		$("#back-link-event").click(function() {
-			history.back();
-		});
-	</script>
+        $("#back-link-event").click(function() {
+        history.back();
+        });
+    </script>
+}
+else {
+	<a id="back-link-event" class="govuk-back-link" href="@backLink">@label</a>
 }


### PR DESCRIPTION
The 'back to case' button on SRMA edit page was acting as a browser back button, which meant that it only worked as expected if users had not edited any values. If users had edited values, the 'back to case' button was taking them back to the pre-edited version of the page, so looked as though it wasn't doing anything. 

Fixed by adding the url to redirect to rather than using javascript back functionality.

THIS IS A HOTFIX BUG to be merged into production.

[Azure Devops 109563](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/109563)