### PR TITLE
Reset version in staging deployment yml

### DIFF
--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -14,7 +14,7 @@ jobs:
       version: ${{steps.release-version.outputs.version}}
     steps:
       - id: release-version
-        run: echo "::set-output name=version::release-6"
+        run: echo "::set-output name=version::release-7"
 
   build-and-push-image-test:
     name: Build and push image test


### PR DESCRIPTION
**What is the change?**
Reset version in staging terraform to the same as in main

**Why do we need the change?**
Otherwise an old version will be deployed to staging

**What is the impact?**
The version number of the staging environment

**Azure DevOps Ticket**
115690