### PR TITLE
Only show concerns records table if there is anything in it (to move the 'add concern' link up)

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -112,58 +112,59 @@
 	                    <tr class="govuk-table__row">
 		                    <th scope="row" class="govuk-table-case-details__header__no_border">Concerns</th>
 		                    <td colspan="2" class="govuk-table-case-details__cell_no_border">
-
-			                    <table class="govuk-table">
-				                    <tbody class="govuk-table__body">
-				                    @foreach (var concern in Model.CaseModel.RecordsModel)
-				                    {
-					                    <tr class="govuk-table__row">
-						                    <td>
-							                    @concern.TypeModel.TypeDisplay
-						                    </td>
-						                    <td>
-							                    <div class="govuk-ragtag-wrapper govuk-!-padding-bottom-1 govuk-!-padding-right-4">
-								                    @{
-									                    if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
-									                    {
-										                    <span class="govuk-tag ragtag ragtag__grey">
-											                    Closed
-										                    </span>
-									                    }
-									                    else
-									                    {
-										                    for (var index = 0; index < concern.RatingModel.RagRating.Item2.Count; ++index)
-										                    {
-											                    <span class="govuk-tag ragtag @concern.RatingModel.RagRatingCss.ElementAt(index)">
-												                    @concern.RatingModel.RagRating.Item2.ElementAt(index)
-											                    </span>
-										                    }
-									                    }
-								                    }
-							                    </div>
-						                    </td>
-						                    <td class="govuk-table__header__right">
-							                    @{
-								                    if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
-								                    {
-									                    <br/>
-								                    }
-								                    else
-								                    {
-									                    <div class="govuk-!-padding-bottom-1">
-										                    @if (Model.IsEditableCase)
-										                    {
-											                    <a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating">Edit</a>
-										                    }
-									                    </div>
-								                    }
-							                    }
-						                    </td>
-					                    </tr>
-				                    }
-				                    </tbody>
-			                    </table>
-
+								@if (Model.CaseModel.RecordsModel.Any())
+								{
+									<table class="govuk-table">
+										<tbody class="govuk-table__body">
+										@foreach (var concern in Model.CaseModel.RecordsModel)
+										{
+											<tr class="govuk-table__row">
+												<td>
+													@concern.TypeModel.TypeDisplay
+												</td>
+												<td>
+													<div class="govuk-ragtag-wrapper govuk-!-padding-bottom-1 govuk-!-padding-right-4">
+														@{
+															if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
+															{
+																<span class="govuk-tag ragtag ragtag__grey">
+																	Closed
+																</span>
+															}
+															else
+															{
+																for (var index = 0; index < concern.RatingModel.RagRating.Item2.Count; ++index)
+																{
+																	<span class="govuk-tag ragtag @concern.RatingModel.RagRatingCss.ElementAt(index)">
+																		@concern.RatingModel.RagRating.Item2.ElementAt(index)
+																	</span>
+																}
+															}
+														}
+													</div>
+												</td>
+												<td class="govuk-table__header__right">
+													@{
+														if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
+														{
+															<br/>
+														}
+														else
+														{
+															<div class="govuk-!-padding-bottom-1">
+																@if (Model.IsEditableCase)
+																{
+																	<a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating">Edit</a>
+																}
+															</div>
+														}
+													}
+												</td>
+											</tr>
+										}
+										</tbody>
+									</table>
+								}
 			                    <div class="govuk-o-grid__item--one-half">
 				                    @if (Model.IsEditableCase)
 				                    {


### PR DESCRIPTION
Cosmetic change to move the 'add concern' link on non-concerns cases. 

[Azure DevOps User Story 112010](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/112010)