### PR TITLE
Update _ListClosedActionsForCase.cshtml

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ListClosedActionsForCase.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ListClosedActionsForCase.cshtml
@@ -1,19 +1,19 @@
-﻿@using ConcernsCaseWork.Models.CaseActions
+@using ConcernsCaseWork.Models.CaseActions
 @model IList<ConcernsCaseWork.Models.CaseActions.ActionSummaryModel>
 
 <table id="close-case-actions" class="govuk-table">
     <thead class="govuk-table__head">
         <tr class="govuk-table__row tr__large">
-            <th class="govuk-table__header govuk-table__cell__cases" scope="col">
+            <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_30" scope="col">
                 Closed actions and decisions
             </th>
-	        <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
+	        <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_30" scope="col">
 	        </th>
 	        <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
-		        Date Opened
+		        Date opened
 	        </th>
-            <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
-                Date Closed
+            <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right govuk-table__header__width_15" scope="col">
+                Date closed
             </th>
         </tr>
     </thead>


### PR DESCRIPTION
**What is the change?**
Changing the heading on the closed actions table pushed the formatting out of the other column headings, so they wrapped onto a new line

**Why do we need the change?**
Poor UI experience

**What is the impact?**
The headings in the closed actions table should be on one line and evenly spaced.

**Azure DevOps Ticket**
[113537](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/113537)
