### PR TITLE
Update build_test.yml

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,7 +2,7 @@
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ ]
         
 jobs:
   build-test:


### PR DESCRIPTION
Stop this pipeline running on push to main (or indeed ever) as this is now superseded by the new pipelines for Azure. 
It could be deleted but I'm tempted to just effectively disable it for now and delete it properly later.


[Azure DevOps Task 111858](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/111858)