### PR TITLE
Feature/112709 update nuget packages

### DIFF
--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -14,7 +14,7 @@ jobs:
       version: ${{steps.release-version.outputs.version}}
     steps:
       - id: release-version
-        run: echo "::set-output name=version::release-5"
+        run: echo "::set-output name=version::release-6"
 
   build-and-push-image-test:
     name: Build and push image test

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts.Tests/ConcernsCaseWork.API.Contracts.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts.Tests/ConcernsCaseWork.API.Contracts.Tests.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts.Tests/ConcernsCaseWork.API.Contracts.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts.Tests/ConcernsCaseWork.API.Contracts.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts.Tests/ConcernsCaseWork.API.Contracts.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts.Tests/ConcernsCaseWork.API.Contracts.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NBuilder" Version="6.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -14,7 +14,6 @@
         <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.15" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NBuilder" Version="6.1.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NBuilder" Version="6.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
+        <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -20,12 +20,12 @@
         <PackageReference Include="NBuilder" Version="6.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NBuilder" Version="6.1.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -25,7 +25,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="1.3.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NBuilder" Version="6.1.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -12,11 +12,11 @@
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.15" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="Moq" Version="4.16.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NBuilder" Version="6.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/ConcernsCaseWork.API.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NBuilder" Version="6.1.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
@@ -48,7 +48,7 @@ public class GetDecisionResponseFactoryTests
                 );
             result.DecisionTypes.Should().BeEquivalentTo(decision.DecisionTypes.Select(x => x.DecisionTypeId),
                 opt => opt.WithStrictOrdering());
-            result.DecisionStatus.Should().Be(decision.Status);
+            result.DecisionStatus.Should().HaveSameValueAs(decision.Status);
             result.Title.Should().Be(decision.GetTitle());
         }
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
         public ConcernsIntegrationTests(ConcernsDataApiFactory fixture)
         {
             _client = fixture.CreateClient();
-            _client.DefaultRequestHeaders.Add("ConcernsApiKey", "app-key");
+            _client.DefaultRequestHeaders.Add("ApiKey", "app-key");
             _dbContext = fixture.Services.GetRequiredService<ConcernsDbContext>();
             _fixture = new Fixture();
             _randomGenerator = new RandomGenerator();

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -13,6 +13,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using ConcernsCaseWork.Data;
 using ConcernsCaseWork.Data.Models;
+using System.Net;
 using Xunit;
 
 namespace ConcernsCaseWork.API.Tests.Integration
@@ -57,7 +58,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 .With(c => c.StatusId = 1)
                 .With(c => c.RatingId = 2)
                 .Build();
-            
+
 
             var httpRequestMessage = new HttpRequestMessage
             {
@@ -68,16 +69,16 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
             var caseToBeCreated = ConcernsCaseFactory.Create(createRequest);
             var expectedConcernsCaseResponse = ConcernsCaseResponseFactory.Create(caseToBeCreated);
-            
+
             var expected = new ApiSingleResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse);
-            
+
             var response = await _client.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(201);
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
             var result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
-            
+
             var createdCase = _dbContext.ConcernsCase.FirstOrDefault(c => c.Urn == result.Data.Urn);
             expected.Data.Urn = createdCase.Urn;
-            
+
             result.Should().BeEquivalentTo(expected);
             createdCase.Description.Should().BeEquivalentTo(createRequest.Description);
         }
@@ -87,26 +88,26 @@ namespace ConcernsCaseWork.API.Tests.Integration
         {
             SetupConcernsCaseTestData("mockUkprn");
             var concernsCase = _dbContext.ConcernsCase.First();
-            
+
             var httpRequestMessage = new HttpRequestMessage
             {
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/urn/{concernsCase.Urn}")
             };
-            
+
             var expectedConcernsCaseResponse = ConcernsCaseResponseFactory.Create(concernsCase);
-            
+
             var expected = new ApiSingleResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse);
-            
+
             var response = await _client.SendAsync(httpRequestMessage);
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             var result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
-            
+
             result.Should().BeEquivalentTo(expected);
             result.Data.Urn.Should().Be(concernsCase.Urn);
         }
