### PR TITLE
updating release number for release 6

### DIFF
--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -14,7 +14,7 @@ jobs:
       version: ${{steps.release-version.outputs.version}}
     steps:
       - id: release-version
-        run: echo "::set-output name=version::release-5"
+        run: echo "::set-output name=version::release-6"
 
   build-and-push-image-test:
     name: Build and push image test


### PR DESCRIPTION
updated to release 6

**What is the change?**
release 6 - vulnerability fix required before pen-testing

**Why do we need the change?**
to secure the api

**What is the impact?**
more secure api

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2032?workitem=113848