### PR TITLE
116342: sort order on the open and closed actions table

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/SRMAControllerTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/SRMAControllerTests.cs
@@ -368,10 +368,10 @@ namespace ConcernsCaseWork.API.Tests.Controllers
                      updatedByDelegate = req.Delegate(srmaModel);
                  });
 
-            controllerSUT.UpdateDateClosed(srmaId, targetDateClosed.ToString(dtSerialisationFormat));
+            controllerSUT.UpdateDateClosed(srmaId);
 
             updatedByDelegate.Should().NotBeNull();
-            updatedByDelegate.ClosedAt.Should().Be(targetDateClosed);
+			updatedByDelegate.ClosedAt.Should().NotBeNull();
         }
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/CloseDecisionIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/CloseDecisionIntegrationTests.cs
@@ -135,14 +135,14 @@ public class CloseDecisionIntegrationTests
 	[Fact]
 	public async Task When_PatchWithMissingCase_Returns_404Response()
 	{
-		var caseId = _fixture.Create<int>();
+		var caseId = 1000000;
 		
 		var request = new CloseDecisionRequest()
 		{
 			SupportingNotes = _fixture.Create<string>()
 		};
 
-		var result = await _client.PatchAsync($"/v2/concerns-cases/{caseId}/decisions/{_fixture.Create<int>()}/close", request.ConvertToJson());
+		var result = await _client.PatchAsync($"/v2/concerns-cases/{caseId}/decisions/1/close", request.ConvertToJson());
 
 		result.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
@@ -161,7 +161,7 @@ public class CloseDecisionIntegrationTests
 
 		var cCase = await CreateCase();
 		var cCaseId = cCase.Id;
-		var decisionId = _fixture.Create<int>();
+		var decisionId = 1000000;
 
 		var result = await _client.PatchAsync($"/v2/concerns-cases/{cCaseId}/decisions/{decisionId}/close", request.ConvertToJson());
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/SRMAController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/SRMAController.cs
@@ -250,7 +250,7 @@ namespace ConcernsCaseWork.API.Controllers
         [HttpPatch]
         [Route("{srmaId}/update-closed-date")]
         [MapToApiVersion("2.0")]
-        public ActionResult<ApiSingleResponseV2<SRMAResponse>> UpdateDateClosed(int srmaId, string dateClosed)
+        public ActionResult<ApiSingleResponseV2<SRMAResponse>> UpdateDateClosed(int srmaId)
         {
             try
             {
@@ -259,7 +259,7 @@ namespace ConcernsCaseWork.API.Controllers
                     SRMAId = srmaId,
                     Delegate = (srma) =>
                     {
-                        srma.ClosedAt = DeserialiseDateTime(dateClosed);
+						srma.ClosedAt = DateTime.Now;
                         return srma;
                     }
                 });

--- a/ConcernsCaseWork/ConcernsCaseWork.Redis/CaseActions/CachedSRMAProvider.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis/CaseActions/CachedSRMAProvider.cs
@@ -115,9 +115,9 @@ namespace ConcernsCaseWork.Redis.CaseActions
 			}
 		}
 
-		public async Task SetDateClosed(long srmaId, DateTime? ClosedDate)
+		public async Task SetDateClosed(long srmaId)
 		{
-			var patched = await _srmaProvider.SetDateClosed(srmaId, ClosedDate);
+			var patched = await _srmaProvider.SetDateClosed(srmaId);
 			if (patched != null)
 			{
 				if (patched.Id != srmaId)

--- a/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/CaseActions/SRMAProviderTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/CaseActions/SRMAProviderTests.cs
@@ -166,7 +166,7 @@ namespace ConcernsCaseWork.Service.Tests.CaseActions
 			var sut = new SRMAProvider(httpClientFactory.Object, logger.Object, Mock.Of<ICorrelationContext>());
 
 			// Act
-			var response = sut.SetDateClosed(654, dateClosed).Result;
+			var response = sut.SetDateClosed(654).Result;
 
 			// Assert
 			Assert.AreEqual(expectedSRMADto.Id, response.Id);

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/CaseActions/SRMAProvider.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/CaseActions/SRMAProvider.cs
@@ -98,12 +98,12 @@ namespace ConcernsCaseWork.Service.CaseActions
 			}
 		}
 
