### PR TITLE
Bug/116411 hide 'concern details' heading if no concerns

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -66,164 +66,165 @@
 		            <th scope="col"></th>
 	            </tr>
 	            </thead>
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table-case-details__header">Trust</th>
-                        <td class="govuk-table__cell">
-                            @Model.TrustDetailsModel.GiasData.GroupName
-                        </td>
-                        <td class="govuk-table__cell govuk-table__header__right"></td>
-                    </tr>
+	            <tbody class="govuk-table__body">
+	            <tr class="govuk-table__row">
+		            <th scope="row" class="govuk-table-case-details__header">Trust</th>
+		            <td class="govuk-table__cell">
+			            @Model.TrustDetailsModel.GiasData.GroupName
+		            </td>
+		            <td class="govuk-table__cell govuk-table__header__right"></td>
+	            </tr>
 
-                    @if (Model.IsConcernsCase)
-                    {
-                        <tr class="govuk-table__row">
-                            <th scope="row" class="govuk-table-case-details__header">Risk to trust</th>
-                            <td class="govuk-table__cell govuk-label-wrapper">
-                                @for (var index = 0; index < Model.CaseModel?.RatingModel?.RagRating?.Item2?.Count; ++index)
-                                {
-                                    <span class="govuk-tag ragtag @Model.CaseModel?.RatingModel?.RagRatingCss?.ElementAt(index)">
-                                        @Model.CaseModel?.RatingModel?.RagRating?.Item2?.ElementAt(index)
-                                    </span>
-                                }
-                            </td>
-                            <td class="govuk-table__cell govuk-table__header__right">
-                                @if (Model.IsEditableCase)
-                                {
-                                    <a class="govuk-link" href="@Request.Path/edit_rating" aria-label="Change risk to trust rating">
-                                        Edit<span class="govuk-visually-hidden"> risk to trust rating</span>
-                                    </a>
-                                }
-                            </td>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <th scope="row" class="govuk-table-case-details__header">Direction of travel</th>
-                            <td class="govuk-table__cell">
-                                @Model.CaseModel.DirectionOfTravel
-                            </td>
-                            <td class="govuk-table__cell govuk-table__header__right">
-                                @if (Model.IsEditableCase)
-                                {
-                                    <a class="govuk-link" href="@Request.Path/edit_directionoftravel" aria-label="Change direction of travel">
-                                        Edit<span class="govuk-visually-hidden"> direction of travel</span>
-                                    </a>
-                                }
-                            </td>
-                        </tr>
-                    }
-                    <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table-case-details__header">Concerns</th>
-                        <td colspan="2" class="govuk-table__cell">
-                            @if (Model.CaseModel.RecordsModel.Any())
-                            {
-                                <table class="govuk-table">
-                                    <tbody class="govuk-table__body">
-                                        @foreach (var concern in Model.CaseModel.RecordsModel)
-                                        {
-                                            <tr class="govuk-table__row">
-                                                <td>
-                                                    @concern.TypeModel.TypeDisplay
-                                                </td>
-                                                <td>
-                                                    <div class="govuk-ragtag-wrapper govuk-!-padding-bottom-1 govuk-!-padding-right-4">
-                                                        @{
-                                                            if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
-                                                            {
-                                                                <span class="govuk-tag ragtag ragtag__grey">
-                                                                    Closed
-                                                                </span>
-                                                            }
-                                                            else
-                                                            {
-                                                                for (var index = 0; index < concern.RatingModel.RagRating.Item2.Count; ++index)
-                                                                {
-                                                                    <span class="govuk-tag ragtag @concern.RatingModel.RagRatingCss.ElementAt(index)">
-                                                                        @concern.RatingModel.RagRating.Item2.ElementAt(index)
-                                                                    </span>
-                                                                }
-                                                            }
-                                                        }
-                                                    </div>
-                                                </td>
-                                                <td class="govuk-table__header__right">
-                                                    @{
-                                                        if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
-                                                        {
-                                                            <br />
-                                                        }
-                                                        else
-                                                        {
-                                                            <div class="govuk-!-padding-bottom-1">
-                                                                @if (Model.IsEditableCase)
-                                                                {
-                                                                    <a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating" aria-label="Change @concern.TypeModel.TypeDisplay rating" data-testid="edit-concern">Edit</a>
-                                                                }
-                                                            </div>
-                                                        }
-                                                    }
-                                                </td>
-                                            </tr>
-                                        }
-                                    </tbody>
-                                </table>
-                            }
-                            <div class="govuk-o-grid__item--one-half">
-                                @if (Model.IsEditableCase)
-                                {
-                                    <a href="@Request.Path/concern" class="govuk-link govuk-link-no-visited-state">Add concern</a>
-                                }
-                            </div>
+	            @if (Model.IsConcernsCase)
+	            {
+		            <tr class="govuk-table__row">
+			            <th scope="row" class="govuk-table-case-details__header">Risk to trust</th>
+			            <td class="govuk-table__cell govuk-label-wrapper">
+				            @for (var index = 0; index < Model.CaseModel?.RatingModel?.RagRating?.Item2?.Count; ++index)
+				            {
+					            <span class="govuk-tag ragtag @Model.CaseModel?.RatingModel?.RagRatingCss?.ElementAt(index)">
+						            @Model.CaseModel?.RatingModel?.RagRating?.Item2?.ElementAt(index)
+					            </span>
+				            }
+			            </td>
+			            <td class="govuk-table__cell govuk-table__header__right">
+				            @if (Model.IsEditableCase)
+				            {
+					            <a class="govuk-link" href="@Request.Path/edit_rating" aria-label="Change risk to trust rating">
+						            Edit<span class="govuk-visually-hidden"> risk to trust rating</span>
+					            </a>
+				            }
+			            </td>
+		            </tr>
+		            <tr class="govuk-table__row">
+			            <th scope="row" class="govuk-table-case-details__header">Direction of travel</th>
+			            <td class="govuk-table__cell">
+				            @Model.CaseModel.DirectionOfTravel
+			            </td>
+			            <td class="govuk-table__cell govuk-table__header__right">
+				            @if (Model.IsEditableCase)
+				            {
+					            <a class="govuk-link" href="@Request.Path/edit_directionoftravel" aria-label="Change direction of travel">
+						            Edit<span class="govuk-visually-hidden"> direction of travel</span>
+					            </a>
+				            }
+			            </td>
+		            </tr>
+	            }
+	            <tr class="govuk-table__row">
+		            <th scope="row" class="govuk-table-case-details__header">Concerns</th>
+		            <td colspan="2" class="govuk-table__cell">
+			            @if (Model.CaseModel.RecordsModel.Any())
+			            {
+				            <table class="govuk-table">
+					            <tbody class="govuk-table__body">
+					            @foreach (var concern in Model.CaseModel.RecordsModel)
+					            {
+						            <tr class="govuk-table__row">
+							            <td>
+								            @concern.TypeModel.TypeDisplay
+							            </td>
+							            <td>
+								            <div class="govuk-ragtag-wrapper govuk-!-padding-bottom-1 govuk-!-padding-right-4">
+									            @{
+										            if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
+										            {
+											            <span class="govuk-tag ragtag ragtag__grey">
+												            Closed
+											            </span>
+										            }
+										            else
+										            {
+											            for (var index = 0; index < concern.RatingModel.RagRating.Item2.Count; ++index)
+											            {
+												            <span class="govuk-tag ragtag @concern.RatingModel.RagRatingCss.ElementAt(index)">
+													            @concern.RatingModel.RagRating.Item2.ElementAt(index)
+												            </span>
+											            }
+										            }
+									            }
+								            </div>
+							            </td>
+							            <td class="govuk-table__header__right">
+								            @{
+									            if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
+									            {
+										            <br />
+									            }
+									            else
+									            {
+										            <div class="govuk-!-padding-bottom-1">
+											            @if (Model.IsEditableCase)
+											            {
+												            <a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating" aria-label="Change @concern.TypeModel.TypeDisplay rating" data-testid="edit-concern">Edit</a>
+											            }
+										            </div>
+									            }
+								            }
+							            </td>
+						            </tr>
+					            }
+					            </tbody>
+				            </table>
+			            }
+			            <div class="govuk-o-grid__item--one-half">
+				            @if (Model.IsEditableCase)
+				            {
+					            <a href="@Request.Path/concern" class="govuk-link govuk-link-no-visited-state">Add concern</a>
+				            }
+			            </div>
 
