### PR TITLE
Fix missing trust type on overview page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/Trusts/TrustCachedServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/Trusts/TrustCachedServiceTests.cs
@@ -55,6 +55,7 @@ namespace ConcernsCaseWork.Redis.Tests.Trusts
 			Assert.That(actualTrust.GiasData.CompaniesHouseNumber, Is.EqualTo(expectedTrust.GiasData.CompaniesHouseNumber));
 			Assert.That(actualTrust.GiasData.GroupContactAddress, Is.EqualTo(expectedTrust.GiasData.GroupContactAddress));
 			Assert.That(actualTrust.GiasData.GroupTypeCode, Is.EqualTo(expectedTrust.GiasData.GroupTypeCode));
+			Assert.That(actualTrust.GiasData.GroupType, Is.EqualTo(expectedTrust.GiasData.GroupType));
 			
 			mockCacheProvider.Verify(c => c.GetFromCache<IDictionary<string, TrustDetailsDto>>(It.IsAny<string>()), Times.Exactly(2));
 			mockCacheProvider.Verify(c => c.SetCache(It.IsAny<string>(), It.IsAny<IDictionary<string, TrustDetailsDto>>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
@@ -89,6 +90,7 @@ namespace ConcernsCaseWork.Redis.Tests.Trusts
 			Assert.That(actualTrust.GiasData.CompaniesHouseNumber, Is.EqualTo(expectedTrust.GiasData.CompaniesHouseNumber));
 			Assert.That(actualTrust.GiasData.GroupContactAddress, Is.EqualTo(expectedTrust.GiasData.GroupContactAddress));
 			Assert.That(actualTrust.GiasData.GroupTypeCode, Is.EqualTo(expectedTrust.GiasData.GroupTypeCode));
+			Assert.That(actualTrust.GiasData.GroupType, Is.EqualTo(expectedTrust.GiasData.GroupType));
 			
 			mockCacheProvider.Verify(c => c.GetFromCache<IDictionary<string, TrustDetailsDto>>(It.IsAny<string>()), Times.Once);
 			mockCacheProvider.Verify(c => c.SetCache(It.IsAny<string>(), It.IsAny<IDictionary<string, TrustDetailsDto>>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Never);
@@ -124,6 +126,7 @@ namespace ConcernsCaseWork.Redis.Tests.Trusts
 			Assert.That(actualTrust.GiasData.CompaniesHouseNumber, Is.EqualTo(expectedTrust.GiasData.CompaniesHouseNumber));
 			Assert.That(actualTrust.GiasData.GroupContactAddress, Is.EqualTo(expectedTrust.GiasData.GroupContactAddress));
 			Assert.That(actualTrust.GiasData.GroupTypeCode, Is.EqualTo(expectedTrust.GiasData.GroupTypeCode));
+			Assert.That(actualTrust.GiasData.GroupType, Is.EqualTo(expectedTrust.GiasData.GroupType));
 			
 			mockCacheProvider.Verify(c => c.GetFromCache<IDictionary<string, TrustDetailsDto>>(It.IsAny<string>()), Times.Exactly(2));
 			mockCacheProvider.Verify(c => c.SetCache(It.IsAny<string>(), It.IsAny<IDictionary<string, TrustDetailsDto>>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/GiasDataDto.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/GiasDataDto.cs
@@ -13,6 +13,9 @@ namespace ConcernsCaseWork.Service.Trusts
 		[JsonProperty("groupName")]
 		public string GroupName { get; }
 		
+		[JsonProperty("groupType")]
+		public string GroupType { get; }
+		
 		[JsonProperty("groupTypeCode")]
 		public string GroupTypeCode { get; }
 			
@@ -23,7 +26,7 @@ namespace ConcernsCaseWork.Service.Trusts
 		public GroupContactAddressDto GroupContactAddress { get; }
 			
 		[JsonConstructor]
-		public GiasDataDto(string ukprn, string groupId, string groupName, string groupTypeCode, string companiesHouseNumber, GroupContactAddressDto groupContactAddress) => 
-			(UkPrn, GroupId, GroupName, GroupTypeCode, CompaniesHouseNumber, GroupContactAddress) = (ukprn, groupId, groupName, groupTypeCode, companiesHouseNumber, groupContactAddress);
+		public GiasDataDto(string ukprn, string groupId, string groupName, string groupTypeCode, string companiesHouseNumber, GroupContactAddressDto groupContactAddress, string groupType) => 
+			(UkPrn, GroupId, GroupName, GroupTypeCode, CompaniesHouseNumber, GroupContactAddress, GroupType) = (ukprn, groupId, groupName, groupTypeCode, companiesHouseNumber, groupContactAddress, groupType);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/GiasDataFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/GiasDataFactory.cs
@@ -6,26 +6,28 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 {
 	public static class GiasDataFactory
 	{
-		private readonly static Fixture Fixture = new Fixture();
+		private readonly static Fixture _fixture = new Fixture();
 		
 		public static GiasDataDto BuildGiasDataDto(string ukPrn = "trust-ukprn")
 		{
 			return new GiasDataDto(ukPrn, 
-				Fixture.Create<string>(), 
-				Fixture.Create<string>(), 
-				Fixture.Create<string>(), 
-				Fixture.Create<string>(),
-				GroupContactAddressFactory.BuildGroupContactAddressDto());
+				_fixture.Create<string>(), 
+				_fixture.Create<string>(), 
+				_fixture.Create<string>(), 
+				_fixture.Create<string>(),
+				GroupContactAddressFactory.BuildGroupContactAddressDto(),
+				_fixture.Create<string>());
 		}
 		
 		public static GiasDataModel BuildGiasDataModel()
 		{
-			return new GiasDataModel(Fixture.Create<string>(), 
-				Fixture.Create<string>(), 
-				Fixture.Create<string>(), 
-				Fixture.Create<string>(), 
-				Fixture.Create<string>(), 
-				GroupContactAddressFactory.BuildGroupContactAddressModel());
+			return new GiasDataModel(_fixture.Create<string>(), 
+				_fixture.Create<string>(), 
+				_fixture.Create<string>(), 
+				_fixture.Create<string>(), 
+				_fixture.Create<string>(), 
+				GroupContactAddressFactory.BuildGroupContactAddressModel(),
+				_fixture.Create<string>());
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/GiasDataModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/GiasDataModel.cs
@@ -16,6 +16,8 @@ namespace ConcernsCaseWork.Models
 		public string GroupNameTitle { get { return GroupName.ToTitle(); } }
 
 		public string GroupTypeCode { get; }
+		
+		public string GroupType { get; }
 
 		public string CompaniesHouseNumber { get; }
 
@@ -23,8 +25,8 @@ namespace ConcernsCaseWork.Models
 
 		public GroupContactAddressModel GroupContactAddress { get; }
 		
-		public GiasDataModel(string ukprn, string groupId, string groupName, string groupTypeCode, string companiesHouseNumber, GroupContactAddressModel groupContactAddress) =>
-			(UkPrn, GroupId, GroupName, GroupTypeCode, CompaniesHouseNumber, GroupContactAddress) = 
-			(ukprn, groupId, groupName.ToTitle(), groupTypeCode, companiesHouseNumber, groupContactAddress);
+		public GiasDataModel(string ukprn, string groupId, string groupName, string groupTypeCode, string companiesHouseNumber, GroupContactAddressModel groupContactAddress, string groupType) =>
+			(UkPrn, GroupId, GroupName, GroupTypeCode, CompaniesHouseNumber, GroupContactAddress, GroupType) = 
+			(ukprn, groupId, groupName.ToTitle(), groupTypeCode, companiesHouseNumber, groupContactAddress, groupType);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustOverview.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_TrustOverview.cshtml
@@ -8,7 +8,7 @@
 	<div class="govuk-summary-list__row">
 		<dt class="govuk-summary-list__key">Type</dt>
 		<dd class="govuk-summary-list__value">
-			@*@Model.IfdData.TrustType*@
+			@Model.GiasData.GroupType
 		</dd>
 	</div>
 


### PR DESCRIPTION
**What is the change?**
Display the trust type (single / multi academy) on the trust overview pages

**Why do we need the change?**
It should be displayed, but wasn't

**What is the impact?**
UI change

**Azure DevOps Ticket**
[112122](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/112122)
