### PR TITLE
display the active decisions on the case management page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Decisions/DecisionMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Decisions/DecisionMappingTests.cs
@@ -1,0 +1,54 @@
+﻿using AutoFixture;
+using ConcernsCaseWork.Models.CaseActions;
+using ConcernsCaseWork.Services.Decisions;
+using FluentAssertions;
+using NUnit.Framework;
+using Service.TRAMS.Decision;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConcernsCaseWork.Tests.Services.Decisions
+{
+	[Parallelizable(ParallelScope.All)]
+	internal class DecisionMappingTests
+	{
+		private readonly static Fixture _fixture = new();
+
+		[Test]
+		public void MapDtoToModel_ReturnsCorrectModel()
+		{
+			var apiDecision = _fixture.Create<GetDecisionResponseDto>();
+			apiDecision.Title = DecisionType.RepayableFinancialSupport;
+
+			var result = DecisionMapping.MapDtoToModel(apiDecision);
+
+			AssertDecisionModel(result, apiDecision);
+			result.Title.Should().Be("Repayable financial support");
+		}
+
+		[Test]
+		public void MapDtoModelList_ReturnsCorrectModel()
+		{
+			var apiDecisions = _fixture.CreateMany<GetDecisionResponseDto>().ToList();
+
+			var result = DecisionMapping.MapDtoToModel(apiDecisions);
+
+			result.Should().HaveCount(apiDecisions.Count);
+
+			for (var idx = 0; idx < apiDecisions.Count; idx++)
+			{
+				var decision = apiDecisions[idx];
+				var model = result[idx];
+
+				AssertDecisionModel(model, decision);
+			}
+		}
+
+		private void AssertDecisionModel(DecisionModel model, GetDecisionResponseDto decision)
+		{
+			model.CaseUrn.Should().Be(decision.ConcernsCaseUrn);
+			model.CreatedAt.Should().Be(decision.CreatedAt.Date);
+			model.ClosedAt.Should().Be(decision.ClosedAt?.Date);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.8" />
     <PackageReference Include="Microsoft.Configuration.ConfigurationBuilders.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
@@ -5,6 +5,7 @@ using ConcernsCaseWork.Pages.Validators;
 using ConcernsCaseWork.Security;
 using ConcernsCaseWork.Services.Actions;
 using ConcernsCaseWork.Services.Cases;
+using ConcernsCaseWork.Services.Decisions;
 using ConcernsCaseWork.Services.FinancialPlan;
 using ConcernsCaseWork.Services.MeansOfReferral;
 using ConcernsCaseWork.Services.Nti;
@@ -149,6 +150,7 @@ namespace ConcernsCaseWork.Extensions
 			services.AddScoped<ICaseActionValidationStrategy, NTIWarningLetterValidator>();
 			services.AddScoped<ICaseActionValidationStrategy, NTIValidator>();
 			services.AddScoped<ICaseActionValidator, CaseActionValidator>();
+			services.AddScoped<IDecisionModelService, DecisionModelService>();
 
 			// Trams api services
 			services.AddScoped<ICaseService, CaseService>();

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/DecisionModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/DecisionModel.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace ConcernsCaseWork.Models.CaseActions
+{
+	public class DecisionModel : CaseActionModel
+	{
+		public string Title { get; set; }
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -29,6 +29,10 @@
 	var noticesToImprove = Model.CaseActions?.Where(ca => ca is NtiModel).Select(nti => nti as NtiModel).ToList();
 	var openNtis = noticesToImprove.Where(nti => nti.ClosedAt == null).ToList();
 	var closedNtis = noticesToImprove.Except(openNtis).ToList();
+
+	var decisions = Model.CaseActions?.Where(ca => ca is DecisionModel).Select(d => d as DecisionModel).ToList();
+	var openDecisions = decisions.Where(d => d.ClosedAt == null);
+	var closedDecisions = decisions.Except(openDecisions).ToList();
 }
 
 <div class="govuk-width-container">
@@ -419,7 +423,7 @@
                                             }
                                             else
                                             {
-                                                <span>In progress</span>
+
                                             }
                                         }
                                     </td>
@@ -428,6 +432,23 @@
                                     </td>
                                 </tr>
                             }
+
+							@foreach (DecisionModel decision in openDecisions)
+							{
+								<tr class="govuk-table__row">
+									<td class="govuk-table__cell">
+									<a href="@Request.Path/action/decision/@decision.Id" class="govuk-link govuk-link-no-visited-state">
+											<span>Decision: @decision.Title</span>
+										</a>
+									</td>
+									<td class="govuk-table__cell">
+										<span>In progress</span>
+									</td>
+									<td class="govuk-table__cell govuk-table__header__right">
+										@DateExtension.ToDayMonthYear(decision.CreatedAt)
+									</td>
+								</tr>
+							}
                         </tbody>
                     </table>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
@@ -2,6 +2,7 @@
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Base;
 using ConcernsCaseWork.Services.Cases;
+using ConcernsCaseWork.Services.Decisions;
 using ConcernsCaseWork.Services.FinancialPlan;
 using ConcernsCaseWork.Services.Nti;
 using ConcernsCaseWork.Services.NtiWarningLetter;
@@ -38,6 +39,7 @@ namespace ConcernsCaseWork.Pages.Case.Management
 		private readonly INtiUnderConsiderationStatusesCachedService _ntiStatusesCachedService;
 		private readonly INtiWarningLetterModelService _ntiWarningLetterModelService;
 		private readonly INtiModelService _ntiModelService;
+		private readonly IDecisionModelService _decisionModelService;
 		private readonly ILogger<IndexPageModel> _logger;
 
 		public CaseModel CaseModel { get; private set; }
@@ -63,7 +65,8 @@ namespace ConcernsCaseWork.Pages.Case.Management
 			INtiUnderConsiderationStatusesCachedService ntiUCStatusesCachedService,
 			INtiWarningLetterModelService ntiWarningLetterModelService,
 			INtiModelService ntiModelService,
-			ILogger<IndexPageModel> logger
+			ILogger<IndexPageModel> logger,
+			IDecisionModelService decisionModelService
 			)
 		{
 			_caseHistoryModelService = caseHistoryModelService;
@@ -79,6 +82,7 @@ namespace ConcernsCaseWork.Pages.Case.Management
 			_ntiWarningLetterModelService = ntiWarningLetterModelService;
 			_ntiModelService = ntiModelService;
 			_logger = logger;
+			_decisionModelService = decisionModelService;
 		}
 
 		public async Task<IActionResult> OnGetAsync()
