### PR TITLE
Added a diagnostics page to show some deployment meta-data mainly the…

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.sln
+++ b/ConcernsCaseWork/ConcernsCaseWork.sln
@@ -39,9 +39,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConcernsCaseWork.API.Tests"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConcernsCaseWork.API.Contracts", "ConcernsCaseWork.API.Contracts\ConcernsCaseWork.API.Contracts.csproj", "{22E09A3E-1571-4182-9F2D-30AD39521BD3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConcernsCaseWork.API.Contracts.Tests", "ConcernsCaseWork.API.Contracts.Tests\ConcernsCaseWork.API.Contracts.Tests.csproj", "{56E4D701-66D5-4635-8D44-05BA26A2E74B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConcernsCaseWork.API.Contracts.Tests", "ConcernsCaseWork.API.Contracts.Tests\ConcernsCaseWork.API.Contracts.Tests.csproj", "{56E4D701-66D5-4635-8D44-05BA26A2E74B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConcernsCaseWork.Data.Tests", "ConcernsCaseWork.Data.Tests\ConcernsCaseWork.Data.Tests.csproj", "{F099C498-7FDC-47C3-BB7D-D36C71DEEE28}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConcernsCaseWork.Data.Tests", "ConcernsCaseWork.Data.Tests\ConcernsCaseWork.Data.Tests.csproj", "{F099C498-7FDC-47C3-BB7D-D36C71DEEE28}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Diagnostics/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Diagnostics/Index.cshtml
@@ -1,0 +1,22 @@
+﻿@page
+@model ConcernsCaseWork.Pages.Diagnostics.IndexModel
+@using System.Globalization;
+@{
+}
+
+<div class="govuk-width-container">
+    <partial name="_BannerError" />
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Diagnostics</h1>
+	        @if (Model.Env != string.Empty)
+            {
+                <div>Environment: @Model.Env</div>
+            }
+	        <div>Release Tag: @Model.ReleaseTag</div>
+	        <div>Current Culture: @CultureInfo.CurrentCulture.Name</div>
+	        <div>Current UI Culture: @CultureInfo.CurrentUICulture.Name</div>
+	        <div>UTC Time: @DateTime.UtcNow</div>
+        </div>
+    </div>
+</div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Diagnostics/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Diagnostics/Index.cshtml.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using System.Globalization;
+
+using System;
+
+namespace ConcernsCaseWork.Pages.Diagnostics
+{
+	[Authorize]
+
+    public class IndexModel : PageModel
+    {
+	    private readonly IConfiguration _configuration;
+	    private readonly IWebHostEnvironment _env;
+        public string Env { get; set; }
+	    public string ReleaseTag { get; set; }
+
+
+		public IndexModel(IConfiguration configuration, IWebHostEnvironment env)
+		{
+			_configuration = configuration;
+			_env = env;
+		}
+
+        public void OnGet()
+        {
+	        this.ReleaseTag = _configuration["ConcernsCasework:ReleaseTag"];
+
+	        if (_env.IsDevelopment() || _env.IsStaging())
+	        {
+		        this.Env = _env.IsDevelopment() ? "Development" : "Staging";
+	        }
+        }
+
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
@@ -34,7 +34,8 @@
 	},
 	"ConcernsCasework": {
 		"ApiEndpoint": "http://localhost",
-		"ApiKey": "app-key"
+		"ApiKey": "app-key",
+		"ReleaseTag":  "insert-a-unique-release-tag-here-during-CD"
 	},
 	"ConcernsCaseworkApi": {
 		"ApiKeys": "app-key"


### PR DESCRIPTION
**What is the change?**
Added a diagnostics/index page to show basic meta data about the runtime environment.
One value is the 'release-tag' which we will populate with something unique to help us identify the version that is deployed. Most likely this would be a commit sha, or a container tag.

**Why do we need the change?**
It's hard to see if a deployment has been effective.

**What is the impact?**
Easier to see if deployment has taken effect

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2033?workitem=114798