### PR TITLE
Add release tag to appsettings

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -26,10 +26,12 @@ jobs:
           VERSION=latest
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=sha-${GITHUB_SHA}
+            CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+            VERSION=sha-${CHECKED_OUT_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
           echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=checked-out-sha::${CHECKED_OUT_SHA}
           echo ::set-output name=deploy-version::${VERSION}
 
       - name: Setup node.js
@@ -45,7 +47,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.gpaas-azure-migration
-          build-args: COMMIT_SHA=${GITHUB_SHA}
+          build-args: COMMIT_SHA=${{ steps.prepare-tags.outputs.checked-out-sha }}
           push: true
           tags: ${{ steps.prepare-tags.outputs.tags }}
 

--- a/.github/workflows/build-and-push-image-production.yml
+++ b/.github/workflows/build-and-push-image-production.yml
@@ -42,10 +42,12 @@ jobs:
           VERSION=latest
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=sha-${GITHUB_SHA}
+            CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+            VERSION=sha-${CHECKED_OUT_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{needs.set-production-release-version.outputs.version}}"
           fi
           echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=checked-out-sha::${CHECKED_OUT_SHA}
           echo ::set-output name=deploy-version::${VERSION}
 
       - name: Setup node.js
@@ -63,7 +65,7 @@ jobs:
           file: ./Dockerfile.gpaas-azure-migration
           build-args: |
             ASPNET_IMAGE_TAG=6.0.9-bullseye-slim-amd64
-            COMMIT_SHA=${GITHUB_SHA}
+            COMMIT_SHA=${{ steps.prepare-tags.outputs.checked-out-sha }}
           push: true
           tags: ${{ steps.prepare-tags.outputs.tags }}
 

--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -42,10 +42,12 @@ jobs:
           VERSION=latest
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=sha-${GITHUB_SHA}
+            CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+            VERSION=sha-${CHECKED_OUT_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{needs.set-test-release-version.outputs.version}}"
           fi
           echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=checked-out-sha::${CHECKED_OUT_SHA}
           echo ::set-output name=deploy-version::${VERSION}
 
       - name: Setup node.js
@@ -63,7 +65,7 @@ jobs:
           file: ./Dockerfile.gpaas-azure-migration
           build-args: |
             ASPNET_IMAGE_TAG=6.0.9-bullseye-slim-amd64
-            COMMIT_SHA=${GITHUB_SHA}
+            COMMIT_SHA=${{ steps.prepare-tags.outputs.checked-out-sha }}
           push: true
           tags: ${{ steps.prepare-tags.outputs.tags }}
 

--- a/Dockerfile.gpaas-azure-migration
+++ b/Dockerfile.gpaas-azure-migration
@@ -32,6 +32,7 @@ RUN dotnet publish ConcernsCaseWork -c Release -o /app --no-build
 # RUN dotnet publish ConcernsCaseWork -c Release -o /app "-p:customBuildMessage=Merry Christmas ${COMMIT_SHA};"
 
 COPY ./script/web-docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY ./script/set-appsettings-release-tag.sh /app/set-appsettings-release-tag.sh
 
 # Stage 2 - Build assets
 FROM node:${NODEJS_IMAGE_TAG} as build
@@ -45,11 +46,9 @@ ARG ASPNET_IMAGE_TAG
 FROM "mcr.microsoft.com/dotnet/aspnet:${ASPNET_IMAGE_TAG}" AS final
 
 ARG COMMIT_SHA
-RUN echo "Setting env releasetag=${COMMIT_SHA}"
-ENV ConcernsCasework:ReleaseTag="${COMMIT_SHA}"
 
 RUN apt-get update
-RUN apt-get install unixodbc curl gnupg -y
+RUN apt-get install unixodbc curl gnupg jq -y
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/msprod.list
 RUN apt-get update
@@ -58,4 +57,8 @@ RUN ACCEPT_EULA=Y apt-get install msodbcsql18 mssql-tools18 -y
 COPY --from=build /app /app
 WORKDIR /app
 RUN chmod +x ./docker-entrypoint.sh
+RUN chmod +x ./set-appsettings-release-tag.sh
+RUN echo "Setting appsettings releasetag=${COMMIT_SHA}"
+RUN ./set-appsettings-release-tag.sh "$COMMIT_SHA"
+
 EXPOSE 80/tcp

--- a/script/set-appsettings-release-tag.sh
+++ b/script/set-appsettings-release-tag.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+RELEASE_TAG="$1"
+
+APP_SETTINGS_FILES=(
+  appsettings.json
+  appsettings.Development.json
+  appsettings.Staging.json
+  appsettings.Production.json
+)
+
+for app_settings_file in "${APP_SETTINGS_FILES[@]}"
+do
+  echo "$(cat "$app_settings_file" | jq --arg releasetag "$RELEASE_TAG" '.ReleaseTag=$releasetag')" > "$app_settings_file"
+done


### PR DESCRIPTION
* Modifies the Dockerfile so that a commit sha can be specified as a build arg, which is then injected into each of the appsettings.json files
* Modifies the github workflows, so that the commit sha is passed through as a build arg
* Fixes the sha that is used to create the version tag. GITHUB_SHA is the commit sha that was used to trigger the workflow, not the sha that is checked out via the checkout action.