### PR TITLE
Add api key check to startup middleware and fix incorrect api key name

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -31,7 +31,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
         public ConcernsIntegrationTests(ConcernsDataApiFactory fixture)
         {
             _client = fixture.CreateClient();
-            _client.DefaultRequestHeaders.Add("ConcernsApiKey", "app-key");
+            _client.DefaultRequestHeaders.Add("ApiKey", "app-key");
             _dbContext = fixture.Services.GetRequiredService<ConcernsDbContext>();
             _fixture = new Fixture();
             _randomGenerator = new RandomGenerator();

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/ApiKeyMiddleware.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/ApiKeyMiddleware.cs
@@ -5,30 +5,35 @@ namespace ConcernsCaseWork.API.Middleware
     public class ApiKeyMiddleware
     {
         private readonly RequestDelegate _next;
-        private const string APIKEYNAME = "ConcernsApiKey";
+        private const string APIKEYNAME = "ApiKey";
         public ApiKeyMiddleware(RequestDelegate next)
         {
             _next = next;
         }
         public async Task InvokeAsync(HttpContext context, IUseCase<string, bool> apiKeyValidationService)
         {
-            if (!context.Request.Headers.TryGetValue(APIKEYNAME, out var extractedApiKey))
-            {
-                context.Response.StatusCode = 401;
-                await context.Response.WriteAsync("Api Key was not provided.");
-                return;
-            }
- 
-            var isKeyValid = apiKeyValidationService.Execute(extractedApiKey);
-            
-            if (!isKeyValid)
-            {
-                context.Response.StatusCode = 401;
-                await context.Response.WriteAsync("Unauthorized client.");
-                return;
-            }
+	        if (IsApiCall(context))
+	        {
+		        if (!context.Request.Headers.TryGetValue(APIKEYNAME, out var extractedApiKey))
+		        {
+			        context.Response.StatusCode = 401;
+			        await context.Response.WriteAsync("Api Key was not provided.");
+			        return;
+		        }
 
-            await _next(context);
+		        var isKeyValid = apiKeyValidationService.Execute(extractedApiKey);
+
+		        if (!isKeyValid)
+		        {
+			        context.Response.StatusCode = 401;
+			        await context.Response.WriteAsync("Unauthorized client.");
+			        return;
+		        }
+	        }
+
+	        await _next(context);
         }
+
+        private bool IsApiCall(HttpContext context) => context.Request.Path.HasValue && context.Request.Path.Value!.StartsWith("/v2");
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/AuthenticationHeaderOperationFilter.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/AuthenticationHeaderOperationFilter.cs
@@ -11,7 +11,7 @@ namespace ConcernsCaseWork.API.StartupConfiguration
             
             var securityScheme = new OpenApiSecurityScheme
             {
-                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ConcernsApiKey" }
+                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ApiKey" }
             };
             
             operation.Security.Add(new OpenApiSecurityRequirement {{ securityScheme, new List<string>() }});

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/SwaggerOptions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/SwaggerOptions.cs
@@ -9,13 +9,13 @@ namespace ConcernsCaseWork.API.StartupConfiguration
     {
         private readonly IApiVersionDescriptionProvider _provider;
 
-        private const string ApiKeyName = "ConcernsApiKey";
+        private const string ApiKeyName = "ApiKey";
         private const string ServiceTitle = "Concerns Casework API";
         private const string ServiceDescription = "Concerns Casework API";
         private const string ContactName = "Support";
         private const string ContactEmail = "servicedelivery.rdd@education.gov.uk";
 
-        private const string SecuritySchemeDescription = "A valid ApiKey in the 'ConcernsApiKey' header is required to " +
+        private const string SecuritySchemeDescription = "A valid ApiKey in the 'ApiKey' header is required to " +
                                                          "access the Concerns Casework API.";
         private const string DeprecatedMessage = "- API version has been deprecated.";
         

--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -126,6 +126,7 @@ namespace ConcernsCaseWork
 			}
 			
 			app.UseMiddleware<ExceptionHandlerMiddleware>();
+			app.UseMiddleware<ApiKeyMiddleware>();
 			
 			// Security headers
 			app.UseSecurityHeaders(


### PR DESCRIPTION
**What is the change?**
Ensure api key is required for API calls

**Why do we need the change?**
Security, so that systems without the API key can't call it

**What is the impact?**
All API calls should require a security key in the header

**Azure DevOps Ticket**
[113517](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/113517)