-		public async Task<SRMADto> SetDateClosed(long srmaId, DateTime? closedDate)
+		public async Task<SRMADto> SetDateClosed(long srmaId)
 		{
 			try
 			{
 				var client = _httpClientFactory.CreateClient(HttpClientName);
-				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-closed-date?dateClosed={SerialiseDateTime(closedDate)}");
+				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-closed-date");
 
 				var response = await client.SendAsync(request);
 				var content = await response.Content.ReadAsStringAsync();

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/ActionSummaryMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/ActionSummaryMappingTests.cs
@@ -1,0 +1,47 @@
+﻿using ConcernsCaseWork.Mappers;
+using ConcernsCaseWork.Models.CaseActions;
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace ConcernsCaseWork.Tests.Mappers
+{
+	[Parallelizable(ParallelScope.All)]
+	public class ActionSummaryMappingTests
+	{
+		[Test]
+		public void Map_Returns_CorrectModel()
+		{
+			var openDecision = new ActionSummaryModel() { RawOpenedDate = new DateTimeOffset(new DateTime(2020, 12, 12)) };
+			var openSrma = new ActionSummaryModel() { RawOpenedDate = new DateTimeOffset(new DateTime(2020, 7, 7)) };
+			var openNti = new ActionSummaryModel() { RawOpenedDate = new DateTimeOffset(new DateTime(2020, 1, 1)) };
+			var openFinancialPlan = new ActionSummaryModel() { RawOpenedDate = new DateTimeOffset(new DateTime(2020, 1, 3)) };
+
+			var closedDecision = new ActionSummaryModel() { RawClosedDate = new DateTimeOffset(new DateTime(2020, 12, 12)) };
+			var closedSrma = new ActionSummaryModel() { RawClosedDate = new DateTimeOffset(new DateTime(2020, 7, 7)) };
+			var closedNti = new ActionSummaryModel() { RawClosedDate = new DateTimeOffset(new DateTime(2020, 1, 1)) };
+			var closedFinancialPlan = new ActionSummaryModel() { RawClosedDate = new DateTimeOffset(new DateTime(2020, 1, 3)) };
+
+			var input = new List<ActionSummaryModel>()
+			{
+				openDecision,
+				openSrma,
+				openNti,
+				openFinancialPlan,
+				closedDecision,
+				closedSrma,
+				closedNti,
+				closedFinancialPlan
+			};
+
+			var result = ActionSummaryMapping.ToActionSummaryBreakdown(input);
+
+			var expectedOpenCases = new List<ActionSummaryModel>() { openNti, openFinancialPlan, openSrma, openDecision };
+			var expectedClosedCases = new List<ActionSummaryModel>() { closedNti, closedFinancialPlan, closedSrma, closedDecision };
+
+			result.OpenActions.Should().BeEquivalentTo(expectedOpenCases, config => config.WithStrictOrdering());
+			result.ClosedActions.Should().BeEquivalentTo(expectedClosedCases, config => config.WithStrictOrdering());
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/FinancialPlanMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/FinancialPlanMappingTests.cs
@@ -330,6 +330,9 @@ namespace ConcernsCaseWork.Tests.Mappers
 				Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/financialplan/{testData.Id}/closed"));
 				Assert.That(actionSummary.StatusName, Is.EqualTo("Awaiting plan"));
 			});
+
+			actionSummary.RawOpenedDate.Should().Be(testData.CreatedAt);
+			actionSummary.RawClosedDate.Should().Be(testData.ClosedAt);
 		}
 
 		[Test]

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiMappingTests.cs
@@ -197,6 +197,9 @@ namespace ConcernsCaseWork.Tests.Mappers
 				Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/nti/{testData.Id}"));
 				Assert.That(actionSummary.StatusName, Is.EqualTo(testData.ClosedStatus.Value));
 			});