-        
+
         [Fact]
         public async Task CanGetConcernCaseByTrustUkprn()
         {
@@ -114,21 +115,21 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
             var expectedData = SetupConcernsCaseTestData(ukprn);
             var concernsCase = expectedData.First();
-            
+
             var httpRequestMessage = new HttpRequestMessage
             {
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/ukprn/{ukprn}")
             };
-            
+
             var expectedConcernsCaseResponse = ConcernsCaseResponseFactory.Create(concernsCase);
             var expectedPaging = new PagingResponse {Page = 1, RecordCount = expectedData.Count};
-            
+
             var expected = new ApiResponseV2<ConcernsCaseResponse>(new List<ConcernsCaseResponse>{expectedConcernsCaseResponse}, expectedPaging);
-            
+
             var response = await _client.SendAsync(httpRequestMessage);
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             var result = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
 
             result.Data.Count(d => d.Urn == concernsCase.Urn).Should().Be(1);
@@ -140,7 +141,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
             var ukprn = "100008";
 
             var concernsCases = SetupConcernsCaseTestData(ukprn, 2);
-            
+
             var httpRequestMessage = new HttpRequestMessage
             {
                 Method = HttpMethod.Get,
@@ -149,13 +150,13 @@ namespace ConcernsCaseWork.API.Tests.Integration
             var expectedPaging = new PagingResponse {Page = 1, RecordCount = concernsCases.Count};
 
             var expectedConcernsCaseResponse = concernsCases.Select(c => ConcernsCaseResponseFactory.Create(c)).ToList();
-            
+
             var expected = new ApiResponseV2<ConcernsCaseResponse>(expectedConcernsCaseResponse, expectedPaging);
-            
+
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Count(d => d.Urn == concernsCases[0].Urn).Should().Be(1);
             content.Data.Count(d => d.Urn == concernsCases[1].Urn).Should().Be(1);
         }
@@ -165,9 +166,9 @@ namespace ConcernsCaseWork.API.Tests.Integration
         {
             var ukprn = "100005";
             var count = 20;
-            
+
             var concernsCases = SetupConcernsCaseTestData(ukprn, 10);
-            
+
             var httpRequestMessage = new HttpRequestMessage
             {
                 Method = HttpMethod.Get,
@@ -175,17 +176,17 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Count().Should().Be(concernsCases.Count);
         }
-        
+
         [Fact]
         public async Task GettingMultipleConcernCasesByTrustUkprn_WhenGreaterThanCount_ShouldReturnCountNumberOfItems()
         {
             var ukprn = "100008";
             var count = 5;
-            
+
             SetupConcernsCaseTestData(ukprn, 10);
 
             var httpRequestMessage = new HttpRequestMessage
@@ -195,8 +196,8 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Count().Should().Be(count);
         }
 
@@ -210,11 +211,11 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsStatusResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Count().Should().Be(3);
         }
-        
+
         [Fact]
         public async Task IndexConcernsTypes_ShouldReturnAllConcernsTypes()
         {
@@ -225,11 +226,11 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsTypeResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Count().Should().Be(13);
         }
-        
+
         [Fact]
         public async Task UpdateConcernsCase_ShouldReturnTheUpdatedConcernsCase()
         {
@@ -255,9 +256,9 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 StatusId = 2,
                 RatingId =  1
             };
-            
+
             AddConcernsCase(currentConcernsCase);
-            
+
             var urn = currentConcernsCase.Urn;
 
             var updateRequest = Builder<ConcernCaseRequest>.CreateNew()
@@ -275,8 +276,8 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Should().BeEquivalentTo(expectedContent);
         }
 
@@ -284,7 +285,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
         public async Task CanCreateNewConcernRecord()
         {
 	        var caseRating = _dbContext.ConcernsRatings.First();
-	        
+
             var concernsCase = new ConcernsCase
             {
                 CreatedAt = _randomGenerator.DateTime(),
@@ -307,7 +308,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 StatusId = 2,
                 RatingId = caseRating.Id
             };
-            
+
             AddConcernsCase(concernsCase);
 
             var linkedCase = _dbContext.ConcernsCase.First();
@@ -321,28 +322,28 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 .With(c => c.RatingId = linkedRating.Id)
                 .With(c => c.MeansOfReferralId = meansOfReferral.Id)
                 .Build();
-            
+
             var httpRequestMessage = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
                 RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records"),
                 Content =  JsonContent.Create(createRequest)
             };
-            
+
             var expectedRecordToBeCreated = ConcernsRecordFactory.Create(createRequest, linkedCase, linkedType, linkedRating, meansOfReferral);
             var expectedConcernsRecordResponse = ConcernsRecordResponseFactory.Create(expectedRecordToBeCreated);
             var expected = new ApiSingleResponseV2<ConcernsRecordResponse>(expectedConcernsRecordResponse);
-            
+
             var response = await _client.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(201);
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
             var result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-            
+
             var createdRecord = _dbContext.ConcernsRecord.FirstOrDefault(c => c.Id == result.Data.Id);
             expected.Data.Id = createdRecord.Id;
-            
+
             result.Should().BeEquivalentTo(expected);
         }