-                        </td>
-                        <td class="govuk-table__cell__no_border"></td>
-                    </tr>
+		            </td>
+		            <td class="govuk-table__cell__no_border"></td>
+	            </tr>
 
-                    <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table-case-details__header">SFSO territory</th>
-                        <td class="govuk-table__cell" data-testid="territory_Field">
-                            @if (Model.CaseModel.Territory == null)
-                            {
-                                <span class='govuk-tag ragtag ragtag__grey'>Empty</span>
-                            }
-                            else
-                            {
-                                @Model.CaseModel.Territory?.Description()
-                            }
+	            <tr class="govuk-table__row">
+		            <th scope="row" class="govuk-table-case-details__header">SFSO territory</th>
+		            <td class="govuk-table__cell" data-testid="territory_Field">
+			            @if (Model.CaseModel.Territory == null)
+			            {
+				            <span class='govuk-tag ragtag ragtag__grey'>Empty</span>
+			            }
+			            else
+			            {
+				            @Model.CaseModel.Territory?.Description()
+			            }
 
-                        </td>
-                        <td class="govuk-table__cell govuk-table__header__right">
-                            @if (Model.IsEditableCase)
-                            {
-                                    <a class="govuk-link" data-testid="edit_Button_SFSO" href="@Request.Path/edit-territory" aria-label="Change SFSO territory">
-                                    Edit<span class="govuk-visually-hidden"> SFSO territory</span>
-                                </a>
-                            }
-                        </td>
-                    </tr>
+		            </td>
+		            <td class="govuk-table__cell govuk-table__header__right">
+			            @if (Model.IsEditableCase)
+			            {
+				            <a class="govuk-link" data-testid="edit_Button_SFSO" href="@Request.Path/edit-territory" aria-label="Change SFSO territory">
+					            Edit<span class="govuk-visually-hidden"> SFSO territory</span>
+				            </a>
+			            }
+		            </td>
+	            </tr>
 
