### PR TITLE
113071: decisions date validation

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/concerns-decisions-add-edit-view-to-case.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/concerns-decisions-add-edit-view-to-case.ts
@@ -6,18 +6,26 @@ describe("User can add case actions to an existing case", () => {
 		cy.login();
 	});
 
+	const decisionPage: DecisionPage = new DecisionPage();
+
 	it("Checking that Concerns decision is visible then adding concerns decision case action to a case,  Validation of wrong date when entered", function () {
 		cy.addConcernsDecisionsAddToCase();
 
-		AddToCasePage.getDayDateField().click().type("23");
-		AddToCasePage.getMonthDateField().click().type("25");
-		AddToCasePage.getYearDateField().click().type("2022");
-		AddToCasePage.getDecisionButton().click();
+		decisionPage
+			.withDateESFADay("23")
+			.withDateESFAMonth("25")
+			.withDateESFAYear("2022")
+			.saveDecision()
+			.hasValidationError("23-25-2022 is an invalid date");
 
-		cy.get("#decision-error-list").should(
-			"contain.text",
-			"23-25-2022 is an invalid date"
-		);
+		decisionPage
+			.withDateESFADay("23")
+			.withDateESFAMonth("12")
+			.withDateESFAYear("")
+			.withSupportingNotesExceedingLimit()
+			.saveDecision()
+			.hasValidationError("Please enter a complete date DD MM YYYY")
+			.hasValidationError("Notes must be 2000 characters or less");
 	});
 
 	it(" Concern Decision - Checking if View live initial record is visible", function () {
@@ -32,8 +40,6 @@ describe("User can add case actions to an existing case", () => {
 			"Decision: Notice to Improve"
 		);
 	});
-
-	const decisionPage: DecisionPage = new DecisionPage();
 
 	it(" Concern Decision - Creating a Decision and validating data is visible for this decision", function () {
 		cy.addConcernsDecisionsAddToCase();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/concerns-decisions-add-edit-view-to-case.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/concerns-decisions-add-edit-view-to-case.ts
@@ -1,14 +1,18 @@
-import AddToCasePage from "../../../pages/caseActions/addToCasePage.js";
 import { DecisionPage } from "../../../pages/caseActions/decisionPage"
 
 describe("User can add case actions to an existing case", () => {
+	const decisionPage: DecisionPage = new DecisionPage();
+
 	beforeEach(() => {
 		cy.login();
 	});
 
-	const decisionPage: DecisionPage = new DecisionPage();
+	after(function () {
+		cy.clearLocalStorage();
+		cy.clearCookies();
+	});
 
-	it("Checking that Concerns decision is visible then adding concerns decision case action to a case,  Validation of wrong date when entered", function () {
+	it(" Concern Decision - Creating a Decision and validating data is visible for this decision", function () {
 		cy.addConcernsDecisionsAddToCase();
 
 		decisionPage
@@ -26,23 +30,6 @@ describe("User can add case actions to an existing case", () => {
 			.saveDecision()
 			.hasValidationError("Please enter a complete date DD MM YYYY")
 			.hasValidationError("Notes must be 2000 characters or less");
-	});
-
-	it(" Concern Decision - Checking if View live initial record is visible", function () {
-		cy.addConcernsDecisionsAddToCase();
-		AddToCasePage.getDayDateField().click().type("12");
-		AddToCasePage.getMonthDateField().click().type("05");
-		AddToCasePage.getYearDateField().click().type("2022");
-		AddToCasePage.getNoticeToImproveBtn().click();
-		AddToCasePage.getDecisionButton().click();
-		cy.get("#open-case-actions").should(
-			"contain.text",
-			"Decision: Notice to Improve"
-		);
-	});
-
-	it(" Concern Decision - Creating a Decision and validating data is visible for this decision", function () {
-		cy.addConcernsDecisionsAddToCase();
 
 		decisionPage
 			.withCrmEnquiry("444")
@@ -55,8 +42,9 @@ describe("User can add case actions to an existing case", () => {
 			.withTypeOfDecisionID("NoticeToImprove")
 			.withTypeOfDecisionID("Section128")
 			.withTotalAmountRequested("£140,000")
-			.withSupportingNotes("These are some supporting notes!");
-		AddToCasePage.getDecisionButton().click();
+			.withSupportingNotes("These are some supporting notes!")
+			.saveDecision();
+
 		cy.get("#open-case-actions td")
 			.should("contain.text", "Decision: Notice to Improve (NTI)")
 			.eq(-3)
@@ -85,8 +73,8 @@ describe("User can add case actions to an existing case", () => {
 			.withDateESFAYear("2022")
 			.withTypeOfDecisionID("QualifiedFloatingCharge")
 			.withTotalAmountRequested("£130,000")
-			.withSupportingNotes("Testing Supporting Notes");
-		AddToCasePage.getDecisionButton().click();
+			.withSupportingNotes("Testing Supporting Notes")
+			.saveDecision();
 
 		decisionPage
 			.hasCrmEnquiry("777")
@@ -98,13 +86,17 @@ describe("User can add case actions to an existing case", () => {
 			.hasTypeOfDecision("Qualified Floating Charge (QFC)")
 			.hasSupportingNotes("Testing Supporting Notes");
 	});
+
 	it("When Decisions is empty, View Behavior", function () {
 		cy.addConcernsDecisionsAddToCase();
-		AddToCasePage.getDecisionButton().click();
+
+		decisionPage.saveDecision();
+
 		cy.get("#open-case-actions td")
 			.should("contain.text", "Decision: Notice to Improve (NTI)")
 			.eq(-3)
 			.click();
+
 		decisionPage
 			.hasCrmEnquiry("Empty")
 			.hasRetrospectiveRequest("No")
@@ -114,9 +106,5 @@ describe("User can add case actions to an existing case", () => {
 			.hasTotalAmountRequested("£0.00")
 			.hasTypeOfDecision("Empty")
 			.hasSupportingNotes("Empty");
-	});
-	after(function () {
-		cy.clearLocalStorage();
-		cy.clearCookies();
 	});
 });

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/decisionPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/decisionPage.ts
@@ -22,13 +22,13 @@ export class DecisionPage {
 	public withSubmissionRequired(isSubmissionRequired: Boolean): this {
 		cy.task("log", `With Submission Required ${isSubmissionRequired}`);
 
-        if (isSubmissionRequired) {
+		if (isSubmissionRequired) {
 			cy.getById("submission-required").click();
 		} else {
 			cy.getById("submission-required-1").click();
 		}
 
-				return this;
+		return this;
 	}
 
 	public withSubmissionLink(submissionLink: string): this {
@@ -48,7 +48,7 @@ export class DecisionPage {
 		return this;
 	}
 
-    public withDateESFAMonth(dateESFAMonth: string): this {
+	public withDateESFAMonth(dateESFAMonth: string): this {
 		cy.task(
 			"log", `With Date ESFA Month ${dateESFAMonth}`
 		);
@@ -58,16 +58,21 @@ export class DecisionPage {
 		return this;
 	}
 
- public withDateESFAYear(dateESFAYear: string): this {
+	public withDateESFAYear(dateESFAYear: string): this {
 		cy.task(
 			"log", `With Date ESFA Year ${dateESFAYear}`
 		);
 
-		cy.getById("dtr-year-request-received").clear().type(dateESFAYear);
+		const element = cy.getById("dtr-year-request-received");
+		element.clear();
+
+		if (dateESFAYear.length > 0) {
+			element.type(dateESFAYear);
+		}
 
 		return this;
 	}
-    public withTypeOfDecisionID(typeOfDecisionID: string): this {
+	public withTypeOfDecisionID(typeOfDecisionID: string): this {
 		cy.task("log", `With type of decision to pick ${typeOfDecisionID}`);
 
 		cy.getById(typeOfDecisionID).click();
@@ -83,7 +88,7 @@ export class DecisionPage {
 		return this;
 	}
 
-	
+
 	public withSupportingNotes(supportingNotes: string): this {
 		cy.task("log", `With Supporting Notes ${supportingNotes}`);
 
@@ -92,6 +97,30 @@ export class DecisionPage {
 		return this;
 	}
 
+	public withSupportingNotesExceedingLimit(): this {
+		cy.task("log", `With Supporting Notes exceeding limit`);
+
+		cy.getById("case-decision-notes").clear().invoke("val", "x".repeat(2001));
+
+		return this;
+	}
+
+	public saveDecision(): this {
+		cy.get('#add-decision-button').click();
+
+		return this;
+	}
+
+	public hasValidationError(message: string): this {
+		cy.task("log", `Has Validation error ${message}`);
+
+		cy.get("#decision-error-list").should(
+			"contain.text",
+			message
+		);
+
+		return this;
+	}
 
 	public hasCrmEnquiry(crmNumber: string): this {
 		cy.task("log", `Has CRM enquiry ${crmNumber}`);
@@ -188,9 +217,6 @@ export class DecisionPage {
 
 		cy.getByTestId("edit-decision-text").children('a').click();
 
-
 		return this;
 	}
-
-
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Models/Validatable/OptionalDateModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Models/Validatable/OptionalDateModelTests.cs
@@ -1,0 +1,106 @@
+﻿using AutoFixture;
+using ConcernsCaseWork.Models.Validatable;
+using FluentAssertions;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcernsCaseWork.Tests.Models.Validatable
+{
+	[Parallelizable(ParallelScope.All)]
+	public class OptionalDateModelTests
+	{
+		private readonly IFixture _fixture = new Fixture();
+		private ValidationContext _validationContext;
+
+		[SetUp]
+		public void Setup()
+		{
+			_validationContext = _fixture.Create<ValidationContext>();
+		}
+
+		[Test]
+		public void When_DateIsValid_Returns_NoValidationErrors()
+		{
+			var model = new OptionalDateModel()
+			{
+				Day = "22",
+				Month = "06",
+				Year = "2022"
+			};
+
+			var result = model.Validate(_validationContext);
+
+			result.Should().BeEmpty();
+		}
+
+		[Test]
+		public void When_DateIsEmpty_Returns_NoValidationErrors()
+		{
+			var model = new OptionalDateModel();
+
+			var result = model.Validate(_validationContext);
+
+			result.Should().BeEmpty();
+		}
+
+		[Test]
+		public void When_NotAllFieldsFilled_Returns_CompleteDateValidationError()
+		{
+			var model = new OptionalDateModel()
+			{
+				Day = "22"
+			};
+
+			var result = model.Validate(_validationContext);
+
+			var expected = new List<ValidationResult>()
+			{
+				new ValidationResult("Please enter a complete date DD MM YYYY")
+			};
+
+			result.Should().BeEquivalentTo(expected);
+		}
+
+		[Test]
+		public void When_WhenDateIsInvalid_Returns_DateIsInvalidError()
+		{
+			var model = new OptionalDateModel()
+			{
+				Day = "22",
+				Month = "22",
+				Year = "2022"
+			};
+
+			var result = model.Validate(_validationContext);
+
+			var expected = new List<ValidationResult>()
+			{
+				new ValidationResult("22-22-2022 is an invalid date")
+			};
+
+			result.Should().BeEquivalentTo(expected);
+		}
+
+		[Test]
+		public void IsEmpty_When_DateIsEmpty_Returns_True()
+		{
+			var model = new OptionalDateModel();
+
+			model.IsEmpty().Should().BeTrue();
+		}
+
+		[Test]
+		public void IsEmpty_When_DateIsNotEmpty_Returns_False()
+		{
+			var model = new OptionalDateModel()
+			{
+				Day = "22",
+				Month = "22",
+				Year = "2022"
+			};
+
+			model.IsEmpty().Should().BeFalse();
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/AddPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/AddPageModelTests.cs
@@ -184,7 +184,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 		}
 
 		[Test]
-		public async Task OnPostAsync_When_DateIsNotSet_Returns_NullDate()
+		public async Task OnPostAsync_When_DateIsNotSet_Returns_MinDate()
 		{
 			const long expectedUrn = 2;
 			var builder = new TestBuilder();
@@ -196,7 +196,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 
 			var page = await sut.OnPostAsync(expectedUrn);
 
-			sut.Decision.ReceivedRequestDate.Should().BeNull();
+			sut.Decision.ReceivedRequestDate.Should().Be(DateTime.MinValue);
 			sut.TempData[ErrorConstants.ErrorMessageKey].Should().BeNull();
 		}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/AddPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/AddPageModelTests.cs
@@ -78,6 +78,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 				API.Contracts.Enums.DecisionType.NoticeToImprove,
 				API.Contracts.Enums.DecisionType.OtherFinancialSupport
 			};
+			getDecisionResponse.ReceivedRequestDate = new DateTimeOffset(new DateTime(2022, 5, 2));
 
 			var decisionService = new Mock<IDecisionService>();
 			decisionService.Setup(m => m.GetDecision(2, 1)).ReturnsAsync(getDecisionResponse);
@@ -98,6 +99,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 			sut.Decision.CrmCaseNumber.Should().Be(getDecisionResponse.CrmCaseNumber);
 			sut.Decision.DecisionTypes.Should().BeEquivalentTo(getDecisionResponse.DecisionTypes);
 			sut.Decision.SupportingNotes.Should().Be(getDecisionResponse.SupportingNotes);
+			sut.ReceivedRequestDate.Day.Should().Be("02");
+			sut.ReceivedRequestDate.Month.Should().Be("05");
+			sut.ReceivedRequestDate.Year.Should().Be("2022");
 		}
 
 		[Test]

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/AddPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/AddPageModelTests.cs
@@ -1,30 +1,28 @@
 ﻿using AutoFixture;
-using NUnit.Framework;
-using System.Threading.Tasks;
-using ConcernsCaseWork.Pages.Case.Management.Action.Decision;
-using ConcernsCaseWork.Pages.Base;
-using Microsoft.Extensions.Logging;
-using Moq;
 using AutoFixture.AutoMoq;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using ConcernsCaseWork.Shared.Tests.Factory;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Routing;
+using ConcernsCaseWork.API.Contracts.Enums;
+using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
+using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
+using ConcernsCaseWork.Constants;
+using ConcernsCaseWork.Models.Validatable;
+using ConcernsCaseWork.Pages.Base;
+using ConcernsCaseWork.Pages.Case.Management.Action.Decision;
 using ConcernsCaseWork.Service.Decision;
+using ConcernsCaseWork.Shared.Tests.Factory;
+using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using Moq;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
-using FluentAssertions;
-using NUnit.Framework.Constraints;
-using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
-using System;
-using ConcernsCaseWork.Constants;
-using Azure;
-using ConcernsCaseWork.API.Contracts.Enums;
-using System.Transactions;
+using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 {
@@ -143,11 +141,19 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 				.WithCaseUrnRouteValue(expectedUrn)
 				.BuildSut();
 
+			sut.ReceivedRequestDate = new OptionalDateModel()
+			{
+				Day = "22",
+				Month = "05",
+				Year = "2022"
+			};
+
 			var page = await sut.OnPostAsync(expectedUrn) as RedirectResult;
 
 			sut.CaseUrn.Should().Be(expectedUrn);
 			page.Url.Should().Be("/case/2/management");
 			sut.Decision.DecisionTypes.Should().BeEmpty();
+			sut.Decision.ReceivedRequestDate.Should().NotBeNull();
 		}
 
 		[Test]
@@ -163,10 +169,35 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 				DecisionType.NonRepayableFinancialSupport
 			};
 
+			sut.ReceivedRequestDate = new OptionalDateModel()
+			{
+				Day = "22",
+				Month = "05",
+				Year = "2022"
+			};
+
 			var page = await sut.OnPostAsync(expectedUrn, 1) as RedirectResult;
 
 			page.Url.Should().Be("/case/2/management/action/decision/1");
 			sut.Decision.DecisionTypes.Should().Contain(DecisionType.NonRepayableFinancialSupport);
+			sut.Decision.ReceivedRequestDate.Should().NotBeNull();
+		}
+
+		[Test]
+		public async Task OnPostAsync_When_DateIsNotSet_Returns_NullDate()
+		{
+			const long expectedUrn = 2;
+			var builder = new TestBuilder();
+			var sut = builder
+				.WithCaseUrnRouteValue(expectedUrn)
+				.BuildSut();
+
+			sut.ReceivedRequestDate = new OptionalDateModel();
+
+			var page = await sut.OnPostAsync(expectedUrn);
+
+			sut.Decision.ReceivedRequestDate.Should().BeNull();
+			sut.TempData[ErrorConstants.ErrorMessageKey].Should().BeNull();
 		}
 
 
@@ -179,13 +210,12 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 				.WithCaseUrnRouteValue(expectedUrn)
 				.BuildSut();
 
-			sut.HttpContext.Request.Form = new FormCollection(
-				new Dictionary<string, StringValues>
-				{
-					{ "dtr-day-request-received", new StringValues("19") },
-					{ "dtr-month-request-received", new StringValues("10") },
-					{ "dtr-year-request-received", new StringValues("2022") }
-				});
+			sut.ReceivedRequestDate = new OptionalDateModel()
+			{
+				Day = "19",
+				Month = "10",
+				Year = "2022"
+			};
 
 			await sut.OnPostAsync(expectedUrn);
 
@@ -232,38 +262,6 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 			sut.DecisionTypeCheckBoxes.Should().NotBeEmpty();
 			sut.ViewData[ViewDataConstants.Title].Should().Be("Add decision");
 		}
-
-		[Test]
-		public async Task OnPostAsync_When_InvalidDate_Error_Message()
-		{
-			long caseUrn = 233433;
-			var invalidDay = "32";
-			var invalidMonth = "13";
-			var invalidYear = "7";
-
-			var expectedErrorMessage = $"{invalidDay}-{invalidMonth}-{invalidYear} is an invalid date";
-
-			var builder = new TestBuilder()
-				.WithCaseUrnRouteValue(caseUrn);
-
-			var sut = builder.BuildSut();
-
-			sut.HttpContext.Request.Form = new FormCollection(
-				new Dictionary<string, StringValues>
-				{
-					{ "dtr-day-request-received", new StringValues(invalidDay) },
-					{ "dtr-month-request-received", new StringValues(invalidMonth) },
-					{ "dtr-year-request-received", new StringValues(invalidYear) }
-				});
-
-
-			await sut.OnPostAsync(caseUrn);
-
-			var decisionsValidationErrors = sut.TempData["Decision.Message"] as IEnumerable<string>;
-
-			Assert.IsTrue(decisionsValidationErrors.Contains(expectedErrorMessage));
-		}
-
 
 		private class TestBuilder
 		{

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/Validatable/OptionalDateModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/Validatable/OptionalDateModel.cs
@@ -16,9 +16,14 @@ namespace ConcernsCaseWork.Models.Validatable
 			var result = new List<ValidationResult>();
 
 			var dateValues = new List<string>() { Day, Month, Year };
-			dateValues.RemoveAll(d => d == "");
+			dateValues.RemoveAll(d => d == null);
 
-			if (dateValues.Count != 3 && dateValues.Count != 0)
+			if (dateValues.Count == 0)
+			{
+				return result;
+			}
+
+			if (dateValues.Count != 3)
 			{
 				result.Add(new ValidationResult("Please enter a complete date DD MM YYYY"));
 				return result;
@@ -30,6 +35,11 @@ namespace ConcernsCaseWork.Models.Validatable
 			}
 
 			return result;
+		}
+
+		public bool IsEmpty()
+		{
+			return ToString() == "--";
 		}
 
 		public override string ToString() => $"{Day}-{Month}-{Year}";

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/Validatable/OptionalDateModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/Validatable/OptionalDateModel.cs
@@ -1,0 +1,37 @@
+﻿using ConcernsCaseWork.Helpers;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcernsCaseWork.Models.Validatable
+{
+	public record OptionalDateModel : IValidatableObject
+	{
+		public string Day { get; set; }
+		public string Month { get; set; }
+		public string Year { get; set; }
+
+		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+		{
+			var result = new List<ValidationResult>();
+
+			var dateValues = new List<string>() { Day, Month, Year };
+			dateValues.RemoveAll(d => d == "");
+
+			if (dateValues.Count != 3 && dateValues.Count != 0)
+			{
+				result.Add(new ValidationResult("Please enter a complete date DD MM YYYY"));
+				return result;
+			}
+
+			if (!DateTimeHelper.TryParseExact(ToString(), out _))
+			{
+				result.Add(new ValidationResult($"{ToString()} is an invalid date"));
+			}
+
+			return result;
+		}
+
+		public override string ToString() => $"{Day}-{Month}-{Year}";
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
@@ -201,7 +201,7 @@
 											Day
 										</label>
 										<input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dtr-day-request-received"
-										   name="dtr-day-request-received" type="text" maxlength="2" inputmode="numeric" value="@($"{Model.Decision.ReceivedRequestDate?.Day:00}")" />
+										   name="ReceivedRequestDate.Day" type="text" maxlength="2" inputmode="numeric" value="@($"{Model.ReceivedRequestDate?.Day:00}")" />
 									</div>
 								</div>
 								<div class="govuk-date-input__item">
@@ -210,7 +210,7 @@
 											Month
 										</label>
 										<input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dtr-month-request-received"
-										   name="dtr-month-request-received" type="text" maxlength="2" inputmode="numeric" value="@($"{Model.Decision.ReceivedRequestDate?.Month:00}")" />
+										   name="ReceivedRequestDate.Month" type="text" maxlength="2" inputmode="numeric" value="@($"{Model.ReceivedRequestDate?.Month:00}")" />
 									</div>
 								</div>
 								<div class="govuk-date-input__item">
@@ -219,7 +219,7 @@
 											Year
 										</label>
 										<input class="govuk-input govuk-date-input__input govuk-input--width-4" id="dtr-year-request-received"
-										   name="dtr-year-request-received" type="text" maxlength="4" inputmode="numeric" value="@($"{Model.Decision.ReceivedRequestDate?.Year}")" />
+										   name="ReceivedRequestDate.Year" type="text" maxlength="4" inputmode="numeric" value="@($"{Model.ReceivedRequestDate?.Year}")" />
 									</div>
 								</div>
 							</div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
@@ -310,7 +310,6 @@
 					}
 
 					$(function () {
-						let validator = formValidator($("#add-decision-form")[0]);
 
 						$totalAmountRequestedObj = $('#total-amount-request');
 
@@ -321,33 +320,6 @@
 						$totalAmountRequestedObj.focusout(function () {
 							formatCurrency($totalAmountRequestedObj);
 						});
-
-						validator.addValidator('dtr-day-request-received', [{
-						  method: function(field, params) {
-							  return noDateOrCompleteDate(params.year.value, params.month.value, params.day.value);
-						  },
-						  message: 'Please enter a complete date (DD MM YYYY)',
-						  params: {
-							day: document.getElementById('dtr-day-request-received'),
-							month: document.getElementById('dtr-month-request-received'),
-							year: document.getElementById('dtr-year-request-received')
-						  }
-						}]);
-
-						function noDateOrCompleteDate(year, month, day) {
-							var missingValuesCount = 0;
-							if(year.length == 0) {
-								missingValuesCount++;
-							}
-							if(month.length == 0) {
-								missingValuesCount++;
-							}
-							if(day.length == 0) {
-								missingValuesCount++;
-							}
-							return missingValuesCount == 0 || missingValuesCount == 3; @* the date should be either empty or valid *@
-						}
-
 
 						autoResizer();
 					});

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
@@ -63,8 +63,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 
 				ReceivedRequestDate = new OptionalDateModel()
 				{
-					Day = Decision.ReceivedRequestDate?.Day.ToString(),
-					Month = Decision.ReceivedRequestDate?.Month.ToString(),
+					Day = Decision.ReceivedRequestDate?.Day.ToString("00"),
+					Month = Decision.ReceivedRequestDate?.Month.ToString("00"),
 					Year = Decision.ReceivedRequestDate?.Year.ToString()
 				};
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
@@ -147,7 +147,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 			return result;
 		}
 
-		private DateTime? ParseDate(OptionalDateModel date)
+		private DateTime ParseDate(OptionalDateModel date)
 		{
 			if (date.IsEmpty())
 			{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
@@ -151,7 +151,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 		{
 			if (date.IsEmpty())
 			{
-				return null;
+				return new DateTime();
 			}
 
 			var result = DateTimeHelper.ParseExact(date.ToString());


### PR DESCRIPTION
**What is the change?**

Decision page now uses a custom date validator for checking dates
This validator can be reused in all other pages
Currently only supports optional dates
Also includes cypress tests to validate behaviour

**Why do we need the change?**
Fixes bug 113071

**What is the impact?**

**Azure DevOps Ticket**