-        
+
         [Fact]
         public async Task UpdateConcernsRecord_ShouldReturnTheUpdatedConcernsRecord()
         {
@@ -372,7 +373,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
             var concernsType = _dbContext.ConcernsTypes.FirstOrDefault(t => t.Id == 1);
             var concernsRating = _dbContext.ConcernsRatings.FirstOrDefault(r => r.Id == 1);
             var concernsMeansOfReferral = _dbContext.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 1);
-            
+
             AddConcernsCase(currentConcernsCase);
 
             var currentConcernsRecord = new ConcernsRecord
@@ -390,7 +391,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 ConcernsRating = concernsRating,
                 ConcernsMeansOfReferral = concernsMeansOfReferral
             };
-            
+
             AddConcernsRecord(currentConcernsRecord);
             var currentRecordId = currentConcernsRecord.Id;
 
@@ -412,8 +413,8 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Should().BeEquivalentTo(expectedContent);
         }
 
@@ -446,20 +447,20 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 StatusId = 2,
                 RatingId = 3
             };
-            
+
             AddConcernsCase(concernsCase);
-            
+
             var concernsType = _dbContext.ConcernsTypes.FirstOrDefault(t => t.Id == 1);
             var concernsRating = _dbContext.ConcernsRatings.FirstOrDefault(r => r.Id == 1);
-            
+
             var currentMeansOfReferral = hasCurrentMeansOfReferral
                 ? _dbContext.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 1)
                 : null;
-            
+
             var updateMeansOfReferral = isAddingMeansOfReferral
                 ? _dbContext.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 2)
                 : null;
-            
+
             var currentConcernsRecord = new ConcernsRecord
             {
                 CreatedAt = _randomGenerator.DateTime(),
@@ -475,7 +476,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 ConcernsRating = concernsRating,
                 ConcernsMeansOfReferral = currentMeansOfReferral
             };
-            
+
             AddConcernsRecord(currentConcernsRecord);
             var currentRecordId = currentConcernsRecord.Id;
 
@@ -485,7 +486,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 .With(r => r.RatingId = concernsRating.Id)
                 .With(r => r.MeansOfReferralId = updateMeansOfReferral?.Id)
                 .Build();
-            
+
             var expectedConcernsRecord = ConcernsRecordFactory.Create(updateRequest, concernsCase, concernsType, concernsRating, updateMeansOfReferral ?? currentMeansOfReferral);
             expectedConcernsRecord.Id = currentRecordId;
             var expectedContent = ConcernsRecordResponseFactory.Create(expectedConcernsRecord);
@@ -498,11 +499,11 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Should().BeEquivalentTo(expectedContent);
         }
-        
+
         [Fact]
         public async Task GetConcernsRecordsByConcernsCaseUid()
         {
@@ -528,7 +529,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 StatusId = 2,
                 RatingId = 4
             };
-            
+
             AddConcernsCase(concernsCase);
 
             var concernsRating = _dbContext.ConcernsRatings.FirstOrDefault();
@@ -550,7 +551,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 StatusId = 1,
                 MeansOfReferralId = concernsMeansOfReferral!.Id
             };
-            
+
             var recordCreateRequest2 = new ConcernsRecordRequest
             {
                 CreatedAt = _randomGenerator.DateTime(),
@@ -573,22 +574,22 @@ namespace ConcernsCaseWork.API.Tests.Integration
                 RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/"),
                 Content =  JsonContent.Create(recordCreateRequest1)
             };
-            
+
             var createResponse1 = await _client.SendAsync(httpCreateRequestMessage1);
             var content1 = await createResponse1.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-            createResponse1.StatusCode.Should().Be(201);
-            
+            createResponse1.StatusCode.Should().Be(HttpStatusCode.Created);
+
             var httpCreateRequestMessage2 = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
                 RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/"),
                 Content =  JsonContent.Create(recordCreateRequest2)
             };
-            
+
             var createResponse2 = await _client.SendAsync(httpCreateRequestMessage2);
             var content2 = await createResponse2.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-            createResponse2.StatusCode.Should().Be(201);
-            
+            createResponse2.StatusCode.Should().Be(HttpStatusCode.Created);
+
             var createdRecord1 = ConcernsRecordFactory
                 .Create(recordCreateRequest1, concernsCase, concernsType, concernsRating, concernsMeansOfReferral);
             createdRecord1.Id = content1.Data.Id;
@@ -598,16 +599,16 @@ namespace ConcernsCaseWork.API.Tests.Integration
             var createdRecords = new List<ConcernsRecord> {createdRecord1, createdRecord2};
             var expected = createdRecords
                 .Select(ConcernsRecordResponseFactory.Create).ToList();
