### PR TITLE
Increase size of SRMA notes to 2000

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221117194721_Increase SRMA Notes Size.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221117194721_Increase SRMA Notes Size.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221117194721_Increase SRMA Notes Size")]
+    partial class IncreaseSRMANotesSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221117194721_Increase SRMA Notes Size.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221117194721_Increase SRMA Notes Size.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    public partial class IncreaseSRMANotesSize : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                schema: "concerns",
+                table: "SRMACase",
+                type: "nvarchar(2000)",
+                maxLength: 2000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                schema: "concerns",
+                table: "SRMACase",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(2000)",
+                oldMaxLength: 2000,
+                oldNullable: true);
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/SRMACase.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/SRMACase.cs
@@ -23,7 +23,7 @@ namespace ConcernsCaseWork.Data.Models
         public DateTime? ClosedAt { get; set; }
         public string CreatedBy { get; set; }
 
-        [StringLength(500)]
+        [StringLength(2000)]
         public string Notes { get; set; }
 
         [ForeignKey(nameof(ReasonId))]

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/SRMA/AddPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/SRMA/AddPageModelTests.cs
@@ -190,7 +190,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.SRMA
 
 			var pageModel = SetupAddPageModel(mockSrmaService.Object, mockLogger.Object);
 
-			var exceededNotesLength = "Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data Test Data";
+			var exceededNotesLength = "1".PadLeft(2001);
 
 			var routeData = pageModel.RouteData.Values;
 			routeData.Add("urn", caseUrn);

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/AddSrma.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/AddSrma.cshtml.cs
@@ -29,7 +29,7 @@ namespace ConcernsCaseWork.Pages.Case.CreateCase.NonConcernsCase
 		private readonly ILogger<AddSrmaPageModel> _logger;
 		private readonly IClaimsPrincipalHelper _claimsPrincipalHelper;
 		private readonly ICreateCaseService _createCaseService;
-		private const int _notesMaxLength = 500;
+		private const int _notesMaxLength = 2000;
 		
 		public int NotesMaxLength => _notesMaxLength;
 		public IEnumerable<RadioItem> SRMAStatuses => GetStatuses();

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Add.cshtml.cs
@@ -21,7 +21,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA
 		private readonly ILogger<AddPageModel> _logger;
 		private readonly ISRMAService _srmaModelService;
 
-		public int NotesMaxLength => 500;
+		public int NotesMaxLength => 2000;
 		public IEnumerable<RadioItem> SRMAStatuses => GetStatuses();
 		
 		[BindProperty(SupportsGet = true, Name = "Urn")]

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Edit/Notes.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Edit/Notes.cshtml.cs
@@ -17,7 +17,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA.Edit
 		private readonly ILogger<EditNotesPageModel> _logger;
 
 		public SRMAModel SRMAModel { get; set; }
-		public int NotesMaxLength => 500;
+		public int NotesMaxLength => 2000;
 
 		public EditNotesPageModel(ISRMAService srmaModelService, ILogger<EditNotesPageModel> logger)
 		{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml
@@ -39,13 +39,13 @@
 						</div>
 					</div>
 
-					<div class="govuk-character-count govuk-!-margin-top-6" data-module="govuk-character-count" data-maxlength="500">
+					<div class="govuk-character-count govuk-!-margin-top-6" data-module="govuk-character-count" data-maxlength="2000">
 						<div class="govuk-form-group">
 							<h2 class="govuk-heading-m">Notes</h2>
 							<textarea class="govuk-textarea govuk-js-character-count concern-auto-resize" id="srma-notes" name="srma-notes" rows="3" aria-describedby="srma-notes-info">@Model.SRMAModel.Notes</textarea>
 						</div>
 						<div id="srma-notes-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
-							You can enter up to 500 characters
+							You can enter up to 2000 characters
 						</div>
 					</div>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml.cs
@@ -97,6 +97,14 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA
 				}
 
 				var srmaNotes = Request.Form["srma-notes"].ToString();
+				if (!string.IsNullOrEmpty(srmaNotes))
+				{
+					if (srmaNotes.Length > 2000)
+					{
+						throw new Exception("Notes provided exceed maximum allowed length 2000 characters).");
+					}
+				}
+				
 				await _srmaModelService.SetNotes(srmaId, srmaNotes);
 				await _srmaModelService.SetStatus(srmaId, resolvedStatus);
 				await _srmaModelService.SetDateClosed(srmaId, DateTime.Now);

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
@@ -160,9 +160,9 @@ window.addUsersValidator = function(validator) {
 window.addSRMANotesValidator = function (validator) {
 	validator.addValidator('srma-notes', [{
 		method: function (field) {
-			return field.value.trim().length <= 500;
+			return field.value.trim().length <= 2000;
 		},
-		message: 'Notes must be 500 characters or less'
+		message: 'Notes must be 2000 characters or less'
 	}]);
 }
 window.addFinancialPlanNotesValidator = function (validator) {


### PR DESCRIPTION
**What is the change?**
Increase size of SRMA notes fields to 2000, including UI validation, API validation, and database field size increase

**Why do we need the change?**
So users can enter more text in SRMA notes

**What is the impact?**
UI, API and database *** INCLUDES MIGRATION***

**Azure DevOps Ticket**
[109695](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/109695)
