### PR TITLE
Feature/116267 change concerns types

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -259,7 +259,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
             var content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsTypeResponse>>();
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            content.Data.Count().Should().Be(13);
+            content.Data.Count().Should().Be(8);
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 			using var context = _testFixture.GetContext();
 
-			var concernsType = context.ConcernsTypes.FirstOrDefault(t => t.Id == 1);
+			var concernsType = context.ConcernsTypes.FirstOrDefault(t => t.Id == 3);
             var concernsRating = context.ConcernsRatings.FirstOrDefault(r => r.Id == 1);
             var concernsMeansOfReferral = context.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 1);
 
@@ -554,7 +554,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 			using var context = _testFixture.GetContext();
 
-			var concernsType = context.ConcernsTypes.FirstOrDefault(t => t.Id == 1);
+			var concernsType = context.ConcernsTypes.FirstOrDefault(t => t.Id == 3);
             var concernsRating = context.ConcernsRatings.FirstOrDefault(r => r.Id == 1);
 
             var currentMeansOfReferral = hasCurrentMeansOfReferral

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
@@ -157,22 +157,6 @@ namespace ConcernsCaseWork.Data
                 entity.HasData(
                     new ConcernsType
                     {
-                        Id = 1,
-                        Name = "Compliance",
-                        Description = "Financial reporting",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
-                    },
-                    new ConcernsType
-                    {
-                        Id = 2,
-                        Name = "Compliance",
-                        Description = "Financial returns",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
-                    },
-                    new ConcernsType
-                    {
                         Id = 3,
                         Name = "Financial",
                         Description = "Deficit",
@@ -183,23 +167,7 @@ namespace ConcernsCaseWork.Data
                     {
                         Id = 4,
                         Name = "Financial",
-                        Description = "Projected deficit / Low future surplus",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
-                    },
-                    new ConcernsType
-                    {
-                        Id = 5,
-                        Name = "Financial",
-                        Description = "Cash flow shortfall",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
-                    },
-                    new ConcernsType
-                    {
-                        Id = 6,
-                        Name = "Financial",
-                        Description = "Clawback",
+                        Description = "Projected deficit",
                         CreatedAt = new DateTime(2021, 11, 17),
                         UpdatedAt = new DateTime(2021, 11, 17)
                     },
@@ -214,51 +182,43 @@ namespace ConcernsCaseWork.Data
                     new ConcernsType
                     {
                         Id = 8,
-                        Name = "Governance",
+                        Name = "Governance and compliance",
                         Description = "Governance",
                         CreatedAt = new DateTime(2021, 11, 17),
                         UpdatedAt = new DateTime(2021, 11, 17)
                     },
                     new ConcernsType
                     {
-                        Id = 9,
-                        Name = "Governance",
-                        Description = "Closure",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
+                        Id = 20,
+                        Name = "Financial",
+                        Description = "Viability",
+                        CreatedAt = new DateTime(2022, 12, 20),
+                        UpdatedAt = new DateTime(2022, 12, 20)
                     },
                     new ConcernsType
                     {
-                        Id = 10,
-                        Name = "Governance",
-                        Description = "Executive Pay",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
+	                    Id = 21,
+	                    Name = "Irregularity",
+	                    Description = "Irregularity",
+	                    CreatedAt = new DateTime(2022, 12, 20),
+	                    UpdatedAt = new DateTime(2022, 12, 20)
                     },
                     new ConcernsType
                     {
-                        Id = 11,
-                        Name = "Governance",
-                        Description = "Safeguarding",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
+	                    Id = 22,
+	                    Name = "Irregularity",
+	                    Description = "Suspected fraud",
+	                    CreatedAt = new DateTime(2022, 12, 20),
+	                    UpdatedAt = new DateTime(2022, 12, 20)
                     },
                     new ConcernsType
                     {
-                        Id = 12,
-                        Name = "Irregularity",
-                        Description = "Allegations and self reported concerns",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
-                    },
-                    new ConcernsType
-                    {
-                        Id = 13,
-                        Name = "Irregularity",
-                        Description = "Related party transactions - in year",
-                        CreatedAt = new DateTime(2021, 11, 17),
-                        UpdatedAt = new DateTime(2021, 11, 17)
-                    }
+	                    Id = 23,
+	                    Name = "Governance and compliance",
+	                    Description = "Compliance",
+	                    CreatedAt = new DateTime(2022, 12, 20),
+	                    UpdatedAt = new DateTime(2022, 12, 20)
+	                }
                 );
             });
             modelBuilder.Entity<ConcernsMeansOfReferral>(entity =>

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221220103353_Update concerns types to match DaRT.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221220103353_Update concerns types to match DaRT.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221220103353_Update concerns types to match DaRT")]
+    partial class UpdateconcernstypestomatchDaRT
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221220103353_Update concerns types to match DaRT.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20221220103353_Update concerns types to match DaRT.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateconcernstypestomatchDaRT : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 5);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 9);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 10);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 11);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 12);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 13);
+
+            migrationBuilder.UpdateData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Description",
+                value: "Projected deficit");
+
+            migrationBuilder.UpdateData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Name",
+                value: "Governance and compliance");
+
+            migrationBuilder.InsertData(
+                schema: "concerns",
+                table: "ConcernsType",
+                columns: new[] { "Id", "CreatedAt", "Description", "Name", "UpdatedAt" },
+                values: new object[,]
+                {
+                    { 20, new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified), "Viability", "Financial", new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 21, new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified), "Irregularity", "Irregularity", new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 22, new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified), "Suspected fraud", "Irregularity", new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 23, new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified), "Compliance", "Governance and compliance", new DateTime(2022, 12, 20, 0, 0, 0, 0, DateTimeKind.Unspecified) }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 20);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 21);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 22);
+
+            migrationBuilder.DeleteData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 23);
+
+            migrationBuilder.UpdateData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Description",
+                value: "Projected deficit / Low future surplus");
+
+            migrationBuilder.UpdateData(
+                schema: "concerns",
+                table: "ConcernsType",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Name",
+                value: "Governance");
+
+            migrationBuilder.InsertData(
+                schema: "concerns",
+                table: "ConcernsType",
+                columns: new[] { "Id", "CreatedAt", "Description", "Name", "UpdatedAt" },
+                values: new object[,]
+                {
+                    { 1, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Financial reporting", "Compliance", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 2, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Financial returns", "Compliance", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 5, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Cash flow shortfall", "Financial", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 6, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Clawback", "Financial", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 9, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Closure", "Governance", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 10, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Executive Pay", "Governance", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 11, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Safeguarding", "Governance", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 12, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Allegations and self reported concerns", "Irregularity", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) },
+                    { 13, new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), "Related party transactions - in year", "Irregularity", new DateTime(2021, 11, 17, 0, 0, 0, 0, DateTimeKind.Unspecified) }
+                });
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/TypeServiceIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/TypeServiceIntegrationTests.cs
@@ -46,7 +46,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 
 			// assert
 			Assert.That(typesDto, Is.Not.Null);