@@ -134,14 +138,6 @@ namespace ConcernsCaseWork.Pages.Case.Management
 			return Page();
 		}
 
-		private async Task PopulateAdditionalCaseInformation()
-		{
-			if(CaseActions?.Any(ca => ca is NtiUnderConsiderationModel) == true)
-			{
-				NtiStatuses = (await _ntiStatusesCachedService.GetAllStatuses()).ToList();
-			}
-		}
-
 		private async Task PopulateCaseActions(long caseUrn)
 		{
 			CaseActions = CaseActions ?? new List<CaseActionModel>();
@@ -150,6 +146,7 @@ namespace ConcernsCaseWork.Pages.Case.Management
 			CaseActions.AddRange(await _ntiUnderConsiderationModelService.GetNtiUnderConsiderationsForCase(caseUrn));
 			CaseActions.AddRange(await _ntiWarningLetterModelService.GetNtiWarningLettersForCase(caseUrn));
 			CaseActions.AddRange(await _ntiModelService.GetNtisForCaseAsync(caseUrn));
+			CaseActions.AddRange(await _decisionModelService.GetDecisionsByUrn(caseUrn));
 		}
 
 		private bool UserHasEditCasePrivileges()

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionMapping.cs
@@ -1,0 +1,31 @@
+﻿using ConcernsCaseWork.Helpers;
+using ConcernsCaseWork.Models.CaseActions;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
+using Service.TRAMS.Decision;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConcernsCaseWork.Services.Decisions
+{
+	public class DecisionMapping
+	{
+		public static DecisionModel MapDtoToModel(GetDecisionResponseDto decision)
+		{
+			var result = new DecisionModel()
+			{
+				CreatedAt = decision.CreatedAt.Date,
+				ClosedAt = decision.ClosedAt?.Date,
+				CaseUrn = decision.ConcernsCaseUrn,
+				Id = decision.DecisionId,
+				Title = EnumHelper.GetEnumDescription(decision.Title)
+			};
+
+			return result;
+		}
+
+		public static List<DecisionModel> MapDtoToModel(List<GetDecisionResponseDto> decisions)
+		{
+			return decisions.Select(d => MapDtoToModel(d)).ToList();
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionModelService.cs
@@ -1,0 +1,24 @@
+﻿using ConcernsCaseWork.Models.CaseActions;
+using Service.TRAMS.Decision;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ConcernsCaseWork.Services.Decisions
+{
+	public class DecisionModelService : IDecisionModelService
+	{
+		private readonly IDecisionService _decisionService;
+
+		public DecisionModelService(IDecisionService decisionService)
+		{
+			_decisionService = decisionService;
+		}
+
+		public async Task<List<DecisionModel>> GetDecisionsByUrn(long urn)
+		{
+			var decisions = await _decisionService.GetDecisionsByCaseUrn(urn);
+
+			return DecisionMapping.MapDtoToModel(decisions);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/IDecisionModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/IDecisionModelService.cs
@@ -1,0 +1,11 @@
+﻿using ConcernsCaseWork.Models.CaseActions;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ConcernsCaseWork.Services.Decisions
+{
+	public interface IDecisionModelService
+	{
+		public Task<List<DecisionModel>> GetDecisionsByUrn(long urn);
+	}
+}

--- a/ConcernsCaseWork/Service.TRAMS/Decision/DecisionService.cs
+++ b/ConcernsCaseWork/Service.TRAMS/Decision/DecisionService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Service.TRAMS.Base;
 using Service.TRAMS.Helpers;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -29,6 +30,18 @@ namespace Service.TRAMS.Decision
 
 			_logger.LogInformation($"Decision created. caseUrn: {postResponse.ConcernsCaseUrn}, DecisionId:{postResponse.DecisionId}");
 			return postResponse;
+		}
+
+		public async Task<List<GetDecisionResponseDto>> GetDecisionsByCaseUrn(long urn)
+		{
+			_logger.LogInformation($"{nameof(DecisionService)}::{LoggingHelpers.EchoCallerName()}");
+			_logger.LogInformation($"Getting decisions for case urn {urn}");
+
+			var result = await Get<List<GetDecisionResponseDto>>($"/{EndpointsVersion}/concerns-cases/{urn}/decisions");
+
+			_logger.LogInformation($"Retrieved {result.Count} decisions for case urn {urn}");
+
+			return result;
 		}
 	}
 }

--- a/ConcernsCaseWork/Service.TRAMS/Decision/DecisionStatus.cs
+++ b/ConcernsCaseWork/Service.TRAMS/Decision/DecisionStatus.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Service.TRAMS.Decision
+{
+	public enum DecisionStatus
+	{
+		InProgress = 1,
+		Closed = 2,
+	}
+}

--- a/ConcernsCaseWork/Service.TRAMS/Decision/GetDecisionResponseDto.cs
+++ b/ConcernsCaseWork/Service.TRAMS/Decision/GetDecisionResponseDto.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Service.TRAMS.Decision
+{
+	public class GetDecisionResponseDto
+	{
+		public int ConcernsCaseUrn { get; set; }
+
+		public int DecisionId { get; set; }
+
+		public DateTimeOffset CreatedAt { get; set; }
+		public DateTimeOffset UpdatedAt { get; set; }
+
+		public DecisionType Title { get; set; }
+
+		public DecisionStatus DecisionStatus { get; set; }
+
+		public DateTimeOffset? ClosedAt { get; set; }
+	}
+}

--- a/ConcernsCaseWork/Service.TRAMS/Decision/IDecisionService.cs
+++ b/ConcernsCaseWork/Service.TRAMS/Decision/IDecisionService.cs
@@ -1,10 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Service.TRAMS.Decision
 {
 	public interface IDecisionService
 	{
 		Task<CreateDecisionResponseDto> PostDecision(CreateDecisionDto createDecisionDto);
+
+		Task<List<GetDecisionResponseDto>> GetDecisionsByCaseUrn(long urn);
 	}
 }
 

--- a/ConcernsCaseWork/Service.TRAMS/Service.TRAMS.csproj
+++ b/ConcernsCaseWork/Service.TRAMS/Service.TRAMS.csproj
@@ -17,7 +17,4 @@
     <ItemGroup>
       <None Remove="Decision\" />
     </ItemGroup>
-    <ItemGroup>
-      <Folder Include="Decision\" />
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
**What is the change?**

display the active decisions on the case management page

**Why do we need the change?**

as per story 107051, we want to display the active decisions on the case management page

**What is the impact?**

none

**Azure DevOps Ticket**
