### PR TITLE
Feature/107054 implement sql lite

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.8.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ConcernsCaseWork.Data\ConcernsCaseWork.Data.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/PocTestUsingSqlLite.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/PocTestUsingSqlLite.cs
@@ -1,0 +1,44 @@
+using ConcernsCaseWork.Data.Gateways;
+using ConcernsCaseWork.Data.Models;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcernsCaseWork.Data.Tests;
+
+[TestFixture]
+public class PocTestUsingSqlLite
+{
+	[Test]
+	public void PocExampleTestUsingSqlLite()
+	{
+		// arrange
+		var connection = new SqliteConnection("DataSource=:memory:");
+		connection.Open();
+ 
+		var options = new DbContextOptionsBuilder<ConcernsDbContext>().UseSqlite(connection).Options;
+ 
+		using (var context = new ConcernsDbContext(options))
+		{
+			context.Database.EnsureCreated();
+		}
+ 
+		var meansOfReferral = new ConcernsMeansOfReferral { Name = "test", Description = "test", CreatedAt = DateTime.Now, UpdatedAt = DateTime.Now };
+		using (var context = new ConcernsDbContext(options))
+		{
+			context.ConcernsMeansOfReferrals.Add(meansOfReferral);
+			context.SaveChanges();
+		}
+ 
+		using (var context = new ConcernsDbContext(options))
+		{
+			var sut = new ConcernsMeansOfReferralGateway(context);
+				
+			// act
+			var result = sut.GetMeansOfReferralById(meansOfReferral.Id);
+				
+			// assert
+			result.Description.Should().Be(meansOfReferral.Description);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/Usings.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
@@ -58,8 +58,6 @@ namespace ConcernsCaseWork.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasSequence<int>("GlobalSequence", "concerns").HasMin(1).StartsAt(1);
-
             modelBuilder.Entity<ConcernsCase>(entity =>
             {
                 entity.ToTable("ConcernsCase", "concerns");
@@ -68,7 +66,7 @@ namespace ConcernsCaseWork.Data
                     .HasName("PK__CCase__C5B214360AF620234");
 
                 entity.Property(e => e.Urn)
-                    .HasDefaultValueSql("NEXT VALUE FOR Concerns.GlobalSequence");
+	                .HasComputedColumnSql("[Id]");
 
                 entity.HasMany(x => x.Decisions)
                     .WithOne();

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221118113155_Change Case Urn to Computed Column.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221118113155_Change Case Urn to Computed Column.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221118113155_Change Case Urn to Computed Column")]
+    partial class ChangeCaseUrntoComputedColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221118113155_Change Case Urn to Computed Column.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221118113155_Change Case Urn to Computed Column.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    public partial class ChangeCaseUrntoComputedColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropSequence(
+                name: "GlobalSequence",
+                schema: "concerns");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Urn",
+                schema: "concerns",
+                table: "ConcernsCase",
+                type: "int",
+                nullable: false,
+                computedColumnSql: "[Id]",
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldDefaultValueSql: "NEXT VALUE FOR Concerns.GlobalSequence");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateSequence<int>(
+                name: "GlobalSequence",
+                schema: "concerns",
+                minValue: 1L);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Urn",
+                schema: "concerns",
+                table: "ConcernsCase",
+                type: "int",
+                nullable: false,
+                defaultValueSql: "NEXT VALUE FOR Concerns.GlobalSequence",
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldComputedColumnSql: "[Id]");
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
@@ -22,7 +22,7 @@ namespace ConcernsCaseWork.Data.Models
         public string NextSteps { get; set; }
         public string DirectionOfTravel { get; set; }
         public string CaseHistory { get; set; }
-        public int Urn { get; set; }
+        public int Urn { get; private set; }
         public int StatusId { get; set; }
         public int RatingId { get; set; }
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
@@ -22,7 +22,7 @@ namespace ConcernsCaseWork.Data.Models
         public string NextSteps { get; set; }
         public string DirectionOfTravel { get; set; }
         public string CaseHistory { get; set; }
-        public int Urn { get; private set; }
+        public int Urn { get; set; }
         public int StatusId { get; set; }
         public int RatingId { get; set; }
 

--- a/ConcernsCaseWork/ConcernsCaseWork.sln
+++ b/ConcernsCaseWork/ConcernsCaseWork.sln
@@ -41,6 +41,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConcernsCaseWork.API.Contra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConcernsCaseWork.API.Contracts.Tests", "ConcernsCaseWork.API.Contracts.Tests\ConcernsCaseWork.API.Contracts.Tests.csproj", "{56E4D701-66D5-4635-8D44-05BA26A2E74B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConcernsCaseWork.Data.Tests", "ConcernsCaseWork.Data.Tests\ConcernsCaseWork.Data.Tests.csproj", "{F099C498-7FDC-47C3-BB7D-D36C71DEEE28}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,10 @@ Global
 		{56E4D701-66D5-4635-8D44-05BA26A2E74B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{56E4D701-66D5-4635-8D44-05BA26A2E74B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{56E4D701-66D5-4635-8D44-05BA26A2E74B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F099C498-7FDC-47C3-BB7D-D36C71DEEE28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F099C498-7FDC-47C3-BB7D-D36C71DEEE28}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F099C498-7FDC-47C3-BB7D-D36C71DEEE28}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F099C498-7FDC-47C3-BB7D-D36C71DEEE28}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**What is the change?**
****** CHANGE ConcernsCase.Urn to be a computed column which references the ID column. THIS IS A BREAKING CHANGE AS IT WILL BREAK ANY TABLES WHICH LINK TO ConcernsCase BY URN. (We should fix these to reference the CaseId instead),

**Why do we need the change?**
The Case Urn appears to be redundant, but we are loth to remove it as it is present throughout the codebase, so this is a compromise to keep it while not needing to implement logic to increment it when a new case is added.
Currently the urn is incremented using a global sequence. It is not possible to use a standard identity insert for this column as there is already identity insert on the ID column, which is the primary key. Sql Lite (and other in-memory databases) don't support global sequence, and as we feel we already have a unique identifier for the case in the ID column, we are removing the global sequence in the Concerns Casework db and changing the Urn to be a computed column referencing Id. 
This opens us up to being able to use in-memory tests using sql lite, rather than at the moment we have to do integration tests on a real database. 

**What is the impact?**
This is a breaking change. As we only have test data so far, I suggest deleting all existing data from the dev and staging dbs after making this change. 
If we do need to keep the data, I can do a manual update before we deploy.

**Azure DevOps Ticket**
[107054](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/107054)