### PR TITLE
Fix meansofreferral still referring to urn instead of id

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Records/CreateRecordDto.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Records/CreateRecordDto.cs
@@ -37,14 +37,14 @@ namespace ConcernsCaseWork.Service.Records
 		[JsonProperty("statusId")]
 		public long StatusId { get; }
 		
-		[JsonProperty("meansOfReferralUrn")]
-		public long MeansOfReferralUrn { get; }
+		[JsonProperty("meansOfReferralId")]
+		public long MeansOfReferralId { get; }
 		
 		[JsonConstructor]
 		public CreateRecordDto(DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset reviewAt, DateTimeOffset closedAt, 
 			string name, string description, string reason, long caseUrn, long typeId, 
-			long ratingId, long statusId, long meansOfReferralUrn) => 
-			(CreatedAt, UpdatedAt, ReviewAt, ClosedAt, Name, Description, Reason, CaseUrn, TypeId, RatingId, StatusId, MeansOfReferralUrn) = 
-			(createdAt, updatedAt, reviewAt, closedAt, name, description, reason, caseUrn, typeId, ratingId, statusId, meansOfReferralUrn);
+			long ratingId, long statusId, long meansOfReferralId) => 
+			(CreatedAt, UpdatedAt, ReviewAt, ClosedAt, Name, Description, Reason, CaseUrn, TypeId, RatingId, StatusId, MeansOfReferralId) = 
+			(createdAt, updatedAt, reviewAt, closedAt, name, description, reason, caseUrn, typeId, ratingId, statusId, meansOfReferralId);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/RecordFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/RecordFactory.cs
@@ -65,12 +65,12 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 				1, 1);
 		}
 		
-		public static CreateRecordDto BuildCreateRecordDto(long caseUrn = 1, long typeId = 1, long ratingId = 1, long meansOfReferralUrn = 1)
+		public static CreateRecordDto BuildCreateRecordDto(long caseUrn = 1, long typeId = 1, long ratingId = 1, long meansOfReferralId = 1)
 		{
 			var currentDate = DateTimeOffset.Now;
 			return new CreateRecordDto(currentDate, currentDate, currentDate, currentDate,
 				Fixture.Create<string>(), Fixture.Create<string>(), Fixture.Create<string>(), caseUrn, typeId, ratingId,
-				1, meansOfReferralUrn);
+				1, meansOfReferralId);
 		}
 		
 		public static RecordModel BuildRecordModel(long statusId = 1)


### PR DESCRIPTION
**What is the change?**
Bug fix to change meansofreferralurn to meansofreferralid

**Why do we need the change?**
Means of referral does not save otherwise

**What is the impact?**
Fixes means of referral not saving

**Azure DevOps Ticket**
[113366](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/113366)