+
+			actionSummary.RawOpenedDate.Should().Be(testData.CreatedAt);
+			actionSummary.RawClosedDate.Should().Be(testData.ClosedAt);
 		}
 
 		[TestCaseSource(nameof(GetStatusTestCases))]

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiUnderConsiderationMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiUnderConsiderationMappingTests.cs
@@ -47,7 +47,7 @@ namespace ConcernsCaseWork.Tests.Mappers
 			Assert.That(serviceModel.ClosedStatusId, Is.EqualTo(ntiDto.ClosedStatusId));
 			Assert.That(serviceModel.ClosedStatusName, Is.EqualTo(ntiDto.ClosedStatusName));
 			Assert.That(serviceModel.ClosedAt, Is.EqualTo(ntiDto.ClosedAt.Value));
-			Assert.That(serviceModel.CreatedAt, Is.EqualTo(ntiDto.CreatedAt.Date));
+			Assert.That(serviceModel.CreatedAt, Is.EqualTo(ntiDto.CreatedAt));
 			Assert.That(serviceModel.Notes, Is.EqualTo(ntiDto.Notes));
 			Assert.That(serviceModel.NtiReasonsForConsidering, Is.Not.Null);
 			Assert.That(serviceModel.UpdatedAt, Is.EqualTo(ntiDto.UpdatedAt));

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiUnderConsiderationMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiUnderConsiderationMappingTests.cs
@@ -136,6 +136,9 @@ namespace ConcernsCaseWork.Tests.Mappers
 				Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/ntiunderconsideration/{testData.Id}"));
 				Assert.That(actionSummary.StatusName, Is.EqualTo(testData.ClosedStatus.Name));
 			});
+
+			actionSummary.RawOpenedDate.Should().Be(testData.CreatedAt);
+			actionSummary.RawClosedDate.Should().Be(testData.ClosedAt);
 		}
 
 		[TestCaseSource(nameof(GetStatusTestCases))]

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiWarningLetterMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiWarningLetterMappingTests.cs
@@ -186,6 +186,9 @@ namespace ConcernsCaseWork.Tests.Mappers
 				Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/ntiwarningletter/{testData.Id}"));
 				Assert.That(actionSummary.StatusName, Is.EqualTo(testData.Status.Name));
 			});
+
+			actionSummary.RawOpenedDate.Should().Be(testData.CreatedAt);
+			actionSummary.RawClosedDate.Should().Be(testData.ClosedAt);
 		}
 
 		[TestCaseSource(nameof(GetStatusTestCases))]

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/SrmaMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/SrmaMappingTests.cs
@@ -127,6 +127,9 @@ public class SrmaMappingTests
 			Assert.That(actionSummary.RelativeUrl, Is.EqualTo($"/case/{testData.CaseUrn}/management/action/srma/{testData.Id}/closed"));
 			Assert.That(actionSummary.StatusName, Is.EqualTo(EnumHelper.GetEnumDescription(testData.Status)));
 		});
+
+		actionSummary.RawOpenedDate.Should().Be(testData.CreatedAt);
+		actionSummary.RawClosedDate.Should().Be(testData.ClosedAt);
 	}
 
 	[Test]

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
@@ -90,11 +90,11 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 
 			var closedActions = _fixture.CreateMany<ActionSummaryModel>().ToList();
 
-			var allActions = new List<ActionSummaryModel>();
-			allActions.AddRange(openActions);
-			allActions.AddRange(closedActions);
+			var actionBreakdown = new ActionSummaryBreakdownModel();
+			actionBreakdown.OpenActions = openActions;
+			actionBreakdown.ClosedActions = closedActions;
 