-			Assert.That(typesDto.Count, Is.EqualTo(13));
+			Assert.That(typesDto.Count, Is.EqualTo(8));
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/Types/TypeCachedServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis.Tests/Types/TypeCachedServiceTests.cs
@@ -45,7 +45,7 @@ namespace ConcernsCaseWork.Redis.Tests.Types
 			
 			// assert
 			Assert.That(actualType, Is.Not.Null);
-			Assert.That(actualType.Count, Is.EqualTo(13));
+			Assert.That(actualType.Count, Is.EqualTo(8));
 			
 			mockCacheProvider.Verify(c => c.GetFromCache<IList<TypeDto>>(It.IsAny<string>()), Times.Once);
 			mockCacheProvider.Verify(c => c.SetCache(It.IsAny<string>(), It.IsAny<IList<TypeDto>>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
@@ -70,7 +70,7 @@ namespace ConcernsCaseWork.Redis.Tests.Types
 			
 			// assert
 			Assert.That(actualType, Is.Not.Null);
-			Assert.That(actualType.Count, Is.EqualTo(13));
+			Assert.That(actualType.Count, Is.EqualTo(8));
 			
 			mockCacheProvider.Verify(c => c.GetFromCache<IList<TypeDto>>(It.IsAny<string>()), Times.Once);
 			mockCacheProvider.Verify(c => c.SetCache(It.IsAny<string>(), It.IsAny<IList<TypeDto>>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Never);

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/TypeFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/TypeFactory.cs
@@ -12,42 +12,25 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 			var currentDate = DateTimeOffset.Now;
 			return new List<TypeDto>
 			{
-				new TypeDto("Compliance", "Compliance: Financial reporting", currentDate, 
-					currentDate, 1),
-				new TypeDto("Compliance", "Compliance: Financial returns", currentDate, 
-					currentDate, 2),
 				new TypeDto("Financial", "Financial: Deficit", currentDate, 
 					currentDate, 3),
-				new TypeDto("Financial", "Financial: Projected deficit / Low future surplus", currentDate, 
+				new TypeDto("Financial", "Financial: Projected deficit", currentDate, 
 					currentDate, 4),
-				new TypeDto("Financial", "Financial: Cash flow shortfall", currentDate, 
-					currentDate, 5),
-				new TypeDto("Financial", "Financial: Clawback", currentDate, 
-					currentDate, 6),
+				new TypeDto("Financial", "Financial: Viability", currentDate, 
+					currentDate, 20),
+				
 				new TypeDto("Force Majeure", "", currentDate, 
 					currentDate, 7),
-				new TypeDto("Governance", "Governance: Governance", currentDate, 
+				
+				new TypeDto("Governance and compliance", "Governance and compliance: Governance", currentDate, 
 					currentDate, 8),
-				new TypeDto("Governance", "Governance: Closure", currentDate, 
-					currentDate, 9),
-				new TypeDto("Governance", "Governance: Executive Pay", currentDate, 
-					currentDate, 10),
-				new TypeDto("Governance", "Governance: Safeguarding", currentDate, 
-					currentDate, 11),
-				new TypeDto("Irregularity", "Irregularity: Allegations and self reported concerns", currentDate, 
-					currentDate, 12),
-				new TypeDto("Irregularity", "Irregularity: Related party transactions - in year", currentDate, 
-					currentDate, 13)
-			};
-		}
+				new TypeDto("Governance and compliance", "Governance and compliance: Compliance", currentDate, 
+					currentDate, 23),
 
-		public static List<TypeDto> BuildListOrphanTypeDto()
-		{
-			var currentDate = DateTimeOffset.Now;
-			return new List<TypeDto>
-			{
-				new TypeDto("Compliance", "Compliance: Financial reporting", currentDate,
-					currentDate, 0)
+				new TypeDto("Irregularity", "Irregularity: Irregularity", currentDate, 
+					currentDate, 21),
+				new TypeDto("Irregularity", "Irregularity: Suspected fraud", currentDate, 
+					currentDate, 22)
 			};
 		}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/TypeFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/TypeFactory.cs
@@ -38,8 +38,8 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 		{
 			return new TypeModel
 			{
-				Type = "Compliance",
-				SubType = "Compliance: Financial reporting",
+				Type = "Financial",
+				SubType = "Financial: Deficit",
 				TypesDictionary = new Dictionary<string, IList<TypeModel.TypeValueModel>>()
 			};
 		}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Types/TypeModelServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Types/TypeModelServiceTests.cs
@@ -34,7 +34,7 @@ namespace ConcernsCaseWork.Tests.Services.Types
 			// assert
 			Assert.That(structuredTypes, Is.Not.Null);
 			Assert.That(structuredTypes.TypesDictionary, Is.Not.Null);
-			Assert.That(structuredTypes.TypesDictionary.Count, Is.EqualTo(5));
+			Assert.That(structuredTypes.TypesDictionary.Count, Is.EqualTo(4));
 
 			foreach ((string key, IList<TypeModel.TypeValueModel> value) in structuredTypes.TypesDictionary)
 			{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
@@ -194,7 +194,6 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 			if (string.IsNullOrEmpty(trustUkPrn))
 				throw new Exception("Cache TrustUkprn is null");
 		
-			CreateRecordsModel = userState.CreateCaseModel.CreateRecordsModel;
 			TrustAddress = await _trustModelService.GetTrustAddressByUkPrn(trustUkPrn);
 			CreateRecordsModel = new List<CreateRecordModel>();
 			RatingsModel = await _ratingModelService.GetRatingsModel();

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Concern.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Concern.cshtml
@@ -37,9 +37,18 @@
 							<div class="govuk-radios__item">
 								<input class="govuk-radios__input" id="sub-type-@subTypeIndex" name="sub-type" type="radio" 
 								       value="@subtype.Id:@subtype.SubType" checked="@subType.Equals(subtype.SubType)">
+								@if (key.ToLower().Contains(subtype.SubType.ToLower()))
+								{
+								<label class="govuk-label govuk-radios__label" for="sub-type-@subTypeIndex">
+									@subtype.SubType
+								</label>
+								}
+								else
+								{
 								<label class="govuk-label govuk-radios__label" for="sub-type-@subTypeIndex">
 									@key: @subtype.SubType
 								</label>
+								}
 							</div>
 
 							subTypeIndex++;


### PR DESCRIPTION
***** BREAKING CHANGES *****

**What is the change?**
Change the available concerns types to match those in DaRT

**Why do we need the change?**
The current list is incorrect.

**What is the impact?**
BREAKING CHANGES.
Any existing data that links to the old concerns types will be invalid. 
Suggest clearing out databases before applying this change (we should be fine to do this in all environments).

Note I've also removed an unused line of code in index.cshtml.cs

**Azure DevOps Ticket**
116267
