### PR TITLE
Reset allowed size of Reason at Review property as this is set when case is closed.

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -328,6 +328,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			request.NextSteps = new string('a', 4001);
 			request.CaseHistory = new string('a', 4001);
 			request.DirectionOfTravel = new string('a', 101);
+			request.ReasonAtReview = new string('a', 201);
 
 			var result = await _client.PatchAsync($"/v2/concerns-cases/1", request.ConvertToJson());
 			result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -341,6 +342,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			error.Should().Contain("The field NextSteps must be a string with a maximum length of 4000.");
 			error.Should().Contain("The field CaseHistory must be a string with a maximum length of 4000.");
 			error.Should().Contain("The field DirectionOfTravel must be a string with a maximum length of 100.");
+			error.Should().Contain("The field ReasonAtReview must be a string with a maximum length of 200.");
 		}
 
 		[Fact]

--- a/ConcernsCaseWork/ConcernsCaseWork.API/RequestModels/ConcernCaseRequest.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/RequestModels/ConcernCaseRequest.cs
@@ -20,7 +20,7 @@ namespace ConcernsCaseWork.API.RequestModels
         [StringLength(50)]
         public string TrustUkprn { get; set; }
         
-        [StringLength(0)] // not used
+        [StringLength(200)]
         public string ReasonAtReview { get; set; }
         public DateTime? DeEscalation { get; set; }
         

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/CaseServiceIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/CaseServiceIntegrationTests.cs
@@ -119,7 +119,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 				ClosedAt = timeNow,
 				Description = "",
 				CrmEnquiry = "",
-				ReasonAtReview = "",
+				ReasonAtReview = "some reason at review",
 				Issue = "some updated issue",
 				CaseAim = "some updated case aim",
 				CaseHistory = "some updated case history",
@@ -150,7 +150,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 				Assert.That(updatedCaseDto.UpdatedAt, Is.EqualTo(timeNow));
 				Assert.That(updatedCaseDto.DeEscalationPoint, Is.EqualTo(postCaseDto.DeEscalationPoint));
 				Assert.That(updatedCaseDto.DirectionOfTravel, Is.EqualTo(DirectionOfTravelEnum.Improving.ToString()));
-				Assert.That(updatedCaseDto.ReasonAtReview, Is.EqualTo(""));
+				Assert.That(updatedCaseDto.ReasonAtReview, Is.EqualTo("some reason at review"));
 				Assert.That(updatedCaseDto.TrustUkPrn, Is.EqualTo(postCaseDto.TrustUkPrn));
 				Assert.That(updatedCaseDto.CaseHistory, Is.EqualTo("some updated case history"));
 			});


### PR DESCRIPTION
**What is the change?**
Reset allowed size of Reason at Review property as this is set when case is closed.

**Why do we need the change?**
Cannot close a case otherwise

**What is the impact?**
Allows closing of a case

**Azure DevOps Ticket**
116427