-			_actionsModelService.Setup(m => m.GetActionsSummary(It.IsAny<long>())).ReturnsAsync(allActions);
+			_actionsModelService.Setup(m => m.GetActionsSummary(It.IsAny<long>())).ReturnsAsync(actionBreakdown);
 
 			var caseModel = _fixture.Create<CaseModel>();
 			_mockCaseModelService.Setup(m => m.GetCaseByUrn(It.IsAny<long>())).ReturnsAsync(caseModel);
@@ -288,7 +288,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 			_mockNtiStatusesCachedService.Setup(s => s.GetAllStatuses())
 				.ReturnsAsync(new List<NtiUnderConsiderationStatusDto>());
 			_actionsModelService.Setup(m => m.GetActionsSummary(It.IsAny<long>()))
-				.ReturnsAsync(new List<ActionSummaryModel>());
+				.ReturnsAsync(new ActionSummaryBreakdownModel());
 		}
 
 		private void PageLoadedWithoutError(IndexPageModel pageModel)

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/ViewClosedPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/ViewClosedPageModelTests.cs
@@ -107,16 +107,17 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
 			var recordsModel = RecordFactory.BuildListRecordModel();
 
-			var allActions = new List<ActionSummaryModel>();
+			var actionBreakdown = new ActionSummaryBreakdownModel();
 
 			var openActions = _fixture
 				.Build<ActionSummaryModel>()
 				.Without(a => a.ClosedDate)
 				.CreateMany().ToList();
-			allActions.AddRange(openActions);
+
+			actionBreakdown.OpenActions = openActions;
 
 			var closedActions = _fixture.CreateMany<ActionSummaryModel>().ToList();
-			allActions.AddRange(closedActions);
+			actionBreakdown.ClosedActions = closedActions;
 
 			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<long>()))
 				.ReturnsAsync(caseModel);
@@ -125,7 +126,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn( It.IsAny<long>()))
 				.ReturnsAsync(recordsModel);
 			mockActionsModelService.Setup(a => a.GetActionsSummary(It.IsAny<long>()))
-				.ReturnsAsync(allActions);
+				.ReturnsAsync(actionBreakdown);
 			mockStatusCachedService.Setup(a => a.GetStatusByName(StatusEnum.Close.ToString()))
 				.ReturnsAsync(new StatusDto("Closed", DateTimeOffset.Now, DateTimeOffset.Now, caseModel.StatusId));
 
@@ -224,7 +225,12 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			var caseModel = CaseFactory.BuildCaseModel();
 			var trustDetailsModel = TrustFactory.BuildTrustDetailsModel();
 			var recordsModel = RecordFactory.BuildListRecordModel();
-			var closedActions = ActionsSummaryFactory.BuildListOfActionSummaries();
+			var closedActions = ActionsSummaryFactory.BuildListOfActionSummaries().ToList();
+
+			var actionBreakdown = new ActionSummaryBreakdownModel()
+			{
+				ClosedActions = closedActions
+			};
 
 			mockCaseModelService.Setup(c => c.GetCaseByUrn(It.IsAny<long>()))
 				.ReturnsAsync(caseModel);
@@ -233,7 +239,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case
 			mockRecordModelService.Setup(r => r.GetRecordsModelByCaseUrn( It.IsAny<long>()))
 				.ReturnsAsync(recordsModel);
 			mockActionsModelService.Setup(a => a.GetActionsSummary(It.IsAny<long>()))
-				.ReturnsAsync(closedActions);
+				.ReturnsAsync(actionBreakdown);
 			mockStatusCachedService.Setup(a => a.GetStatusByName(StatusEnum.Close.ToString()))
 				.ReturnsAsync(new StatusDto("Open", DateTimeOffset.Now, DateTimeOffset.Now, 99999));
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Decisions/DecisionMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Decisions/DecisionMappingTests.cs
@@ -8,6 +8,7 @@ using ConcernsCaseWork.Models.Validatable;
 using ConcernsCaseWork.Services.Decisions;
 using FluentAssertions;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,6 +36,8 @@ namespace ConcernsCaseWork.Tests.Services.Decisions
 			result.ClosedDate.Should().Be("30-08-2024");
 			result.Name.Should().Be($"Decision: {apiDecision.Title}");
 			result.RelativeUrl.Should().Be($"/case/{apiDecision.ConcernsCaseUrn}/management/action/decision/{apiDecision.DecisionId}");
