### PR TITLE
run build_test job on develop

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
     - main
+    - develop
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
     types: [ opened, synchronize, reopened ]
         
 jobs:


### PR DESCRIPTION
**What is the change?**

run the build_test job on develop

**Why do we need the change?**

need to run the tests when pull requests and merges are done against develop

**What is the impact?**

**Azure DevOps Ticket**
