### PR TITLE
117705: set edit permissions on a decision

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Permissions/CasePermission.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Permissions/CasePermission.cs
@@ -1,0 +1,7 @@
+﻿namespace ConcernsCaseWork.API.Contracts.Permissions
+{
+	public enum CasePermission
+	{
+		Edit = 1
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Permissions/GetCasePermissionsResponse.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Permissions/GetCasePermissionsResponse.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConcernsCaseWork.API.Contracts.Permissions
+{
+	public class GetCasePermissionsResponse
+	{
+		public GetCasePermissionsResponse()
+		{
+			Permissions = new List<CasePermission>();
+		}
+
+		public List<CasePermission> Permissions { get; set; }
+
+		public bool HasEditPermissions()
+		{
+			return Permissions.Contains(CasePermission.Edit);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Permissions/CasePermissionsService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Permissions/CasePermissionsService.cs
@@ -1,0 +1,40 @@
+﻿using ConcernsCaseWork.API.Contracts.Permissions;
+using ConcernsCaseWork.Logging;
+using ConcernsCaseWork.Service.Base;
+using Microsoft.Extensions.Logging;
+
+namespace ConcernsCaseWork.Service.Permissions
+{
+	public class CasePermissionsService : ConcernsAbstractService, ICasePermissionsService
+	{
+		private readonly ILogger<CasePermissionsService> _logger;
+
+		public CasePermissionsService(
+			IHttpClientFactory clientFactory,
+			ILogger<CasePermissionsService> logger,
+			ICorrelationContext correlationContext) : base(clientFactory, logger, correlationContext)
+		{
+			_logger = logger;
+		}
+
+		public async Task<GetCasePermissionsResponse> GetCasePermissions(long id)
+		{
+			_logger.LogMethodEntered();
+			_logger.LogInformation($"Client getting permissions for case {id}");
+
+			var result = new GetCasePermissionsResponse()
+			{
+				Permissions = new List<CasePermission>() { CasePermission.Edit }
+			};
+
+			_logger.LogInformation($"Client retrieved permissions for case {id}");
+
+			return result;
+		}
+	}
+
+	public interface ICasePermissionsService
+	{
+		public Task<GetCasePermissionsResponse> GetCasePermissions(long id);
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/IndexPageModelTests.cs
@@ -1,8 +1,10 @@
 ﻿using AutoFixture;
+using ConcernsCaseWork.API.Contracts.Permissions;
 using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
 using ConcernsCaseWork.Constants;
 using ConcernsCaseWork.Pages.Case.Management.Action.Decision;
 using ConcernsCaseWork.Service.Decision;
+using ConcernsCaseWork.Service.Permissions;
 using ConcernsCaseWork.Shared.Tests.Factory;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
@@ -71,7 +73,10 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 
 			var logger = new Mock<ILogger<IndexPageModel>>();
 
-			return new IndexPageModel(_mockDecision.Object, logger.Object)
+			var permissionsService = new Mock<ICasePermissionsService>();
+			permissionsService.Setup(m => m.GetCasePermissions(It.IsAny<long>())).ReturnsAsync(_fixture.Create<GetCasePermissionsResponse>());
+
+			return new IndexPageModel(_mockDecision.Object, permissionsService.Object, logger.Object)
 			{
 				PageContext = pageContext,
 				TempData = tempData,

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/Decision/IndexPageModelTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
@@ -49,6 +50,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 
 			pageModel.Decision.ConcernsCaseUrn.Should().Be(apiDecision.ConcernsCaseUrn);
 			pageModel.Decision.DecisionId.Should().Be(apiDecision.DecisionId);
+			pageModel.Decision.IsEditable.Should().BeTrue();
 			
 			pageModel.ViewData[ViewDataConstants.Title].Should().Be("Decision");
 		}
@@ -73,8 +75,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.Decision
 
 			var logger = new Mock<ILogger<IndexPageModel>>();
 
+			var casePermissions = new GetCasePermissionsResponse() { Permissions = new List<CasePermission>() { CasePermission.Edit } };
 			var permissionsService = new Mock<ICasePermissionsService>();
-			permissionsService.Setup(m => m.GetCasePermissions(It.IsAny<long>())).ReturnsAsync(_fixture.Create<GetCasePermissionsResponse>());
+			permissionsService.Setup(m => m.GetCasePermissions(It.IsAny<long>())).ReturnsAsync(casePermissions);
 
 			return new IndexPageModel(_mockDecision.Object, permissionsService.Object, logger.Object)
 			{

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Decisions/DecisionMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Decisions/DecisionMappingTests.cs
@@ -1,6 +1,7 @@
 using AutoFixture;
 using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
 using ConcernsCaseWork.API.Contracts.Enums;
+using ConcernsCaseWork.API.Contracts.Permissions;
 using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
 using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
 using ConcernsCaseWork.Models.CaseActions;
@@ -10,6 +11,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace ConcernsCaseWork.Tests.Services.Decisions
@@ -94,7 +96,9 @@ namespace ConcernsCaseWork.Tests.Services.Decisions
 				}
 			};
 
-			var result = DecisionMapping.ToViewDecisionModel(apiDecision);
+			var casePermissions = new GetCasePermissionsResponse() { Permissions = new List<CasePermission> { CasePermission.Edit } };
+
+			var result = DecisionMapping.ToViewDecisionModel(apiDecision, casePermissions);
 
 			result.DecisionId.Should().Be(apiDecision.DecisionId);
 			result.ConcernsCaseUrn.Should().Be(apiDecision.ConcernsCaseUrn);
@@ -128,10 +132,23 @@ namespace ConcernsCaseWork.Tests.Services.Decisions
 			var apiDecision = new GetDecisionResponse();
 			apiDecision.DecisionTypes = new DecisionType[] { };
 
-			var result = DecisionMapping.ToViewDecisionModel(apiDecision);
+			var result = DecisionMapping.ToViewDecisionModel(apiDecision, new GetCasePermissionsResponse());
 
 			result.EsfaReceivedRequestDate.Should().BeNull();
 			result.Outcome.Should().BeNull();
+		}
+
+		[TestCaseSource(nameof(DecisionPermissionTestCases))]
+		public void ToDecisionModel_WhenNotEditable_ReturnsCorrectModel(
+			bool isEditable,
+			GetCasePermissionsResponse casePermissionsResponse)
+		{
+			var apiDecision = _fixture.Create<GetDecisionResponse>();
+			apiDecision.IsEditable = isEditable;
+
+			var result = DecisionMapping.ToViewDecisionModel(apiDecision, casePermissionsResponse);
+
+			result.IsEditable.Should().BeFalse();
 		}
 
 		[Test]
@@ -312,6 +329,12 @@ namespace ConcernsCaseWork.Tests.Services.Decisions
 			var result = DecisionMapping.ToDecisionSummaryModel(apiDecision);
 
 			result.ClosedAt.Should().Be(apiDecision.ClosedAt?.Date);
+		}
+
+		private static IEnumerable<TestCaseData> DecisionPermissionTestCases()
+		{
+			yield return new TestCaseData(false, new GetCasePermissionsResponse() { Permissions = new List<CasePermission>() { CasePermission.Edit } });
+			yield return new TestCaseData(true, new GetCasePermissionsResponse());
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
@@ -57,6 +57,7 @@ using ConcernsCaseWork.Authorization;
 using ConcernsCaseWork.Middleware;
 using ConcernsCaseWork.Pages.Base;
 using ConcernsCaseWork.Services.PageHistory;
+using ConcernsCaseWork.Service.Permissions;
 
 namespace ConcernsCaseWork.Extensions
 {
@@ -192,6 +193,7 @@ namespace ConcernsCaseWork.Extensions
             services.AddScoped<INtiConditionsService, NtiConditionsService>();
 			services.AddScoped<ITeamsService, TeamsService>();
 			services.AddScoped<IDecisionService, DecisionService>();
+			services.AddScoped<ICasePermissionsService, CasePermissionsService>();
 
 			// Redis services
 			services.AddSingleton<ICacheProvider, CacheProvider>();

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Index.cshtml
@@ -50,7 +50,7 @@
                     </td>
                 </tr>
 
-                @if (!Model.Decision.IsEditable)
+                @if (Model.Decision.ClosedDate != string.Empty)
                 {
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header govuk-table__header__width_15" data-testid="decision-closed-label">Date decision closed</th>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Index.cshtml.cs
@@ -3,6 +3,7 @@ using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Base;
 using ConcernsCaseWork.Service.Decision;
+using ConcernsCaseWork.Service.Permissions;
 using ConcernsCaseWork.Services.Decisions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 	public class IndexPageModel : AbstractPageModel
 	{
 		private IDecisionService _decisionService;
+		private ICasePermissionsService _casePermissionsService;
 		private ILogger _logger;
 
 		public ViewDecisionModel Decision { get; set; }
@@ -21,9 +23,11 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 
 		public IndexPageModel(
 			IDecisionService decisionService,
+			ICasePermissionsService casePermisisionsService,
 			ILogger<IndexPageModel> logger)
 		{
 			_decisionService = decisionService;
+			_casePermissionsService = casePermisisionsService;
 			_logger = logger;
 		}
 
@@ -39,8 +43,9 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 				TryGetRouteValueInt64("decisionId", out var decisionId);
 
 				var apiDecision = await _decisionService.GetDecision(urn, (int)decisionId);
+				var casePermissions = await _casePermissionsService.GetCasePermissions(urn);
 
-				Decision = DecisionMapping.ToViewDecisionModel(apiDecision);
+				Decision = DecisionMapping.ToViewDecisionModel(apiDecision, casePermissions);
 			}
 			catch (Exception ex)
 			{

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Decisions/DecisionMapping.cs
@@ -1,4 +1,5 @@
 ﻿using ConcernsCaseWork.API.Contracts.Decisions.Outcomes;
+using ConcernsCaseWork.API.Contracts.Permissions;
 using ConcernsCaseWork.API.Contracts.RequestModels.Concerns.Decisions;
 using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
 using ConcernsCaseWork.Extensions;
@@ -29,7 +30,9 @@ namespace ConcernsCaseWork.Services.Decisions
 			return result;
 		}
 
-		public static ViewDecisionModel ToViewDecisionModel(GetDecisionResponse decisionResponse)
+		public static ViewDecisionModel ToViewDecisionModel(
+			GetDecisionResponse decisionResponse,
+			GetCasePermissionsResponse casePermissionsResponse)
 		{
 			var receivedRequestDate = GetEsfaReceivedRequestDate(decisionResponse);
 
@@ -48,7 +51,7 @@ namespace ConcernsCaseWork.Services.Decisions
 				EditLink = $"/case/{decisionResponse.ConcernsCaseUrn}/management/action/decision/addOrUpdate/{decisionResponse.DecisionId}",
 				BackLink = $"/case/{decisionResponse.ConcernsCaseUrn}/management",
 				Outcome = ToViewDecisionOutcomeModel(decisionResponse),
-				IsEditable = decisionResponse.IsEditable,
+				IsEditable = decisionResponse.IsEditable && casePermissionsResponse.HasEditPermissions(),
 				CreatedDate = DateTimeHelper.ParseToDisplayDate(decisionResponse.CreatedAt),
 				ClosedDate = decisionResponse.ClosedAt.HasValue ? DateTimeHelper.ParseToDisplayDate(decisionResponse.ClosedAt.Value) : string.Empty
 			};


### PR DESCRIPTION
**What is the change?**

add permissions to decision so edit operations cannot be done

**Why do we need the change?**

ensure that only we can control who can edit decisions

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/117705
