### PR TITLE
Add NPM build stage into Dockerfile

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
       - name: Build Frontend
         run: make build-frontend
@@ -48,7 +48,7 @@ jobs:
           file: ./Dockerfile.gpaas-azure-migration
           push: true
           tags: ${{ steps.prepare-tags.outputs.tags }}
-          
+
       - name: Azure login with ACA credentials
         uses: azure/login@v1
         with:

--- a/.github/workflows/build-and-push-image-production.yml
+++ b/.github/workflows/build-and-push-image-production.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
       - name: Build Frontend
         run: make build-frontend

--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
       - name: Build Frontend
         run: make build-frontend
@@ -64,7 +64,7 @@ jobs:
           build-args: ASPNET_IMAGE_TAG=6.0.9-bullseye-slim-amd64
           push: true
           tags: ${{ steps.prepare-tags.outputs.tags }}
-      
+
       - name: Azure login with ACA credentials
         uses: azure/login@v1
         with:
@@ -81,4 +81,3 @@ jobs:
               --resource-group ${{ secrets.TEST_ACA_RESOURCE_GROUP }} \
               --image ${{ secrets.TEST_ACR_URL }}/amsd-app:${{ steps.prepare-tags.outputs.deploy-version }} \
               --output none
-

--- a/Dockerfile.gpaas-azure-migration
+++ b/Dockerfile.gpaas-azure-migration
@@ -1,6 +1,8 @@
 ﻿# Stage 1
 ARG ASPNET_IMAGE_TAG=6.0.9-bullseye-slim
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+ARG NODEJS_IMAGE_TAG=16-bullseye
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS publish
 WORKDIR /build
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -29,7 +31,14 @@ RUN dotnet publish ConcernsCaseWork -c Release -o /app
 
 COPY ./script/web-docker-entrypoint.sh /app/docker-entrypoint.sh
 
-# Stage 2
+# Stage 2 - Build assets
+FROM node:${NODEJS_IMAGE_TAG} as build
+COPY --from=publish /app /app
+WORKDIR /app/wwwroot
+RUN npm install
+RUN npm run build
+
+# Stage 3 - Final
 ARG ASPNET_IMAGE_TAG
 FROM "mcr.microsoft.com/dotnet/aspnet:${ASPNET_IMAGE_TAG}" AS final
 


### PR DESCRIPTION
**What is the change?**
- Adds a `npm run build` stage to the Dockerfile for Azure

**Why do we need the change?**
- Currently, front-end assets are not built into the resulting Docker image for use on Azure which causes problems (no .css!)

**What is the impact?**
- Resolves issues of frontend assets being missing
