### PR TITLE
Remove timeline partial from case index page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -566,8 +566,6 @@
                         </tbody>
                     </table>
 
-                <partial name="_CaseHistory" model="@Model.CasesHistoryModel" />
-
             </div>
             <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="trust-overview">
                 <partial name="_TrustOverview" model="@Model.TrustDetailsModel" />


### PR DESCRIPTION
Remove timeline partial from case index page.

[Azure DevOps 109735](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/109735)

Note that there is a fuller [PR (431) ](https://github.com/DFE-Digital/amsd-casework/pull/431) to remove **all** of the case history code. This PR is to be merged into main, and includes this change, which is to just remove the partial. I'm keeping this hotfix change simple to keep the risk of problems low. 