-            
+
             var httpRequestMessage = new HttpRequestMessage
             {
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/case/urn/{concernsCase.Urn}")
             };
-            
+
             var response = await _client.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(200);
-            
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
             content.Data.Count().Should().Be(2);
             content.Data.Should().BeEquivalentTo(expected);
@@ -619,7 +620,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
             var ownerId = "7583";
 
             var openConcernsCases = new List<ConcernsCase>();
-            
+
             for (var i = 0; i < 5; i++)
             {
                 var concernsCase = new ConcernsCase
@@ -644,7 +645,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
                     StatusId = 2,
                     RatingId = 1
                 };
-                
+
                 AddConcernsCase(concernsCase);
                 openConcernsCases.Add(concernsCase);
             }
@@ -673,22 +674,22 @@ namespace ConcernsCaseWork.API.Tests.Integration
                     StatusId = 3,
                     RatingId = 3
                 };
-                
+
                 AddConcernsCase(concernsCase);
             }
 
             var expected = openConcernsCases.Select(ConcernsCaseResponseFactory.Create).ToList();
 
-            
+
             var httpRequestMessage = new HttpRequestMessage
             {
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/owner/{ownerId}?status=2")
             };
-            
+
             var response = await _client.SendAsync(httpRequestMessage);
-            response.StatusCode.Should().Be(200);
-            
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
             content.Data.Count().Should().Be(5);
             content.Data.Should().BeEquivalentTo(expected);
@@ -721,15 +722,15 @@ namespace ConcernsCaseWork.API.Tests.Integration
                     StatusId = 2,
                     RatingId = 3
                 };
-                
+
                 AddConcernsCase(concernsCase);
-                
+
                 listOfCases.Add(concernsCase);
             }
-            
+
 	        return listOfCases;
         }
-        
+
         [Fact]
         public async Task IndexConcernsMeansOfReferral_ShouldReturnAllConcernsMeansOfReferral()
         {
@@ -740,19 +741,19 @@ namespace ConcernsCaseWork.API.Tests.Integration
             };
             var response = await _client.SendAsync(httpRequestMessage);
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsMeansOfReferralResponse>>();
-            
-            response.StatusCode.Should().Be(200);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Data.Count().Should().Be(2);
-            						
+
             content.Data.First().Name.Should().Be("Internal");
             content.Data.First().Description.Should().Be("ESFA activity, TFFT or other departmental activity");
             content.Data.First().Id.Should().BeGreaterThan(0);
-			
+
             content.Data.Last().Name.Should().Be("External");
             content.Data.Last().Description.Should().Be("CIU casework, whistleblowing, self reported, regional director (RD) or other government bodies");
             content.Data.Last().Id.Should().BeGreaterThan(0);
         }
-        
+
         public void Dispose()
         {
 	        if (RecordsToBeDisposedAtEndOfTests.Any())
@@ -761,7 +762,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 		        _dbContext.SaveChanges();
 		        RecordsToBeDisposedAtEndOfTests.Clear();
 	        }
-	        
+
 	        if (CasesToBeDisposedAtEndOfTests.Any())
 	        {
 				_dbContext.ConcernsCase.RemoveRange(CasesToBeDisposedAtEndOfTests);
@@ -786,14 +787,14 @@ namespace ConcernsCaseWork.API.Tests.Integration
 		        throw;
 	        }
         }
-        
+
         private void AddConcernsRecord(ConcernsRecord concernsRecord)
