### PR TITLE
113196: updated decision types text to match design

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Enums/DecisionType.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Enums/DecisionType.cs
@@ -28,7 +28,7 @@ namespace ConcernsCaseWork.API.Contracts.Enums
 	    [Description("Other financial support")]
 	    OtherFinancialSupport = 8,
 
-	    [Description("Other financial support")]
+	    [Description("Estimates funding/Pupil Number Adjustment")]
 	    EstimatesFundingOrPupilNumberAdjustment = 9,
 
 	    [Description("ESFA approval to spend or write-off")]

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Enums/Concerns/DecisionType.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Enums/Concerns/DecisionType.cs
@@ -28,7 +28,7 @@ namespace ConcernsCaseWork.Data.Enums.Concerns
 	    [Description("Other financial support")]
 	    OtherFinancialSupport = 8,
 
-	    [Description("Other financial support")]
+	    [Description("Estimates funding/Pupil Number Adjustment")]
 	    EstimatesFundingOrPupilNumberAdjustment = 9,
 
 	    [Description("ESFA approval to spend or write-off")]


### PR DESCRIPTION
**What is the change?**

second Other financial support changed to Estimates funding/Pupil Number Adjustment

**Why do we need the change?**

Bug was raised about an incorrect design

**What is the impact?**

There are two enums that had to be changed, one for client and one for server, I am not comfortable in merging them for a simple bug so I have updated both

**Azure DevOps Ticket**