+			result.RawOpenedDate.Should().Be(apiDecision.CreatedAt);
+			result.RawClosedDate.Should().Be(apiDecision.ClosedAt);
 		}
 		
 		[Test]
@@ -52,17 +55,6 @@ namespace ConcernsCaseWork.Tests.Services.Decisions
 			var result = DecisionMapping.ToActionSummary(apiDecision);
 
 			result.StatusName.Should().Be(expectedStatusName);
-		}
-				
-		[Test]
-		public void ToActionSummary_WhenClosedAtIsNull_ReturnsCorrectModel()
-		{
-			var apiDecision = _fixture.Create<DecisionSummaryResponse>();
-			apiDecision.ClosedAt = null;
-
-			var result = DecisionMapping.ToActionSummary(apiDecision);
-
-			result.ClosedDate.Should().BeNull();
 		}
 
 		[TestCase(null, "No")]

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/ActionSummaryMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/ActionSummaryMapping.cs
@@ -1,0 +1,23 @@
+﻿using ConcernsCaseWork.Models.CaseActions;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConcernsCaseWork.Mappers
+{
+	public class ActionSummaryMapping
+	{
+		public static ActionSummaryBreakdownModel ToActionSummaryBreakdown(List<ActionSummaryModel> actionSummaries)
+		{
+			var openCaseActions = actionSummaries.Where(a => a.RawClosedDate == null).OrderBy(a => a.RawOpenedDate).ToList();
+			var closedCaseActions = actionSummaries.Except(openCaseActions).OrderBy(a => a.RawClosedDate).ToList();
+
+			var result = new ActionSummaryBreakdownModel()
+			{
+				OpenActions = openCaseActions,
+				ClosedActions = closedCaseActions
+			};
+
+			return result;
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/CaseActionsMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/CaseActionsMapping.cs
@@ -64,7 +64,9 @@ namespace ConcernsCaseWork.Mappers
 				Name = "SRMA",
 				OpenedDate = srmaModel.CreatedAt.ToDayMonthYear(),
 				RelativeUrl = relativeUrl,
-				StatusName = EnumHelper.GetEnumDescription(srmaModel.Status)
+				StatusName = EnumHelper.GetEnumDescription(srmaModel.Status),
+				RawOpenedDate = srmaModel.CreatedAt,
+				RawClosedDate = srmaModel.ClosedAt
 			};
 
 			return result;

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/FinancialPlanMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/FinancialPlanMapping.cs
@@ -101,7 +101,9 @@ namespace ConcernsCaseWork.Mappers
 				Name = "Financial Plan",
 				OpenedDate = model.CreatedAt.ToDayMonthYear(),
 				RelativeUrl = relativeUrl,
-				StatusName = status
+				StatusName = status,
+				RawOpenedDate = model.CreatedAt,
+				RawClosedDate = model.ClosedAt
 			};
 
 			return result;

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiMappers.cs
@@ -101,7 +101,9 @@ namespace ConcernsCaseWork.Mappers
 				Name = "NTI",
 				OpenedDate = model.CreatedAt.ToDayMonthYear(),
 				RelativeUrl = $"/case/{model.CaseUrn}/management/action/nti/{model.Id}",
-				StatusName = status
+				StatusName = status,
+				RawOpenedDate = model.CreatedAt,
+				RawClosedDate = model.ClosedAt,
 			};
 
 			return result;

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiUnderConsiderationMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiUnderConsiderationMappers.cs
@@ -75,7 +75,9 @@ namespace ConcernsCaseWork.Mappers
 				Name = "NTI Under Consideration",
 				OpenedDate = model.CreatedAt.ToDayMonthYear(),
 				RelativeUrl = $"/case/{model.CaseUrn}/management/action/ntiunderconsideration/{model.Id}",