-        {	        
+        {
 	        try
 	        {
 		        _dbContext.ConcernsRecord.Add(concernsRecord);
 		        _dbContext.SaveChanges();
-		        
+
 		        RecordsToBeDisposedAtEndOfTests.Add(concernsRecord);
 	        }
 	        catch (Exception)

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CaseActions/Decisions/CreateDecisionTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CaseActions/Decisions/CreateDecisionTests.cs
@@ -46,7 +46,7 @@ namespace ConcernsCaseWork.API.Tests.UseCases.CaseActions.Decisions
             var sut = new CreateDecision(Mock.Of<IConcernsCaseGateway>(), Mock.Of<IDecisionFactory>(), Mock.Of<ICreateDecisionResponseFactory>());
 
             Func<Task> action = async () => await sut.Execute(null, CancellationToken.None);
-            action.Should().Throw<ArgumentNullException>();
+            await action.Should().ThrowAsync<ArgumentNullException>();
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace ConcernsCaseWork.API.Tests.UseCases.CaseActions.Decisions
             var sut = new CreateDecision(Mock.Of<IConcernsCaseGateway>(), Mock.Of<IDecisionFactory>(), Mock.Of<ICreateDecisionResponseFactory>());
 
             Func<Task> action = async () => await sut.Execute(badRequestObject, CancellationToken.None);
-            action.Should().Throw<ArgumentException>().And.ParamName.Should().Be("request");
+            (await action.Should().ThrowAsync<ArgumentException>()).And.ParamName.Should().Be("request");
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace ConcernsCaseWork.API.Tests.UseCases.CaseActions.Decisions
             var sut = new CreateDecision(mockGateway.Object, Mock.Of<IDecisionFactory>(), Mock.Of<ICreateDecisionResponseFactory>());
             Func<Task> action = async () => await sut.Execute(request, CancellationToken.None);
 
-            action.Should().Throw<InvalidOperationException>().And.Message.Should()
+            (await action.Should().ThrowAsync<InvalidOperationException>()).And.Message.Should()
                 .Contain($"The concerns case for urn {request.ConcernsCaseUrn}, was not found");
         }
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CaseActions/Decisions/GetDecisionTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CaseActions/Decisions/GetDecisionTests.cs
@@ -31,7 +31,7 @@ namespace ConcernsCaseWork.API.Tests.UseCases.CaseActions.Decisions
             var sut = new GetDecision(Mock.Of<IConcernsCaseGateway>(), Mock.Of<IGetDecisionResponseFactory>());
 
             Func<Task> action = async () => await sut.Execute(null, CancellationToken.None);
-            action.Should().Throw<ArgumentNullException>();
+            await action.Should().ThrowAsync<ArgumentNullException>();
         }
 
         [Fact]

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CaseActions/Decisions/UpdateDecisionTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CaseActions/Decisions/UpdateDecisionTests.cs
@@ -33,7 +33,7 @@ namespace ConcernsCaseWork.API.Tests.UseCases.CaseActions.Decisions
         }
 
         [Fact]
-        public void Execute_When_ConcernsCase_Not_Found_Throws_Exception()
+        public async Task Execute_When_ConcernsCase_Not_Found_Throws_Exception()
         {
             var mockDecisionFactory = new Mock<IDecisionFactory>();
             var mockUpdateDecisionResponseFactory = new Mock<IUpdateDecisionResponseFactory>();
@@ -49,7 +49,7 @@ namespace ConcernsCaseWork.API.Tests.UseCases.CaseActions.Decisions
             var sut = fixture.Create<UpdateDecision>();
             Func<Task<UpdateDecisionResponse>> action = () => sut.Execute((caseUrn, decisionId, request), CancellationToken.None);
 
-            action.Should().Throw<InvalidOperationException>().And.Message.Should()
+            (await action.Should().ThrowAsync<InvalidOperationException>()).And.Message.Should()
                 .Be($"Concerns Case {caseUrn} not found");
             mockGateWay.Verify(x => x.GetConcernsCaseByUrn(caseUrn, true), Times.Once);
         }

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/PatchSRMATests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/PatchSRMATests.cs
@@ -35,7 +35,7 @@ namespace ConcernsCaseWork.API.Tests.UseCases
             var result = useCase.Execute(new PatchSRMARequest { SRMAId = srmaDbModel.Id, Delegate = patchStatusDelegate});
 
             result.Should().NotBeNull();
-            result.Status.Should().BeEquivalentTo(targetStatus);
+            result.Status.Should().Be(targetStatus);
         }
 
         [Fact]

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/appsettings.tests.json
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/appsettings.tests.json
@@ -22,10 +22,10 @@
   },
   "ConcernsCaseworkApi": {
 	"ApiKeys": "app-key"
-  },  
-  "ConnectionStrings": {
-	"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true"
   },
