### PR TITLE
Fix appsettings release tag parameter

### DIFF
--- a/script/set-appsettings-release-tag.sh
+++ b/script/set-appsettings-release-tag.sh
@@ -15,5 +15,5 @@ APP_SETTINGS_FILES=(
 
 for app_settings_file in "${APP_SETTINGS_FILES[@]}"
 do
-  echo "$(cat "$app_settings_file" | jq --arg releasetag "$RELEASE_TAG" '.ReleaseTag=$releasetag')" > "$app_settings_file"
+  echo "$(cat "$app_settings_file" | jq --arg releasetag "$RELEASE_TAG" '.ConcernsCasework.ReleaseTag=$releasetag')" > "$app_settings_file"
 done


### PR DESCRIPTION
* Moves `ReleaseTag` to be nested within `ConcernsCasework`, as it is referenced to with `ConcernsCasework:ReleaseTag`