-				StatusName = statusName
+				StatusName = statusName,
+				RawOpenedDate = model.CreatedAt,
+				RawClosedDate = model.ClosedAt
 			};
 
 			return result;

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiUnderConsiderationMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiUnderConsiderationMappers.cs
@@ -33,7 +33,7 @@ namespace ConcernsCaseWork.Mappers
 				Id = ntiDto.Id,
 				CaseUrn = ntiDto.CaseUrn,
 				NtiReasonsForConsidering = ntiDto.Reasons?.Select(r => ToServiceModel(r)).ToArray(),	
-				CreatedAt = ntiDto.CreatedAt.Date,
+				CreatedAt = ntiDto.CreatedAt,
 				Notes = ntiDto.Notes,
 				UpdatedAt = ntiDto.UpdatedAt,
 				ClosedAt = ntiDto.ClosedAt,

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiWarningLetterMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiWarningLetterMappers.cs
@@ -96,7 +96,9 @@ namespace ConcernsCaseWork.Mappers
 				Name = "NTI Warning Letter",
 				OpenedDate = model.CreatedAt.ToDayMonthYear(),
 				RelativeUrl = $"/case/{model.CaseUrn}/management/action/ntiwarningletter/{model.Id}",
-				StatusName = status
+				StatusName = status,
+				RawOpenedDate = model.CreatedAt,
+                RawClosedDate = model.ClosedAt
 			};
 
 			return result;

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/ActionSummaryBreakdownModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/ActionSummaryBreakdownModel.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace ConcernsCaseWork.Models.CaseActions
+{
+	public class ActionSummaryBreakdownModel
+	{
+		public ActionSummaryBreakdownModel()
+		{
+			OpenActions = new List<ActionSummaryModel>();
+			ClosedActions = new List<ActionSummaryModel>();
+		}
+		public List<ActionSummaryModel> OpenActions { get; set; }
+		public List<ActionSummaryModel> ClosedActions { get; set; }
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/ActionSummaryModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/ActionSummaryModel.cs
@@ -1,3 +1,6 @@
+using Microsoft.VisualBasic;
+using System;
+
 namespace ConcernsCaseWork.Models.CaseActions
 {
 	public record ActionSummaryModel
@@ -7,5 +10,11 @@ namespace ConcernsCaseWork.Models.CaseActions
 		public string Name { get; set; }
 		public string OpenedDate { get; set; }
 		public string ClosedDate { get; set; }
+
+		// Properties required to do sorting
+		// We can't sort on strings, because we lose the time
+		// Once we can move the action summaries into a dedicated api these could be removed
+		public DateTimeOffset RawOpenedDate { get; set; }
+		public DateTimeOffset? RawClosedDate { get; set; }
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Add.cshtml.cs
@@ -285,8 +285,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Nti
 				Conditions = Array.Empty<NtiConditionModel>(),
 				Notes = notes,
 				DateStarted = dateStarted,
-				CreatedAt = DateTime.Now.Date,
-				UpdatedAt = DateTime.Now.Date
+				CreatedAt = DateTime.Now,
+				UpdatedAt = DateTime.Now
 			};
 
 			return nti;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Add.cshtml.cs
@@ -301,8 +301,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiWarningLetter
 				Conditions = new List<NtiWarningLetterConditionModel>(),
 				Notes = notes,
 				SentDate = sentDate,
-				CreatedAt = DateTime.Now.Date,
-				UpdatedAt = DateTime.Now.Date
+				CreatedAt = DateTime.Now,
+				UpdatedAt = DateTime.Now
 			};
 
 			return nti;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Resolve.cshtml.cs
@@ -107,7 +107,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA
 				
 				await _srmaModelService.SetNotes(srmaId, srmaNotes);
 				await _srmaModelService.SetStatus(srmaId, resolvedStatus);
-				await _srmaModelService.SetDateClosed(srmaId, DateTime.Now);
+				await _srmaModelService.SetDateClosed(srmaId);
 
 				return Redirect($"/case/{caseUrn}/management");
 			}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
