### PR TITLE
114347: added new api for updating a decision outcome

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/HttpExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/HttpExtensions.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using Azure;
+using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
+using ConcernsCaseWork.API.ResponseModels;
+using Newtonsoft.Json;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Net.Mime;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.API.Tests.Helpers
 {
@@ -12,6 +17,13 @@ namespace ConcernsCaseWork.API.Tests.Helpers
 			var body = JsonConvert.SerializeObject(toConvert);
 
 			return new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
+		}
+
+		public static async Task<T> ReadResponseFromWrapper<T>(this HttpContent content) where T : class
+		{
+			var result = await content.ReadFromJsonAsync<ApiSingleResponseV2<T>>();
+
+			return result.Data;
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/DecisionOutcomeController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/DecisionOutcomeController.cs
@@ -12,19 +12,26 @@ namespace ConcernsCaseWork.API.Controllers
 	public class DecisionOutcomeController : ControllerBase
 	{
 		IUseCaseAsync<CreateDecisionOutcomeUseCaseParams, CreateDecisionOutcomeResponse> _createDecisionOutcomeUseCase;
+		IUseCaseAsync<UpdateDecisionOutcomeUseCaseParams, UpdateDecisionOutcomeResponse> _updateDecisionOutcomeUseCase;
 		private ILogger<ConcernsStatusController> _logger;
 
 		public DecisionOutcomeController(
 			IUseCaseAsync<CreateDecisionOutcomeUseCaseParams, CreateDecisionOutcomeResponse> createDecisionOutcomeUseCase,
+			IUseCaseAsync<UpdateDecisionOutcomeUseCaseParams, UpdateDecisionOutcomeResponse> updateDecisionOutcomeUseCase,
 			ILogger<ConcernsStatusController> logger)
 		{
 			_createDecisionOutcomeUseCase = createDecisionOutcomeUseCase;
+			_updateDecisionOutcomeUseCase = updateDecisionOutcomeUseCase;
 			_logger = logger;
 		}
 
 		[HttpPost]
 		[ApiVersion("2.0")]
-		public async Task<ActionResult<ApiSingleResponseV2<CreateDecisionOutcomeResponse>>> Create(int caseId, int decisionId, CreateDecisionOutcomeRequest request, CancellationToken cancellationToken)
+		public async Task<ActionResult<ApiSingleResponseV2<CreateDecisionOutcomeResponse>>> Create(
+			int caseId, 
+			int decisionId, 
+			CreateDecisionOutcomeRequest request, 
+			CancellationToken cancellationToken)
 		{
 			_logger.LogInformation($"Creating decision outcome for case {caseId}, decision {decisionId}");
 
@@ -46,9 +53,37 @@ namespace ConcernsCaseWork.API.Controllers
 
 		[HttpPut]
 		[ApiVersion("2.0")]
-		public IActionResult Put(int urn, int decisionId, UpdateDecisionOutcomeRequest request)
+		public async Task<ActionResult<ApiSingleResponseV2<UpdateDecisionOutcomeResponse>>> Put(
+			int caseId, 
+			int decisionId, 
+			UpdateDecisionOutcomeRequest request, 
+			CancellationToken cancellationToken)
 		{
-			return new ObjectResult("") { StatusCode = StatusCodes.Status200OK };
+			_logger.LogInformation($"Updating decision outcome for case {caseId}, decision {decisionId}");
+
+			var parameters = new UpdateDecisionOutcomeUseCaseParams()
+			{
+				ConcernsCaseId = caseId,
+				DecisionId = decisionId,
+				Request = request
+			};
+
+			var updated = await _updateDecisionOutcomeUseCase.Execute(parameters, cancellationToken);
+
+			_logger.LogInformation($"Updated decision outcome for case {caseId}, decision {decisionId}, outcome {updated.DecisionOutcomeId}");
+
+			var result = new ApiSingleResponseV2<UpdateDecisionOutcomeResponse>()
+			{
+				Data = new UpdateDecisionOutcomeResponse()
+				{
+					ConcernsCaseUrn = caseId,
+					DecisionId = decisionId,
+					DecisionOutcomeId = updated.DecisionOutcomeId
+
+				}
+			};
+
+			return new ObjectResult(result) { StatusCode = StatusCodes.Status200OK };
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Exceptions/ResourceConflictException.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Exceptions/ResourceConflictException.cs
@@ -1,0 +1,10 @@
+﻿namespace ConcernsCaseWork.API.Exceptions
+{
+	public class ResourceConflictException : Exception
+	{
+		public ResourceConflictException(string message) : base(message)
+		{
+
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Factories/CaseActionFactories/DecisionOutcomeFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Factories/CaseActionFactories/DecisionOutcomeFactory.cs
@@ -1,0 +1,33 @@
+﻿using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome;
+using DecisionOutcome = ConcernsCaseWork.API.Contracts.Decisions.Outcomes.DecisionOutcome;
+
+namespace ConcernsCaseWork.API.Factories.CaseActionFactories
+{
+	public class DecisionOutcomeFactory
+	{
+		public static Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome ToDbModel(
+			DecisionOutcome request,
+			int decisionId)
+		{
+			var today = DateTimeOffset.Now;
+
+			var result = new Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome()
+			{
+				DecisionId = decisionId,
+				Status = request.Status,
+				TotalAmount = request.TotalAmount,
+				Authorizer = request.Authorizer,
+				CreatedAt = today,
+				UpdatedAt = today,
+				DecisionMadeDate = request.DecisionMadeDate,
+				DecisionEffectiveFromDate = request.DecisionEffectiveFromDate,
+				BusinessAreasConsulted = request.BusinessAreasConsulted.Select(b => new DecisionOutcomeBusinessAreaMapping()
+				{
+					DecisionOutcomeBusinessId = b
+				}).ToList()
+			};
+
+			return result;
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
@@ -69,6 +69,7 @@ namespace ConcernsCaseWork.API.StartupConfiguration
 			services.AddScoped<IConcernsTeamCaseworkGateway, ConcernsTeamCaseworkGateway>();
 
 			services.AddScoped<IUseCaseAsync<CreateDecisionOutcomeUseCaseParams, CreateDecisionOutcomeResponse>, CreateDecisionOutcome>();
+			services.AddScoped<IUseCaseAsync<UpdateDecisionOutcomeUseCaseParams, UpdateDecisionOutcomeResponse>, UpdateDecisionOutcome>();
 
 			// concerns factories
 			services.AddScoped<IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse>, CreateDecision>();

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/Outcome/CreateDecisionOutcome.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/Outcome/CreateDecisionOutcome.cs
@@ -1,5 +1,6 @@
 ﻿using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
 using ConcernsCaseWork.API.Exceptions;
+using ConcernsCaseWork.API.Factories.CaseActionFactories;
 using ConcernsCaseWork.Data.Gateways;
 using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome;
 
@@ -29,7 +30,7 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 			if (decision.Outcome != null) throw new ResourceConflictException(
 				$"Decision with id {parameters.DecisionId} already has an outcome, Case {parameters.ConcernsCaseId}");
 
-			var toCreate = ToDbModel(parameters.Request, parameters.DecisionId);
+			var toCreate = DecisionOutcomeFactory.ToDbModel(parameters.Request, parameters.DecisionId);
 			var decisionOutcome = await _decisionOutcomeGateway.CreateDecisionOutcome(toCreate, cancellationToken);
 
 			return new CreateDecisionOutcomeResponse()
@@ -38,31 +39,6 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 				ConcernsCaseUrn = parameters.ConcernsCaseId,
 				DecisionOutcomeId = decisionOutcome.DecisionOutcomeId
 			};
-		}
-
-		private Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome ToDbModel(
-			CreateDecisionOutcomeRequest request,
-			int decisionId)
-		{
-			var today = DateTimeOffset.Now;
-
-			var result = new Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome()
-			{
-				DecisionId = decisionId,
-				Status = request.Status,
-				TotalAmount = request.TotalAmount,
-				Authorizer = request.Authorizer,
-				CreatedAt = today,
-				UpdatedAt = today,
-				DecisionMadeDate = request.DecisionMadeDate,
-				DecisionEffectiveFromDate = request.DecisionEffectiveFromDate,
-				BusinessAreasConsulted = request.BusinessAreasConsulted.Select(b => new DecisionOutcomeBusinessAreaMapping()
-				{
-					DecisionOutcomeBusinessId = b
-				}).ToList()
-			};
-
-			return result;
 		}
 	}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/Outcome/UpdateDecisionOutcome.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/Outcome/UpdateDecisionOutcome.cs
@@ -1,5 +1,6 @@
 ﻿using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
 using ConcernsCaseWork.API.Exceptions;
+using ConcernsCaseWork.API.Factories.CaseActionFactories;
 using ConcernsCaseWork.Data.Gateways;
 using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome;
 
@@ -29,7 +30,7 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 			if (decision.Outcome == null) throw new NotFoundException(
 				$"Decision with id {parameters.DecisionId} does not have an outcome, Case {parameters.ConcernsCaseId}");
 
-			var model = ToDbModel(parameters.Request, parameters.DecisionId);
+			var model = DecisionOutcomeFactory.ToDbModel(parameters.Request, parameters.DecisionId);
 
 			var decisionOutcome = await _decisionOutcomeGateway.UpdateDecisionOutcome(model, cancellationToken);
 
@@ -39,31 +40,6 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 				ConcernsCaseUrn = parameters.ConcernsCaseId,
 				DecisionOutcomeId = decisionOutcome.DecisionOutcomeId
 			};
-		}
-
-		private Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome ToDbModel(
-			UpdateDecisionOutcomeRequest request,
-			int decisionId)
-		{
-			var today = DateTimeOffset.Now;
-
-			var result = new Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome()
-			{
-				DecisionId = decisionId,
-				Status = request.Status,
-				TotalAmount = request.TotalAmount,
-				Authorizer = request.Authorizer,
-				CreatedAt = today,
-				UpdatedAt = today,
-				DecisionMadeDate = request.DecisionMadeDate,
-				DecisionEffectiveFromDate = request.DecisionEffectiveFromDate,
-				BusinessAreasConsulted = request.BusinessAreasConsulted.Select(b => new DecisionOutcomeBusinessAreaMapping()
-				{
-					DecisionOutcomeBusinessId = b
-				}).ToList()
-			};
-
-			return result;
 		}
 	}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/Outcome/UpdateDecisionOutcome.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/Outcome/UpdateDecisionOutcome.cs
@@ -5,18 +5,18 @@ using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions.Ou
 
 namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 {
-	public class CreateDecisionOutcome : IUseCaseAsync<CreateDecisionOutcomeUseCaseParams, CreateDecisionOutcomeResponse>
+	public class UpdateDecisionOutcome : IUseCaseAsync<UpdateDecisionOutcomeUseCaseParams, UpdateDecisionOutcomeResponse>
 	{
 		private IConcernsCaseGateway _concernsCaseGateway;
 		private IDecisionOutcomeGateway _decisionOutcomeGateway;
 
-		public CreateDecisionOutcome(IConcernsCaseGateway concernsCaseGateway, IDecisionOutcomeGateway decisionOutcomeGateway)
+		public UpdateDecisionOutcome(IConcernsCaseGateway concernsCaseGateway, IDecisionOutcomeGateway decisionOutcomeGateway)
 		{
 			_concernsCaseGateway = concernsCaseGateway;
 			_decisionOutcomeGateway = decisionOutcomeGateway;
 		}
 
-		public async Task<CreateDecisionOutcomeResponse> Execute(CreateDecisionOutcomeUseCaseParams parameters, CancellationToken cancellationToken)
+		public async Task<UpdateDecisionOutcomeResponse> Execute(UpdateDecisionOutcomeUseCaseParams parameters, CancellationToken cancellationToken)
 		{
 			var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(parameters.ConcernsCaseId);
 
@@ -26,13 +26,14 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 
 			if (decision == null) throw new NotFoundException($"Decision with id {parameters.DecisionId}, Case {parameters.ConcernsCaseId}");
 
-			if (decision.Outcome != null) throw new ResourceConflictException(
-				$"Decision with id {parameters.DecisionId} already has an outcome, Case {parameters.ConcernsCaseId}");
+			if (decision.Outcome == null) throw new NotFoundException(
+				$"Decision with id {parameters.DecisionId} does not have an outcome, Case {parameters.ConcernsCaseId}");
 
-			var toCreate = ToDbModel(parameters.Request, parameters.DecisionId);
-			var decisionOutcome = await _decisionOutcomeGateway.CreateDecisionOutcome(toCreate, cancellationToken);
+			var model = ToDbModel(parameters.Request, parameters.DecisionId);
 
-			return new CreateDecisionOutcomeResponse()
+			var decisionOutcome = await _decisionOutcomeGateway.UpdateDecisionOutcome(model, cancellationToken);
+
+			return new UpdateDecisionOutcomeResponse()
 			{
 				DecisionId = parameters.DecisionId,
 				ConcernsCaseUrn = parameters.ConcernsCaseId,
@@ -41,7 +42,7 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 		}
 
 		private Data.Models.Concerns.Case.Management.Actions.Decisions.Outcome.DecisionOutcome ToDbModel(
-			CreateDecisionOutcomeRequest request,
+			UpdateDecisionOutcomeRequest request,
 			int decisionId)
 		{
 			var today = DateTimeOffset.Now;
@@ -66,10 +67,10 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions.Outcome
 		}
 	}
 
-	public record CreateDecisionOutcomeUseCaseParams
+	public record UpdateDecisionOutcomeUseCaseParams
 	{
 		public int ConcernsCaseId { get; set; }
 		public int DecisionId { get; set; }
-		public CreateDecisionOutcomeRequest Request { get; set; }
+		public UpdateDecisionOutcomeRequest Request { get; set; }
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/DecisionOutcomeGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/DecisionOutcomeGateway.cs
@@ -34,10 +34,44 @@ namespace ConcernsCaseWork.Data.Gateways
 				throw;
 			}
 		}
+
+		public async Task<DecisionOutcome> UpdateDecisionOutcome(DecisionOutcome request, CancellationToken cancellationToken = default)
+		{
+			try
+			{
+				var toUpdate = await _concernsDbContext.Decisions
+					.Include(x => x.Outcome)
+					.Select(x => x.Outcome)
+					.FirstAsync(x => x.DecisionId == request.DecisionId);
+
+				toUpdate.Status = request.Status;
+				toUpdate.TotalAmount = request.TotalAmount;
+				toUpdate.Authorizer = request.Authorizer;
+				toUpdate.BusinessAreasConsulted = request.BusinessAreasConsulted;
+				toUpdate.DecisionEffectiveFromDate = request.DecisionEffectiveFromDate;
+				toUpdate.DecisionMadeDate = request.DecisionMadeDate;
+
+				await _concernsDbContext.SaveChangesAsync(cancellationToken);
+
+				return toUpdate;
+
+			}
+			catch (DbUpdateException ex)
+			{
+				_logger.LogError($"Failed to update Decision Outcome for Decision {request.DecisionId}, {ex}");
+				throw;
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError("An application exception has occurred whilst updating Decision Outcome for Decision {Id}, {ex}", request.DecisionId, ex);
+				throw;
+			}
+		}
 	}
 
 	public interface IDecisionOutcomeGateway
 	{
 		Task<DecisionOutcome> CreateDecisionOutcome(DecisionOutcome request, CancellationToken cancellationToken = default);
+		Task<DecisionOutcome> UpdateDecisionOutcome(DecisionOutcome request, CancellationToken cancellationToken = default);
 	}
 }


### PR DESCRIPTION
**What is the change?**

added support for http status code 409
refactored the exception middleware to make it easier to add new http status codes

**Why do we need the change?**

requirement to be able to edit a decision outcome

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/114347

**Important**
The API is PUT decision outcome, the branch is incorrectly named
