### PR TITLE
114784: added a button to close a decision

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/concerns-decisions-add-edit-view-to-case.spec.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/concerns-decisions-add-edit-view-to-case.spec.ts
@@ -69,6 +69,7 @@ describe("User can add case actions to an existing case", () => {
 			.hasTypeOfDecision("Section 128 (S128)")
 			.hasSupportingNotes("These are some supporting notes!")
 			.hasActionEdit()
+			.cannotCloseDecision()
 			.editDecision();
 
 		Logger.Log("Editing Decision");

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/decision/viewDecisionPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/decision/viewDecisionPage.ts
@@ -172,6 +172,15 @@ export class ViewDecisionPage
 		return this;
 	}
 
+	public cannotCloseDecision(): this
+	{
+		Logger.Log("Checking we cannot close a decision without an outcome");
+
+		cy.getByTestId("close-decision-button").should("not.exist");
+
+		return this;
+	}
+
 	public editDecision(): this {
 		cy.task("log", `Edit Decision`);
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Index.cshtml
@@ -226,6 +226,18 @@
                     </tr>
                 </tbody>
             </table>
+
+            <div class="govuk-button-group">
+                <a 
+                    data-prevent-double-click="true"
+                    class="govuk-button govuk-!-margin-top-6"
+                    data-module="govuk-button"
+                    role="button"
+                    data-testid="close-decision-button"
+                    href="@Request.Path/close">
+                    Continue to close decision
+                </a>
+            </div>
         }
         else
         {


### PR DESCRIPTION
**What is the change?**

added a button to close a decision
added cypress test to verify the button does not show unless a decision has an outcome

**Why do we need the change?**

requirements

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/102802
