### PR TITLE
Change order of actions in migration as it sometimes fails

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221118113155_Change Case Urn to Computed Column.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221118113155_Change Case Urn to Computed Column.cs
@@ -9,10 +9,6 @@ namespace ConcernsCaseWork.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropSequence(
-                name: "GlobalSequence",
-                schema: "concerns");
-
             migrationBuilder.AlterColumn<int>(
                 name: "Urn",
                 schema: "concerns",
@@ -23,6 +19,10 @@ namespace ConcernsCaseWork.Data.Migrations
                 oldClrType: typeof(int),
                 oldType: "int",
                 oldDefaultValueSql: "NEXT VALUE FOR Concerns.GlobalSequence");
+            
+            migrationBuilder.DropSequence(
+                name: "GlobalSequence",
+                schema: "concerns");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
**What is the change?**
Change the order in which the global sequence is removed in the migration

**Why do we need the change?**
Sometimes the migration failed as the dependencies were in the wrong order 

**What is the impact?**
Fix for migration in db

**Azure DevOps Ticket**
[111349](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/111349)
