### PR TITLE
Fix the SRMA 'back to case' button

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
@@ -7,6 +7,7 @@
 @{
 	ViewData["Title"] = "SRMA";
 	ViewData["BackButtonLabel"] = "Back to case";
+	ViewData["BackButtonLink"] = $"/case/{Model.CaseUrn}/management";
 
 	var errorClass = "govuk-error-message";
 	var srmaValidationErrors = TempData["SRMA.Message"] as IEnumerable<string>;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml.cs
@@ -28,6 +28,9 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA
 
 		public SRMAModel SRMAModel { get; set; }
 		public string DeclineCompleteButtonLabel { get; private set; }
+		
+		[BindProperty(Name = "Urn", SupportsGet = true)]
+		public long CaseUrn { get; set; }
 
 		public IndexPageModel(ISRMAService srmaService, ILogger<IndexPageModel> logger)
 		{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_BackLink.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_BackLink.cshtml
@@ -1,11 +1,18 @@
 ﻿@{
 	var nonce = Context.GetNonce();
 	var label = ViewData["BackButtonLabel"] ?? "Back";
-	
+
+	var backLink = Convert.ToString(ViewData["BackButtonLink"]);
+}
+@if (string.IsNullOrWhiteSpace(backLink))
+{
 	<a id="back-link-event" class="govuk-back-link" href="#">@label</a>
 	<script nonce="@nonce">
-		$("#back-link-event").click(function() {
-			history.back();
-		});
-	</script>
+        $("#back-link-event").click(function() {
+        history.back();
+        });
+    </script>
+}
+else {
+	<a id="back-link-event" class="govuk-back-link" href="@backLink">@label</a>
 }


### PR DESCRIPTION
The 'back to case' button on SRMA edit page was acting as a browser back button, which meant that it only worked as expected if users had not edited any values. If users had edited values, the 'back to case' button was taking them back to the pre-edited version of the page, so looked as though it wasn't doing anything.

Fixed by adding the url to redirect to rather than using javascript back functionality.

THIS IS A HOTFIX BUG to be merged into production. Note that there is another PR to get this merged into the main branch: [PR 420](https://github.com/DFE-Digital/amsd-casework/pull/420)

[Azure Devops 109563](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/109563)