+	"ConnectionStrings": {
+		"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true;TrustServerCertificate=True;"
+	},
   "app": {
 	"username": "alex",
 	"password": "secret"

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/appsettings.tests.json
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/appsettings.tests.json
@@ -24,7 +24,7 @@
 	"ApiKeys": "app-key"
   },
 	"ConnectionStrings": {
-		"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true;TrustServerCertificate=True;"
+		"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true;TrustServerCertificate=True"
 	},
   "app": {
 	"username": "alex",

--- a/ConcernsCaseWork/ConcernsCaseWork.API/ConcernsCaseWork.API.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/ConcernsCaseWork.API.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.2.0" />
+      <PackageReference Include="FluentValidation" Version="11.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.API/ConcernsCaseWork.API.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/ConcernsCaseWork.API.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="FluentValidation" Version="11.2.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
       <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
     </ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.API/ConcernsCaseWork.API.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/ConcernsCaseWork.API.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.3.0" />
+      <PackageReference Include="FluentValidation" Version="11.4.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseController.cs
@@ -11,7 +11,7 @@ namespace ConcernsCaseWork.API.Controllers
     [ApiController]
     [Route("v{version:apiVersion}/concerns-cases")]
     public class ConcernsCaseController: ControllerBase
-    { 
+    {
         private readonly ILogger<ConcernsCaseController> _logger;
         private readonly ICreateConcernsCase _createConcernsCase;
         private readonly IGetConcernsCaseByUrn _getConcernsCaseByUrn;
@@ -20,7 +20,7 @@ namespace ConcernsCaseWork.API.Controllers
         private readonly IGetConcernsCasesByOwnerId _getConcernsCasesByOwnerId;
 
         public ConcernsCaseController(
-            ILogger<ConcernsCaseController> logger, 
+            ILogger<ConcernsCaseController> logger,
             ICreateConcernsCase createConcernsCase,
             IGetConcernsCaseByUrn getConcernsCaseByUrn,
             IGetConcernsCaseByTrustUkprn getConcernsCaseByTrustUkprn,
@@ -34,7 +34,7 @@ namespace ConcernsCaseWork.API.Controllers
             _updateConcernsCase = updateConcernsCase;
             _getConcernsCasesByOwnerId = getConcernsCasesByOwnerId;
         }
-        
+
         [HttpPost]
         [MapToApiVersion("2.0")]
         public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Create(ConcernCaseRequest request)
@@ -50,7 +50,7 @@ namespace ConcernsCaseWork.API.Controllers
             _logger.LogInformation($"Failed to create Concerns Case due to bad request");
             return BadRequest();
         }
-        
+
         [HttpGet]
         [Route("urn/{urn}")]
         [MapToApiVersion("2.0")]
@@ -58,20 +58,20 @@ namespace ConcernsCaseWork.API.Controllers
         {
             _logger.LogInformation($"Attempting to get Concerns Case by Urn {urn}");
             var concernsCase = _getConcernsCaseByUrn.Execute(urn);
-            
+
             if (concernsCase == null)
             {
                 _logger.LogInformation($"No Concerns case found for URN {urn}");
                 return NotFound();
             }
-            
+
             _logger.LogInformation($"Returning Concerns case with Urn {urn}");
             _logger.LogDebug(JsonSerializer.Serialize(concernsCase));
             var response = new ApiSingleResponseV2<ConcernsCaseResponse>(concernsCase);
-            
+
             return Ok(response);
         }
-        
+
         [HttpGet]
         [Route("ukprn/{trustUkprn}")]
         [MapToApiVersion("2.0")]
@@ -84,10 +84,10 @@ namespace ConcernsCaseWork.API.Controllers
             _logger.LogDebug(JsonSerializer.Serialize(concernsCases));
             var pagingResponse = PagingResponseFactory.Create(page, count, concernsCases.Count, Request);
             var response = new ApiResponseV2<ConcernsCaseResponse>(concernsCases, pagingResponse);
-            
+
             return Ok(response);
         }
-        
+
         [HttpPatch("{urn}")]
         [MapToApiVersion("2.0")]
         public ActionResult<ApiSingleResponseV2<ConcernsCaseResponse>> Update(int urn, ConcernCaseRequest request)
@@ -113,7 +113,7 @@ namespace ConcernsCaseWork.API.Controllers
             _logger.LogInformation($"Failed to update Concerns Case due to bad request");
             return BadRequest();
         }
-        
+
         [HttpGet]
         [Route("owner/{ownerId}")]
         [MapToApiVersion("2.0")]
@@ -126,7 +126,7 @@ namespace ConcernsCaseWork.API.Controllers
             _logger.LogDebug(JsonSerializer.Serialize(concernsCases));
             var pagingResponse = PagingResponseFactory.Create(page, count, concernsCases.Count, Request);
             var response = new ApiResponseV2<ConcernsCaseResponse>(concernsCases, pagingResponse);
-            
+
             return Ok(response);
         }
     }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/ApiKeyMiddleware.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/ApiKeyMiddleware.cs
