### PR TITLE
Add sonarcloud scanning to GitHub workflows

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
       - name: Azure Container Registry login
         uses: docker/login-action@v2
@@ -40,6 +42,43 @@ jobs:
 
       - name: Build Frontend
         run: make build-frontend
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      
+      - name: Install SonarCloud scanners
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Install dotnet reportgenerator
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      
+      - name: Restore dependencies
+        run: dotnet restore ApplyToBecomeInternal/ApplyToBecomeInternal.sln
+      
+      - name: Build solution, test and run SonarCloud scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet-sonarscanner begin /k:"DFE-Digital_amsd-casework" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
+          dotnet build ConcernsCaseWork/ConcernsCaseWork.sln --no-restore
+          dotnet test ConcernsCaseWork/ConcernsCaseWork.sln --no-build --verbosity diagnostic --collect:"XPlat Code Coverage"
+          reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:./ConcernsCaseWork/CoverageReport -reporttypes:SonarQube
+          dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
       - name: Push image
         uses: docker/build-push-action@v3

--- a/.github/workflows/continuous-integration-image-build-test.yml
+++ b/.github/workflows/continuous-integration-image-build-test.yml
@@ -14,6 +14,38 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Install SonarCloud scanners
+        run: dotnet tool install --global dotnet-sonarscanner
+      - name: Install dotnet reportgenerator
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      - name: Restore dependencies
+        run: dotnet restore ApplyToBecomeInternal/ApplyToBecomeInternal.sln
+      - name: Build solution, test and run SonarCloud scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet-sonarscanner begin /k:"DFE-Digital_amsd-casework" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
+          dotnet build ConcernsCaseWork/ConcernsCaseWork.sln --no-restore
+          dotnet test ConcernsCaseWork/ConcernsCaseWork.sln --no-build --verbosity diagnostic --collect:"XPlat Code Coverage"
+          reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:./ConcernsCaseWork/CoverageReport -reporttypes:SonarQube
+          dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
       - name: Build
         run: |


### PR DESCRIPTION
**What is the change?**

Modified GitHub workflows to add SonarCloud scanning onto pull requests

**Why do we need the change?**

RSD strategy is to have code quality scanning across projects. The scanner can highlight potential code smells, security issues, and highlight drops in code coverage

**What is the impact?**

On opened pull requests, a scan will be undertaken on the Concerns solution and tests. The results will be fed into the pull request as a comment and can be viewed on [SonarCloud](https://sonarcloud.io/project/configuration?id=DFE-Digital_amsd-casework).

**Azure DevOps Ticket**

N/a