### PR TITLE
updating production release image to release-8

### DIFF
--- a/.github/workflows/build-and-push-image-production.yml
+++ b/.github/workflows/build-and-push-image-production.yml
@@ -14,7 +14,7 @@ jobs:
       version: ${{steps.release-version.outputs.version}}
     steps:
       - id: release-version
-        run: echo "::set-output name=version::release-7"
+        run: echo "::set-output name=version::release-8"
 
   build-and-push-image-production:
     name: Build and push image prodcution


### PR DESCRIPTION
**What is the change?**
116191

**Why do we need the change?**
Production release needed prior to migration script testing

**What is the impact?**
1st Production release via pipelines. Possibly issues and production unavailable. But not used by live users yet.

**Azure DevOps Ticket**
116191