### PR TITLE
Update styles of narrative boxes to show line breaks

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -197,7 +197,7 @@
 					         <a class="govuk-link float__right" href="@Request.Path/edit_issue">Edit</a>
 				         }
 				         <div class="govuk-body details govuk-body-accordion-limit">
-					         <p class="word-break">@Model.CaseModel.Issue</p>
+					         <p class="dfe-text-area-display">@Model.CaseModel.Issue</p>
 				         </div>
 			         </div>
 		         </div>
@@ -214,7 +214,7 @@
 					         <a class="govuk-link float__right" href="@Request.Path/edit_current_status">Edit</a>
 				         }
 				         <div class="govuk-body details govuk-body-accordion-limit">
-					         <p class="word-break">@Model.CaseModel.CurrentStatus</p>
+					         <p class="dfe-text-area-display">@Model.CaseModel.CurrentStatus</p>
 				         </div>
 			         </div>
 		         </div>
@@ -231,7 +231,7 @@
 					         <a class="govuk-link float__right" href="@Request.Path/edit_case_aim">Edit</a>
 				         }
 				         <div class="govuk-body details govuk-body-accordion-limit">
-					         <p class="word-break">@Model.CaseModel.CaseAim</p>
+					         <p class="dfe-text-area-display">@Model.CaseModel.CaseAim</p>
 				         </div>
 			         </div>
 		         </div>
@@ -248,7 +248,7 @@
 					         <a class="govuk-link float__right" href="@Request.Path/edit_de_escalation_point">Edit</a>
 				         }
 				         <div class="govuk-body details govuk-body-accordion-limit">
-					         <p class="word-break">@Model.CaseModel.DeEscalationPoint</p>
+					         <p class="dfe-text-area-display">@Model.CaseModel.DeEscalationPoint</p>
 				         </div>
 			         </div>
 		         </div>
@@ -265,7 +265,7 @@
 					         <a class="govuk-link float__right" href="@Request.Path/edit_next_steps">Edit</a>
 				         }
 				         <div class="govuk-body details govuk-body-accordion-limit">
-					         <p class="word-break">@Model.CaseModel.NextSteps</p>
+					         <p class="dfe-text-area-display">@Model.CaseModel.NextSteps</p>
 				         </div>
 			         </div>
 		         </div>
@@ -281,7 +281,7 @@
                  	         <a class="govuk-link float__right" href="@Request.Path/casehistory">Edit</a>
                          }
                          <div class="govuk-body details govuk-body-accordion-limit">
-                 	         <p class="word-break">@Model.CaseModel.CaseHistory</p>
+                 	         <p class="dfe-text-area-display">@Model.CaseModel.CaseHistory</p>
                          </div>
                      </div>
                  </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
@@ -56,7 +56,7 @@
 						</div>
 						<div aria-labelledby="accordion-default-heading-1" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-1">
 							<div class="govuk-body details govuk-body-accordion-limit">
-								<p class="word-break">@Model.CaseModel.Issue</p>
+								<p class="dfe-text-area-display">@Model.CaseModel.Issue</p>
 							</div>
 						</div>
 					</div>
@@ -69,7 +69,7 @@
 						</div>
 						<div aria-labelledby="accordion-default-heading-2" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-2">
 							<div class="govuk-body details govuk-body-accordion-limit">
-								<p class="word-break">@Model.CaseModel.CurrentStatus</p>
+								<p class="dfe-text-area-display">@Model.CaseModel.CurrentStatus</p>
 							</div>
 						</div>
 					</div>
@@ -82,7 +82,7 @@
 						</div>
 						<div aria-labelledby="accordion-default-heading-3" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-3">
 							<div class="govuk-body details govuk-body-accordion-limit">
-								<p class="word-break">@Model.CaseModel.CaseAim</p>
+								<p class="dfe-text-area-display">@Model.CaseModel.CaseAim</p>
 							</div>
 						</div>
 					</div>
@@ -95,7 +95,7 @@
 						</div>
 						<div aria-labelledby="accordion-default-heading-4" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-4">
 							<div class="govuk-body details govuk-body-accordion-limit">
-								<p class="word-break">@Model.CaseModel.DeEscalationPoint</p>
+								<p class="dfe-text-area-display">@Model.CaseModel.DeEscalationPoint</p>
 							</div>
 						</div>
 					</div>
@@ -108,7 +108,7 @@
 						</div>
 						<div aria-labelledby="accordion-default-heading-5" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-5">
 							<div class="govuk-body details govuk-body-accordion-limit">
-								<p class="word-break">@Model.CaseModel.NextSteps</p>
+								<p class="dfe-text-area-display">@Model.CaseModel.NextSteps</p>
 							</div>
 						</div>
 					</div>
@@ -121,7 +121,7 @@
                     	</div>
                     	<div aria-labelledby="accordion-default-heading-5" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-5">
                     		<div class="govuk-body details govuk-body-accordion-limit">
-                    			<p class="word-break">@Model.CaseModel.CaseHistory</p>
+                    			<p class="dfe-text-area-display">@Model.CaseModel.CaseHistory</p>
                     		</div>
                     	</div>
                     </div>
@@ -134,7 +134,7 @@
 						</div>
 						<div aria-labelledby="accordion-default-heading-6" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-6">
 							<div class="govuk-body details govuk-body-accordion-limit">
-								<p class="word-break">@Model.CaseModel.ReasonAtReview</p>
+								<p class="dfe-text-area-display">@Model.CaseModel.ReasonAtReview</p>
 							</div>
 						</div>
 					</div>

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
@@ -1664,6 +1664,11 @@ span.summary-validation-symbol {
   font-size: 0;
 }
 
+// Respect line breaks
+.dfe-text-area-display {
+  white-space: pre-wrap;
+}
+
 .govuk-ragtag-wrapper {
   font-size: 0;
   display: inline-flex;


### PR DESCRIPTION
**What is the change?**
Text smooshes up into a block on readonly view

**Why do we need the change?**
To enable users to be able to read text clearly

**What is the impact?**
Users can read text in the format they've entered

**Azure DevOps Ticket**
[110100 ](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/110100)