@@ -1,17 +1,12 @@
 ﻿using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Base;
-using ConcernsCaseWork.Services.Actions;
 using ConcernsCaseWork.Redis.NtiUnderConsideration;
 using ConcernsCaseWork.Redis.Status;
 using ConcernsCaseWork.Service.NtiUnderConsideration;
 using ConcernsCaseWork.Service.Status;
+using ConcernsCaseWork.Services.Actions;
 using ConcernsCaseWork.Services.Cases;
-using ConcernsCaseWork.Services.Decisions;
-using ConcernsCaseWork.Services.FinancialPlan;
-using ConcernsCaseWork.Services.Nti;
-using ConcernsCaseWork.Services.NtiUnderConsideration;
-using ConcernsCaseWork.Services.NtiWarningLetter;
 using ConcernsCaseWork.Services.Ratings;
 using ConcernsCaseWork.Services.Records;
 using ConcernsCaseWork.Services.Trusts;
@@ -43,7 +38,6 @@ namespace ConcernsCaseWork.Pages.Case.Management
 		public TrustDetailsModel TrustDetailsModel { get; private set; }
 		public IList<ActiveCaseSummaryModel> ActiveCases { get; private set; }
 		public IList<ClosedCaseSummaryModel> ClosedCases { get; private set; }
-		public List<ActionSummaryModel> CaseActions { get; private set; }
 		public List<NtiUnderConsiderationStatusDto> NtiStatuses { get; set; }
 		public bool IsConcernsCase { get; set; }
 		public bool IsEditableCase { get; private set; }
@@ -128,11 +122,10 @@ namespace ConcernsCaseWork.Pages.Case.Management
 
 		private async Task PopulateCaseActions(long caseUrn)
 		{
-			CaseActions = CaseActions ?? new List<ActionSummaryModel>();
-			CaseActions.AddRange(await _actionsModelService.GetActionsSummary(caseUrn));
+			var caseActionsSummaryBreakdown = await _actionsModelService.GetActionsSummary(caseUrn);
 
-			OpenCaseActions = CaseActions.Where(a => a.ClosedDate == null).ToList();
-			ClosedCaseActions = CaseActions.Except(OpenCaseActions).ToList();
+			OpenCaseActions = caseActionsSummaryBreakdown.OpenActions;
+			ClosedCaseActions = caseActionsSummaryBreakdown.ClosedActions;
 		}
 
 		private bool UserHasEditCasePrivileges()

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml.cs
@@ -72,7 +72,7 @@ namespace ConcernsCaseWork.Pages.Case
 				var recordsModel = await _recordModelService.GetRecordsModelByCaseUrn(caseUrn);
 				CaseModel.RecordsModel = recordsModel;
 
-				CaseActions = (await _actionsModelService.GetActionsSummary(caseUrn)).Where(a => a.ClosedDate != null).ToList();
+				CaseActions = (await _actionsModelService.GetActionsSummary(caseUrn)).ClosedActions;
 			}
 			catch (Exception ex)
 			{

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/ActionsModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/ActionsModelService.cs
@@ -48,12 +48,14 @@ namespace ConcernsCaseWork.Services.Actions
 			_decisionModelService = decisionModelService;
 		}
 
