### PR TITLE
114324: return the decision outcome from the get decision api

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/ResponseModels/Concerns/Decisions/GetDecisionResponse.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.API.Contracts.Enums;
+﻿using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
+using ConcernsCaseWork.API.Contracts.Enums;
 
 namespace ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions
 {
@@ -20,5 +21,7 @@ namespace ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions
 		public DecisionStatus DecisionStatus { get; set; }
 		public DateTimeOffset? ClosedAt { get; set; }
 		public string Title { get; set; }
+
+		public DecisionOutcome? Outcome { get; set; }
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
@@ -2,7 +2,9 @@
 using AutoFixture.Idioms;
 using ConcernsCaseWork.API.Factories.Concerns.Decisions;
 using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions;
+using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
 using Xunit;
@@ -40,18 +42,46 @@ public class GetDecisionResponseFactoryTests
             var result = sut.Create(concernsCaseUrn, decision);
 
             result.ConcernsCaseUrn.Should().Be(concernsCaseUrn);
-            result.Should().BeEquivalentTo(decision,
-                opt => opt.IncludingAllDeclaredProperties()
-                    .Excluding(x => x.DecisionTypes)
-                    .Excluding(x => x.Status)
-                    .Excluding(x => x.ConcernsCaseId)
+			result.Should().BeEquivalentTo(decision,
+				opt => opt.IncludingAllDeclaredProperties()
+					.Excluding(x => x.DecisionTypes)
+					.Excluding(x => x.Status)
+					.Excluding(x => x.ConcernsCaseId)
 					.Excluding(x => x.Outcome)
-                );
-            result.DecisionTypes.Should().BeEquivalentTo(decision.DecisionTypes.Select(x => x.DecisionTypeId),
+				);
+
+			result.Outcome.Status.Should().Be(decision.Outcome.Status);
+			result.Outcome.Authorizer.Should().Be(decision.Outcome.Authorizer);
+			result.Outcome.DecisionMadeDate.Should().Be(decision.Outcome.DecisionMadeDate);
+			result.Outcome.DecisionEffectiveFromDate.Should().Be(decision.Outcome.DecisionEffectiveFromDate);
+			result.Outcome.TotalAmount.Should().Be(decision.Outcome.TotalAmount);
+
+			var expectedBusinessAreas = decision.Outcome.BusinessAreasConsulted.Select(b => b.DecisionOutcomeBusinessId);
+
+			result.Outcome.BusinessAreasConsulted.Should().BeEquivalentTo(expectedBusinessAreas);
+
+
+			result.DecisionTypes.Should().BeEquivalentTo(decision.DecisionTypes.Select(x => x.DecisionTypeId),
                 opt => opt.WithStrictOrdering());
             result.DecisionStatus.Should().HaveSameValueAs(decision.Status);
             result.Title.Should().Be(decision.GetTitle());
         }
+
+		[Fact]
+		public void Create_WithNoOutcome_Returns_DecisionResponse()
+		{
+			var fixture = CreateFixture();
+
+			var concernsCaseUrn = fixture.Create<int>();
+			var decision = fixture.Create<Decision>();
+			decision.Outcome = null;
+
+			var sut = new GetDecisionResponseFactory();
+
+			var result = sut.Create(concernsCaseUrn, decision);
+
+			result.Outcome.Should().BeNull();
+		}
 
         [Fact]
         public void Constructor_Guards_Against_Null_Arguments()

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/HttpExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/HttpExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+
+namespace ConcernsCaseWork.API.Tests.Helpers
+{
+	public static class HttpExtensions
+	{
+		public static StringContent ConvertToJson(this object toConvert)
+		{
+			var body = JsonConvert.SerializeObject(toConvert);
+
+			return new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/DecisionIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/DecisionIntegrationTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoFixture;
+using Azure.Core;
 using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
 using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
 using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
@@ -54,12 +55,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			var wrapper = await getResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<GetDecisionResponse>>();
 			var result = wrapper.Data;
 
-			result.Should().BeEquivalentTo(request, (options) =>
-			{
-				options.Excluding(r => r.ConcernsCaseUrn);
-
-				return options;
-			});
+			AssertDecision(result, request);
 
 			result.ConcernsCaseUrn.Should().Be(concernsCaseId);
 			result.Outcome.Should().BeNull();
@@ -86,6 +82,8 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			var wrapper = await getResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<GetDecisionResponse>>();
 			var result = wrapper.Data;
 
+			AssertDecision(result, decisionRequest);
+
 			result.Outcome.Status.Should().Be(outcomeRequest.Status);
 			result.Outcome.Authorizer.Should().Be(outcomeRequest.Authorizer);
 			result.Outcome.TotalAmount.Should().Be(100);
@@ -93,6 +91,16 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			result.Outcome.DecisionEffectiveFromDate.Should().Be(_decisionEffectiveDate);
 
 			result.Outcome.BusinessAreasConsulted.Should().BeEquivalentTo(outcomeRequest.BusinessAreasConsulted);
+		}
+
+		private void AssertDecision(GetDecisionResponse actual, CreateDecisionRequest expected)
+		{
+			actual.Should().BeEquivalentTo(expected, (options) =>
+			{
+				options.Excluding(r => r.ConcernsCaseUrn);
+
+				return options;
+			});
 		}
 
 		private async Task<ConcernsCase> CreateConcernsCase()

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/DecisionIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/DecisionIntegrationTests.cs
@@ -1,0 +1,150 @@
+﻿using AutoFixture;
+using ConcernsCaseWork.API.Tests.Fixtures;
+using ConcernsCaseWork.Data;
+using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions;
+using ConcernsCaseWork.Data.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
+using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
+using Newtonsoft.Json;
+using System.Net;
+using FluentAssertions;
+using ConcernsCaseWork.API.ResponseModels;
+using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
+using System.Net.Http.Json;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using System.Runtime.CompilerServices;
+using Azure.Core;
+
+namespace ConcernsCaseWork.API.Tests.Integration
+{
+	public class DecisionIntegrationTests : IClassFixture<ApiTestFixture>
+	{
+		private HttpClient _client;
+		private Fixture _fixture;
+		private ConcernsDbContext _context;
+
+		private DateTimeOffset _decisionMadeDate = new DateTimeOffset(2022, 1, 1, 0, 0, 0, new TimeSpan());
+		private DateTimeOffset _decisionEffectiveDate = new DateTimeOffset(2022, 5, 5, 0, 0, 0, new TimeSpan());
+
+		public DecisionIntegrationTests(ApiTestFixture apiTestFixture)
+		{
+			_client = apiTestFixture.Client;
+			_context = apiTestFixture.DbContext;
+
+			_fixture = new();
+		}
+
+		[Fact]
+		public async Task When_Get_HasNoOutcome_Returns_200()
+		{
+			var request = _fixture.Create<CreateDecisionRequest>();
+			request.TotalAmountRequested = 100;
+
+			var concernsCase = await CreateConcernsCase();
+			var concernsCaseId = concernsCase.Id;
+
+			var createdDecision = await CreateDecision(concernsCaseId, request);
+
+			var getResponse = await _client.GetAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/{createdDecision.DecisionId}");
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			var wrapper = await getResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<GetDecisionResponse>>();
+			var result = wrapper.Data;
+
+			result.Should().BeEquivalentTo(request, (options) =>
+			{
+				options.Excluding(r => r.ConcernsCaseUrn);
+
+				return options;
+			});
+
+			result.ConcernsCaseUrn.Should().Be(concernsCaseId);
+			result.Outcome.Should().BeNull();
+		}
+
+		[Fact]
+		public async Task When_Get_HasOutcome_Returns_200()
+		{
+			var decisionRequest = _fixture.Create<CreateDecisionRequest>();
+			decisionRequest.TotalAmountRequested = 100;
+
+			var outcomeRequest = _fixture.Create<CreateDecisionOutcomeRequest>();
+
+			var concernsCase = await CreateConcernsCase();
+			var concernsCaseId = concernsCase.Id;
+
+			var createdDecision = await CreateDecision(concernsCaseId, decisionRequest);
+
+			var createdOutcome = await CreateDecisionOutcome(concernsCaseId, createdDecision.DecisionId, outcomeRequest);
+
+			var getResponse = await _client.GetAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/{createdDecision.DecisionId}");
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			var wrapper = await getResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<GetDecisionResponse>>();
+			var result = wrapper.Data;
+
+			result.Outcome.Status.Should().Be(outcomeRequest.Status);
+			result.Outcome.Authorizer.Should().Be(outcomeRequest.Authorizer);
+			result.Outcome.TotalAmount.Should().Be(100);
+			result.Outcome.DecisionMadeDate.Should().Be(_decisionMadeDate);
+			result.Outcome.DecisionEffectiveFromDate.Should().Be(_decisionEffectiveDate);
+
+			result.Outcome.BusinessAreasConsulted.Should().BeEquivalentTo(outcomeRequest.BusinessAreasConsulted);
+		}
+
+		private async Task<ConcernsCase> CreateConcernsCase()
+		{
+			var toAdd = new ConcernsCase()
+			{
+				RatingId = 1,
+				StatusId = 1
+			};
+
+			var result = _context.ConcernsCase.Add(toAdd);
+			await _context.SaveChangesAsync();
+
+			return result.Entity;
+		}
+
+		private async Task<CreateDecisionOutcomeResponse> CreateDecisionOutcome(int concernsCaseId, int decisionId, CreateDecisionOutcomeRequest request)
+		{
+			request.TotalAmount = 100;
+			request.DecisionMadeDate = _decisionMadeDate;
+			request.DecisionEffectiveFromDate = _decisionEffectiveDate;
+
+			var body = JsonConvert.SerializeObject(request);
+
+			var postResult = await _client.PostAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/{decisionId}/outcome", CreateJsonPayload(body));
+			postResult.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			var response = await postResult.Content.ReadFromJsonAsync<ApiSingleResponseV2<CreateDecisionOutcomeResponse>>();
+
+			return response.Data;
+		}
+
+		private async Task<CreateDecisionResponse> CreateDecision(int concernsCaseId, CreateDecisionRequest request)
+		{
+			var body = JsonConvert.SerializeObject(request);
+
+			var postResult = await _client.PostAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/", CreateJsonPayload(body));
+			postResult.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			var response = await postResult.Content.ReadFromJsonAsync<ApiSingleResponseV2<CreateDecisionResponse>>();
+
+			return response.Data;
+		}
+
+		private StringContent CreateJsonPayload(string body)
+		{
+			return new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/DecisionIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/DecisionIntegrationTests.cs
@@ -1,27 +1,22 @@
 ﻿using AutoFixture;
+using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
+using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
+using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
+using ConcernsCaseWork.API.ResponseModels;
 using ConcernsCaseWork.API.Tests.Fixtures;
+using ConcernsCaseWork.API.Tests.Helpers;
 using ConcernsCaseWork.Data;
-using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions;
 using ConcernsCaseWork.Data.Models;
+using FluentAssertions;
+using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
-using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
-using Newtonsoft.Json;
-using System.Net;
-using FluentAssertions;
-using ConcernsCaseWork.API.ResponseModels;
-using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
-using System.Net.Http.Json;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using System.Runtime.CompilerServices;
-using Azure.Core;
 
 namespace ConcernsCaseWork.API.Tests.Integration
 {
@@ -83,7 +78,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 			var createdDecision = await CreateDecision(concernsCaseId, decisionRequest);
 
-			var createdOutcome = await CreateDecisionOutcome(concernsCaseId, createdDecision.DecisionId, outcomeRequest);
+			await CreateDecisionOutcome(concernsCaseId, createdDecision.DecisionId, outcomeRequest);
 
 			var getResponse = await _client.GetAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/{createdDecision.DecisionId}");
 			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -120,9 +115,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			request.DecisionMadeDate = _decisionMadeDate;
 			request.DecisionEffectiveFromDate = _decisionEffectiveDate;
 
-			var body = JsonConvert.SerializeObject(request);
-
-			var postResult = await _client.PostAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/{decisionId}/outcome", CreateJsonPayload(body));
+			var postResult = await _client.PostAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/{decisionId}/outcome", request.ConvertToJson());
 			postResult.StatusCode.Should().Be(HttpStatusCode.Created);
 
 			var response = await postResult.Content.ReadFromJsonAsync<ApiSingleResponseV2<CreateDecisionOutcomeResponse>>();
@@ -132,19 +125,12 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 		private async Task<CreateDecisionResponse> CreateDecision(int concernsCaseId, CreateDecisionRequest request)
 		{
-			var body = JsonConvert.SerializeObject(request);
-
-			var postResult = await _client.PostAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/", CreateJsonPayload(body));
+			var postResult = await _client.PostAsync($"/v2/concerns-cases/{concernsCaseId}/decisions/", request.ConvertToJson());
 			postResult.StatusCode.Should().Be(HttpStatusCode.Created);
 
 			var response = await postResult.Content.ReadFromJsonAsync<ApiSingleResponseV2<CreateDecisionResponse>>();
 
 			return response.Data;
-		}
-
-		private StringContent CreateJsonPayload(string body)
-		{
-			return new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Factories/Concerns/Decisions/GetDecisionResponseFactory.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
+﻿using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
+using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
 using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions;
 
 namespace ConcernsCaseWork.API.Factories.Concerns.Decisions
@@ -16,7 +17,7 @@ namespace ConcernsCaseWork.API.Factories.Concerns.Decisions
 				DecisionId = decision.DecisionId,
 				DecisionTypes = decision.DecisionTypes.Select(x => (Contracts.Enums.DecisionType)x.DecisionTypeId).ToArray(),
 				TotalAmountRequested = decision.TotalAmountRequested,
-				SupportingNotes =decision.SupportingNotes,
+				SupportingNotes = decision.SupportingNotes,
 				ReceivedRequestDate = decision.ReceivedRequestDate,
 				SubmissionDocumentLink = decision.SubmissionDocumentLink,
 				SubmissionRequired = decision.SubmissionRequired,
@@ -25,9 +26,30 @@ namespace ConcernsCaseWork.API.Factories.Concerns.Decisions
 				CreatedAt = decision.CreatedAt,
 				UpdatedAt = decision.UpdatedAt,
 				ClosedAt = decision.ClosedAt,
-				DecisionStatus = (Contracts.Enums.DecisionStatus) decision.Status,
-				Title = decision.GetTitle()
+				DecisionStatus = (Contracts.Enums.DecisionStatus)decision.Status,
+				Title = decision.GetTitle(),
+				Outcome = CreateDecisionOutcome(decision.Outcome)
 			};
+		}
+
+		private DecisionOutcome  CreateDecisionOutcome(Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome? entity)
+		{
+			if (entity == null)
+			{
+				return null;
+			}
+
+			var result = new DecisionOutcome()
+			{
+				Status = entity.Status,
+				Authorizer = entity.Authorizer,
+				DecisionEffectiveFromDate = entity.DecisionEffectiveFromDate,
+				DecisionMadeDate = entity.DecisionMadeDate,
+				TotalAmount = entity.TotalAmount,
+				BusinessAreasConsulted = entity.BusinessAreasConsulted.Select(b => b.DecisionOutcomeBusinessId).ToList()
+		};
+
+		return result;
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ConcernsCaseGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ConcernsCaseGateway.cs
@@ -1,5 +1,6 @@
 using ConcernsCaseWork.Data.Models;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Cryptography.X509Certificates;
 
 namespace ConcernsCaseWork.Data.Gateways
 {
@@ -34,11 +35,14 @@ namespace ConcernsCaseWork.Data.Gateways
 
         public ConcernsCase GetConcernsCaseByUrn(int urn, bool withChangeTracking = false)
         {
-	        var exp = _concernsDbContext.ConcernsCase
-		        .Include(x => x.Decisions)
-		        .ThenInclude(x => x.DecisionTypes);
+			var exp = _concernsDbContext.ConcernsCase
+				.Include(x => x.Decisions)
+				.ThenInclude(x => x.DecisionTypes)
+				.Include(x => x.Decisions)
+				.ThenInclude(x => x.Outcome)
+				.ThenInclude(x => x.BusinessAreasConsulted);
 
-	        if (!withChangeTracking)
+			if (!withChangeTracking)
 	        {
 		        exp.AsNoTracking();
 	        }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -114,7 +114,7 @@ namespace ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decision
         public Enums.Concerns.DecisionStatus Status { get; set; }
         public DateTimeOffset? ClosedAt { get; set; }
 
-		public DecisionOutcome Outcome { get; set; }
+		public DecisionOutcome? Outcome { get; set; }
 
         public string GetTitle()
         {

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Concerns/Case/Management/Actions/Decisions/Outcome/DecisionOutcome.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Concerns/Case/Management/Actions/Decisions/Outcome/DecisionOutcome.cs
@@ -4,6 +4,11 @@ namespace ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decision
 {
 	public record DecisionOutcome
 	{
+		public DecisionOutcome()
+		{
+			BusinessAreasConsulted = new List<DecisionOutcomeBusinessAreaMapping>();
+		}
+
 		public int DecisionOutcomeId { get; set; }
 
 		public int DecisionId { get; set; }


### PR DESCRIPTION
**What is the change?**

return the outcome from the decision api

added tests for the get decision api to prove it works when there is no outcome and then when an outcome is present

**Why do we need the change?**

view decision page

**What is the impact?**

low

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/114324