-                    <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table-case-details__header">Caseworker</th>
-                        <td class="govuk-table__cell">
-                            @Model.CaseModel.CreatedBy.FromEmailToFullName()
-                        </td>
-                        <td class="govuk-table__cell govuk-table__header__right"></td>
-                    </tr>
+	            <tr class="govuk-table__row">
+		            <th scope="row" class="govuk-table-case-details__header">Caseworker</th>
+		            <td class="govuk-table__cell">
+			            @Model.CaseModel.CreatedBy.FromEmailToFullName()
+		            </td>
+		            <td class="govuk-table__cell govuk-table__header__right"></td>
+	            </tr>
 
-                    <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table-case-details__header">Date Created</th>
-                        <td class="govuk-table__cell">
-                            @DateTimeHelper.ParseToDisplayDate(Model.CaseModel.CreatedAt)
-                        </td>
-                        <td class="govuk-table__cell govuk-table__header__right"></td>
-                    </tr>
+	            <tr class="govuk-table__row">
+		            <th scope="row" class="govuk-table-case-details__header">Date Created</th>
+		            <td class="govuk-table__cell">
+			            @DateTimeHelper.ParseToDisplayDate(Model.CaseModel.CreatedAt)
+		            </td>
+		            <td class="govuk-table__cell govuk-table__header__right"></td>
+	            </tr>
 
-                </tbody>
+	            </tbody>
             </table>
             
+            @if (Model.IsConcernsCase)
+            {   
             <h2 class="govuk-heading-m">Concern details</h2>
             <hr class="govuk-section-break govuk-section-break--visible">
-	         @if (Model.IsConcernsCase)
-	         {
+	 
 				<table class="govuk-table" id="concern-narratives-default">
 		            <caption class="govuk-table__caption govuk-table__caption--m"></caption>
 		            <thead>


### PR DESCRIPTION
**What is the change?**
'Concern details' heading is showing when it should not be showing, ie when there are no concern details to display.

**Why do we need the change?**
To make the UI correct

**What is the impact?**
UI

**Azure DevOps Ticket**
116411
