### PR TITLE
Update continuous-integration-tfsec.yml

### DIFF
--- a/.github/workflows/continuous-integration-tfsec.yml
+++ b/.github/workflows/continuous-integration-tfsec.yml
@@ -9,6 +9,6 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v3
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
**What is the change?**
- Update the aquasecurity/tfsec-pr-commenter-action to version 1.3.1

**Why do we need the change?**
In versions <1.3.0 there was an excessive use of unauthenticated `wget` calls resulting in the action hitting Github API rate limits and causing premature failures.

Related: https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/61