@@ -5,30 +5,35 @@ namespace ConcernsCaseWork.API.Middleware
     public class ApiKeyMiddleware
     {
         private readonly RequestDelegate _next;
-        private const string APIKEYNAME = "ConcernsApiKey";
+        private const string APIKEYNAME = "ApiKey";
         public ApiKeyMiddleware(RequestDelegate next)
         {
             _next = next;
         }
         public async Task InvokeAsync(HttpContext context, IUseCase<string, bool> apiKeyValidationService)
         {
-            if (!context.Request.Headers.TryGetValue(APIKEYNAME, out var extractedApiKey))
-            {
-                context.Response.StatusCode = 401;
-                await context.Response.WriteAsync("Api Key was not provided.");
-                return;
-            }
- 
-            var isKeyValid = apiKeyValidationService.Execute(extractedApiKey);
-            
-            if (!isKeyValid)
-            {
-                context.Response.StatusCode = 401;
-                await context.Response.WriteAsync("Unauthorized client.");
-                return;
-            }
+	        if (IsApiCall(context))
+	        {
+		        if (!context.Request.Headers.TryGetValue(APIKEYNAME, out var extractedApiKey))
+		        {
+			        context.Response.StatusCode = 401;
+			        await context.Response.WriteAsync("Api Key was not provided.");
+			        return;
+		        }
 
-            await _next(context);
+		        var isKeyValid = apiKeyValidationService.Execute(extractedApiKey);
+
+		        if (!isKeyValid)
+		        {
+			        context.Response.StatusCode = 401;
+			        await context.Response.WriteAsync("Unauthorized client.");
+			        return;
+		        }
+	        }
+
+	        await _next(context);
         }
+
+        private bool IsApiCall(HttpContext context) => context.Request.Path.HasValue && context.Request.Path.Value!.StartsWith("/v2");
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/AuthenticationHeaderOperationFilter.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/AuthenticationHeaderOperationFilter.cs
@@ -11,7 +11,7 @@ namespace ConcernsCaseWork.API.StartupConfiguration
             
             var securityScheme = new OpenApiSecurityScheme
             {
-                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ConcernsApiKey" }
+                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ApiKey" }
             };
             
             operation.Security.Add(new OpenApiSecurityRequirement {{ securityScheme, new List<string>() }});

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/SwaggerOptions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/SwaggerOptions.cs
@@ -9,13 +9,13 @@ namespace ConcernsCaseWork.API.StartupConfiguration
     {
         private readonly IApiVersionDescriptionProvider _provider;
 
-        private const string ApiKeyName = "ConcernsApiKey";
+        private const string ApiKeyName = "ApiKey";
         private const string ServiceTitle = "Concerns Casework API";
         private const string ServiceDescription = "Concerns Casework API";
         private const string ContactName = "Support";
         private const string ContactEmail = "servicedelivery.rdd@education.gov.uk";
 
-        private const string SecuritySchemeDescription = "A valid ApiKey in the 'ConcernsApiKey' header is required to " +
+        private const string SecuritySchemeDescription = "A valid ApiKey in the 'ApiKey' header is required to " +
                                                          "access the Concerns Casework API.";
         private const string DeprecatedMessage = "- API version has been deprecated.";
         

--- a/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />

--- a/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.5.0">

--- a/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.CoreTypes.Tests/ConcernsCaseWork.CoreTypes.Tests.csproj
@@ -15,9 +15,15 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
@@ -13,9 +13,15 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsCaseWork.Data.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsCaseWork.Data.csproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.8">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/ConcernsCaseWork.Integration.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/ConcernsCaseWork.Integration.Tests.csproj
@@ -12,9 +12,12 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/ConcernsCaseWork.Integration.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/ConcernsCaseWork.Integration.Tests.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/ConcernsCaseWork.Integration.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/ConcernsCaseWork.Integration.Tests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
           <PrivateAssets>all</PrivateAssets>

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/appsettings.tests.json
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/appsettings.tests.json
@@ -26,7 +26,7 @@
 	"api_key": "secret"
   },
 	"ConnectionStrings": {
-		"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true;TrustServerCertificate=True;"
+		"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true;TrustServerCertificate=True"
 	},
   "app": {
 	"username": "alex",

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/appsettings.tests.json
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/appsettings.tests.json
@@ -25,9 +25,9 @@
 	"api_endpoint": "secret",
 	"api_key": "secret"
   },
-  "ConnectionStrings": {
-	"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true;"
-  },
+	"ConnectionStrings": {
+		"DefaultConnection": "Server=localhost;Database=integrationtests;Integrated Security=true;TrustServerCertificate=True;"
+	},
   "app": {
 	"username": "alex",
 	"password": "secret"

--- a/ConcernsCaseWork/ConcernsCaseWork.Logging/ConcernsCaseWork.Logging.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Logging/ConcernsCaseWork.Logging.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/ConcernsCaseWork.Redis.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/ConcernsCaseWork.Redis.Tests.csproj
@@ -13,9 +13,12 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/ConcernsCaseWork.Redis.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/ConcernsCaseWork.Redis.Tests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
@@ -28,5 +28,5 @@
       <ProjectReference Include="..\ConcernsCaseWork.Shared.Tests\ConcernsCaseWork.Shared.Tests.csproj" />
       <ProjectReference Include="..\ConcernsCaseWork.Redis\ConcernsCaseWork.Redis.csproj" />
     </ItemGroup>
-	
+
 </Project>

--- a/ConcernsCaseWork/ConcernsCaseWork.Redis/ConcernsCaseWork.Redis.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis/ConcernsCaseWork.Redis.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-      <PackageReference Include="AutoMapper" Version="11.0.1" />
+      <PackageReference Include="AutoMapper" Version="12.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.0" />
     </ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Redis/ConcernsCaseWork.Redis.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis/ConcernsCaseWork.Redis.csproj
@@ -7,8 +7,8 @@
     <ItemGroup>
       <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
       <PackageReference Include="AutoMapper" Version="11.0.1" />
-      <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.8" />
+      <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/ConcernsCaseWork.Service.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/ConcernsCaseWork.Service.Tests.csproj
@@ -11,9 +11,15 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/ConcernsCaseWork.Service.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/ConcernsCaseWork.Service.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/ConcernsCaseWork.Service.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/ConcernsCaseWork.Service.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/ConcernsCaseWork.Service.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/ConcernsCaseWork.Service.csproj
@@ -8,7 +8,7 @@
 	
 	<ItemGroup>
 		<PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/ConcernsCaseWork.Shared.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/ConcernsCaseWork.Shared.Tests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-        <PackageReference Include="AutoMapper" Version="11.0.1" />
+        <PackageReference Include="AutoMapper" Version="12.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/ConcernsCaseWork.Shared.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/ConcernsCaseWork.Shared.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
         <PackageReference Include="AutoMapper" Version="11.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/ConcernsCaseWork.Shared.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/ConcernsCaseWork.Shared.Tests.csproj
@@ -14,9 +14,12 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/ConcernsCaseWork.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/ConcernsCaseWork.Tests.csproj
@@ -16,9 +16,12 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/ConcernsCaseWork.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/ConcernsCaseWork.Tests.csproj
@@ -10,10 +10,10 @@
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0">

--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.17.0" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.17.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Sentry.AspNetCore" Version="3.24.0" />
     <PackageReference Include="Sentry.Serilog" Version="3.24.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />

--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -6,14 +6,14 @@
     <UserSecretsId>ac20b61d-9280-4be5-bbad-ad27aaff2f24</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
-	
+
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.8" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.25.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.11" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.25.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.17.0" />
@@ -25,7 +25,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
   </ItemGroup>
-	
+
   <ItemGroup>
 	  <ProjectReference Include="..\ConcernsCaseWork.API.Contracts\ConcernsCaseWork.API.Contracts.csproj" />
 	  <ProjectReference Include="..\ConcernsCaseWork.API\ConcernsCaseWork.API.csproj" />
@@ -39,13 +39,13 @@
     <Folder Include="wwwroot\assets" />
     <Folder Include="wwwroot\dist" />
   </ItemGroup>
-	
+
   <ItemGroup>
     <Content Update="wwwroot\files\Risk_Management_Framework.pdf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-	
+
   <ItemGroup>
     <_ContentIncludedByDefault Remove="wwwroot\assets\fonts\bold-affa96571d-v2.woff" />
     <_ContentIncludedByDefault Remove="wwwroot\assets\fonts\bold-b542beb274-v2.woff2" />
@@ -225,13 +225,13 @@
     <_ContentIncludedByDefault Remove="wwwroot\dist\moj\vendor\jquery.js" />
     <_ContentIncludedByDefault Remove="wwwroot\dist\moj\vendor\jquery.js.LICENSE.txt" />
   </ItemGroup>
-	
+
   <ItemGroup>
     <Compile Update="Pages\Case\Concern\Index.cshtml.cs">
       <DependentUpon>Index.cshtml</DependentUpon>
     </Compile>
   </ItemGroup>
-	
+
   <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema=" " /></VisualStudio></ProjectExtensions>
-	
+
 </Project>

--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.17.0" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.17.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.21.0" />
-    <PackageReference Include="Sentry.Serilog" Version="3.21.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.24.0" />
+    <PackageReference Include="Sentry.Serilog" Version="3.24.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -126,6 +126,7 @@ namespace ConcernsCaseWork
 			}
 			
 			app.UseMiddleware<ExceptionHandlerMiddleware>();
+			app.UseMiddleware<ApiKeyMiddleware>();
 			
 			// Security headers
 			app.UseSecurityHeaders(


### PR DESCRIPTION
**What is the change?**
Updating nuget packages to the latest versions that .net 6 supports.

**Why do we need the change?**
outdated package can potentially be a security risk as well as miss out of features and performance.
Some referenced packages are also deprecated and need to be moved up to later versions

**What is the impact?**
this is a breaking change, trust needs to be configured between the deployed container and database server. But as a work around we can force trust on the database connection string.

**Azure DevOps Ticket**
112709