-		public async Task<IList<ActionSummaryModel>> GetActionsSummary(long caseUrn)
+		public async Task<ActionSummaryBreakdownModel> GetActionsSummary(long caseUrn)
 		{
-			var caseActions = new List<ActionSummaryModel>();
-				
+			var result = new ActionSummaryBreakdownModel();
+
 			try
 			{
+				var caseActions = new List<ActionSummaryModel>();
+
 				caseActions.AddRange(await GetSrmas(caseUrn));
 				caseActions.AddRange(await GetFinancialPlans(caseUrn));
 				caseActions.AddRange(await GetNtisUnderConsideration(caseUrn));
@@ -61,7 +63,9 @@ namespace ConcernsCaseWork.Services.Actions
 				caseActions.AddRange(await GetNtisForCase(caseUrn));
 				caseActions.AddRange(await _decisionModelService.GetDecisionsByUrn(caseUrn));
 
-				return caseActions;
+				result = ActionSummaryMapping.ToActionSummaryBreakdown(caseActions);
+
+				return result;
 			}
 			catch (Exception ex)
 			{
@@ -69,7 +73,7 @@ namespace ConcernsCaseWork.Services.Actions
 					nameof(ActionsModelService), LoggingHelpers.EchoCallerName(), ex.Message);
 			}
 			
-			return caseActions;
+			return result;
 		}
 
 		private async Task<IEnumerable<ActionSummaryModel>> GetSrmas(long caseUrn)

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/IActionsModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Actions/IActionsModelService.cs
@@ -6,6 +6,6 @@ namespace ConcernsCaseWork.Services.Actions
 {
 	public interface IActionsModelService
 	{
-		Task<IList<ActionSummaryModel>> GetActionsSummary(long caseUrn);
+		Task<ActionSummaryBreakdownModel> GetActionsSummary(long caseUrn);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/ISRMAService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/ISRMAService.cs
@@ -18,6 +18,6 @@ namespace ConcernsCaseWork.Services.Cases
 		public Task SetVisitDates(long srmaId, DateTime startDate, DateTime? endDate);
 		public Task SetDateAccepted(long srmaId, DateTime? acceptedDate);
 		public Task SetDateReportSent(long srmaId, DateTime? reportSentDate);
-		public Task SetDateClosed(long srmaId, DateTime? ClosedDate);
+		public Task SetDateClosed(long srmaId);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/SRMAService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/SRMAService.cs
@@ -40,9 +40,9 @@ namespace ConcernsCaseWork.Services.Cases
 			await _cachedSrmaProvider.SetDateAccepted(srmaId, acceptedDate);	
 		}
 
-		public async Task SetDateClosed(long srmaId, DateTime? ClosedDate)
+		public async Task SetDateClosed(long srmaId)
 		{
-			await _cachedSrmaProvider.SetDateClosed(srmaId, ClosedDate);	
+			await _cachedSrmaProvider.SetDateClosed(srmaId);
 		}
 
 		public async Task SetDateReportSent(long srmaId, DateTime? reportSentDate)

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionMapping.cs
@@ -21,7 +21,9 @@ namespace ConcernsCaseWork.Services.Decisions
 				ClosedDate = decisionSummary.ClosedAt?.ToDayMonthYear(),
 				Name = $"Decision: {decisionSummary.Title}",
 				StatusName = decisionSummary.Outcome.HasValue ? EnumHelper.GetEnumDescription(decisionSummary.Outcome) : EnumHelper.GetEnumDescription(decisionSummary.Status),
-				RelativeUrl = $"/case/{decisionSummary.ConcernsCaseUrn}/management/action/decision/{decisionSummary.DecisionId}"
+				RelativeUrl = $"/case/{decisionSummary.ConcernsCaseUrn}/management/action/decision/{decisionSummary.DecisionId}",
+				RawOpenedDate = decisionSummary.CreatedAt,
+				RawClosedDate = decisionSummary.ClosedAt
 			};
 
 			return result;


### PR DESCRIPTION
**What is the change?**

updated the srma patch closed date to set the closed date in the api rather than accept a query parameter

refactor the action summaries into a model that wraps closed and open actions

**Why do we need the change?**

Bug

**What is the impact?**

Wide reaching but low

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/116342
