### PR TITLE
117713: added permissions to the nti warning letter page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiWarningLetterMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiWarningLetterMappingTests.cs
@@ -7,6 +7,9 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ConcernsCaseWork.API.Contracts.Permissions;
+using ConcernsCaseWork.Service.Nti;
+using ConcernsCaseWork.Shared.Tests.Factory;
 
 namespace ConcernsCaseWork.Tests.Mappers
 {
@@ -43,7 +46,7 @@ namespace ConcernsCaseWork.Tests.Mappers
 				Id = testData.Id,
 				CaseUrn = testData.CaseUrn,
 				CreatedAt = testData.CreatedAt,
-				ClosedAt = testData.ClosedAt,
+				ClosedAt = null,
 				Notes = testData.Notes,
 				DateLetterSent = testData.SentDate,
 				StatusId = testData.Status.Key,
@@ -52,8 +55,10 @@ namespace ConcernsCaseWork.Tests.Mappers
 				ClosedStatusId = testData.ClosedStatus.Key
 			};
 
+			var permissionsResponse = new GetCasePermissionsResponse() { Permissions = new List<CasePermission>() { CasePermission.Edit } };
+
 			// act
-			var serviceModel = NtiWarningLetterMappers.ToServiceModel(ntiDto, statuses);
+			var serviceModel = NtiWarningLetterMappers.ToServiceModel(ntiDto, statuses, permissionsResponse);
 
 			// assert
 			Assert.That(serviceModel, Is.Not.Null);
@@ -66,6 +71,24 @@ namespace ConcernsCaseWork.Tests.Mappers
 			Assert.That(serviceModel.Status.Name, Is.EqualTo(testData.Status.Value));
 			Assert.That(serviceModel.ClosedStatus.Id, Is.EqualTo(testData.ClosedStatus.Key));
 			Assert.That(serviceModel.ClosedStatus.Name, Is.EqualTo(testData.ClosedStatus.Value));
+			serviceModel.IsEditable.Should().BeTrue();
+		}
+
+		[TestCaseSource(nameof(GetPermissionTestCases))]
+		public void WhenMapDtoToServiceModel_Not_Editable_ReturnsCorrectModel(
+			DateTime closedDate,
+			GetCasePermissionsResponse casePermissionsResponse)
+		{
+			var ntiDto = _fixture.Create<NtiDto>();
+			ntiDto.StatusId = null;
+			ntiDto.ClosedStatusId = null;
+			ntiDto.ClosedAt = closedDate;
+			var ntiStatuses = NTIStatusFactory.BuildListNTIStatusDto();
+
+			var serviceModel = NtiMappers.ToServiceModel(ntiDto, ntiStatuses, casePermissionsResponse);
+
+			serviceModel.IsEditable.Should().BeFalse();
+			serviceModel.ClosedAt.Should().Be(closedDate);
 		}
 
 		[Test]
@@ -209,6 +232,12 @@ namespace ConcernsCaseWork.Tests.Mappers
 		{
 			yield return new TestCaseData(null, "In progress");
 			yield return new TestCaseData(new NtiWarningLetterStatusModel() { Name = "Test"}, "Test");
+		}
+
+		private static IEnumerable<TestCaseData> GetPermissionTestCases()
+		{
+			yield return new TestCaseData(new DateTime(), new GetCasePermissionsResponse() { Permissions = new List<CasePermission>() { CasePermission.Edit } });
+			yield return new TestCaseData(null, new GetCasePermissionsResponse());
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/NtiWL/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/Action/NtiWL/IndexPageModelTests.cs
@@ -38,7 +38,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management.Action.NtiWL
 			var ntiWarningLetterModel = NTIWarningLetterFactory.BuildNTIWarningLetterModel();
 			var mockLogger = new Mock<ILogger<IndexPageModel>>();	
 
-			mockNtiWarningLetterModelService.Setup(n => n.GetNtiWarningLetterId(It.IsAny<long>())).ReturnsAsync(ntiWarningLetterModel);
+			mockNtiWarningLetterModelService.Setup(n => n.GetNtiWarningLetterViewModel(1, It.IsAny<long>())).ReturnsAsync(ntiWarningLetterModel);
 
 			var pageModel = SetupIndexPageModel(mockModelService: mockNtiWarningLetterModelService, mockLogger: mockLogger);
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiWarningLetterMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiWarningLetterMappers.cs
@@ -1,4 +1,5 @@
-﻿using ConcernsCaseWork.Extensions;
+﻿using ConcernsCaseWork.API.Contracts.Permissions;
+using ConcernsCaseWork.Extensions;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Service.NtiWarningLetter;
 using System;
@@ -27,7 +28,7 @@ namespace ConcernsCaseWork.Mappers
 			};
 		}
 
-		public static NtiWarningLetterModel ToServiceModel(NtiWarningLetterDto ntiDto, ICollection<NtiWarningLetterStatusDto> statuses )
+		public static NtiWarningLetterModel ToServiceModel(NtiWarningLetterDto ntiDto, ICollection<NtiWarningLetterStatusDto> statuses)
 		{
 			return new NtiWarningLetterModel
 			{
@@ -44,6 +45,17 @@ namespace ConcernsCaseWork.Mappers
 				ClosedStatus = ntiDto.ClosedStatusId.HasValue ? ToServiceModel(statuses.FirstOrDefault(s => s.Id == ntiDto.ClosedStatusId)) : null,
 				ClosedAt = ntiDto.ClosedAt
 			};
+		}
+
+		public static NtiWarningLetterModel ToServiceModel(
+			NtiWarningLetterDto ntiDto, 
+			ICollection<NtiWarningLetterStatusDto> statuses, 
+			GetCasePermissionsResponse permissionsResponse)
+		{
+			var result = ToServiceModel(ntiDto, statuses);
+			result.IsEditable = permissionsResponse.HasEditPermissions() && !result.ClosedAt.HasValue;
+
+			return result;
 		}
 
 		public static NtiWarningLetterConditionModel ToServiceModel(NtiWarningLetterConditionDto ntiConditionDto)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
@@ -175,7 +175,7 @@
         </table>
 
 
-        @if (Model.NtiWarningLetterModel.ClosedAt == null)
+        @if (Model.NtiWarningLetterModel.IsEditable)
         {
             <div class="govuk-button-group">
                 <a data-prevent-double-click="true" href="@Request.Path/edit" class="govuk-button govuk-button--secondary" data-module="govuk-button" role="button" id="edit-nti-wl-button">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml.cs
@@ -13,6 +13,7 @@ using ConcernsCaseWork.Service.NtiWarningLetter;
 using ConcernsCaseWork.Mappers;
 using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Redis.NtiWarningLetter;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiWarningLetter
 {
@@ -47,16 +48,16 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiWarningLetter
 
 		public async Task OnGetAsync()
 		{
-			long caseUrn = 0;
+			long caseId = 0;
 			long ntiWarningLetterId = 0;
 
 			try
 			{
 				_logger.LogInformation("Case::Action::NTI-Warning letter::IndexPageModel::OnGetAsync");
 
-				(caseUrn, ntiWarningLetterId) = GetRouteData();
+				(caseId, ntiWarningLetterId) = GetRouteData();
 
-				NtiWarningLetterModel = await GetWarningLetterModel(ntiWarningLetterId);
+				NtiWarningLetterModel = await GetWarningLetterModel(caseId, ntiWarningLetterId);
 
 				if (NtiWarningLetterModel == null)
 				{
@@ -70,9 +71,9 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.NtiWarningLetter
 			}
 		}
 
-		private async Task<NtiWarningLetterModel> GetWarningLetterModel(long ntiWarningLetterId)
+		private async Task<NtiWarningLetterModel> GetWarningLetterModel(long caseId, long ntiWarningLetterId)
 		{
-			var wl = await _ntiWarningLetterModelService.GetNtiWarningLetterId(ntiWarningLetterId);
+			var wl = await _ntiWarningLetterModelService.GetNtiWarningLetterViewModel(caseId, ntiWarningLetterId);
 			NtiWarningLetterStatuses = await _ntiWarningLetterStatusesCachedService.GetAllStatusesAsync();
 
 			if (wl != null)

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/NtiWarningLetter/INtiWarningLetterModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/NtiWarningLetter/INtiWarningLetterModelService.cs
@@ -8,6 +8,7 @@ namespace ConcernsCaseWork.Services.NtiWarningLetter
 	{
 		Task<NtiWarningLetterModel> CreateNtiWarningLetter(NtiWarningLetterModel ntiWarningLetterModel);
 		Task<NtiWarningLetterModel> GetNtiWarningLetterId(long wlId);
+		Task<NtiWarningLetterModel> GetNtiWarningLetterViewModel(long caseId, long warningLetterId);
 		Task<NtiWarningLetterModel> PatchNtiWarningLetter(NtiWarningLetterModel patchWarningLetter);
 		Task<IEnumerable<NtiWarningLetterModel>> GetNtiWarningLettersForCase(long caseUrn);
 		Task<NtiWarningLetterModel> GetWarningLetter(string continuationId);

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/NtiWarningLetter/NtiWarningLetterModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/NtiWarningLetter/NtiWarningLetterModelService.cs
@@ -1,6 +1,7 @@
 ﻿using ConcernsCaseWork.Mappers;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Redis.NtiWarningLetter;
+using ConcernsCaseWork.Service.Permissions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,11 +13,16 @@ namespace ConcernsCaseWork.Services.NtiWarningLetter
 	{
 		private readonly INtiWarningLetterCachedService _ntiWarningLetterCachedService;
 		private readonly INtiWarningLetterStatusesCachedService _ntiWarningLetterStatusesCachedService;
+		private readonly ICasePermissionsService _casePermissionsService;
 
-		public NtiWarningLetterModelService(INtiWarningLetterCachedService ntiWarningLetterCachedService, INtiWarningLetterStatusesCachedService ntiWarningLetterStatusService)
+		public NtiWarningLetterModelService(
+			INtiWarningLetterCachedService ntiWarningLetterCachedService, 
+			INtiWarningLetterStatusesCachedService ntiWarningLetterStatusService,
+			ICasePermissionsService casePermissionsService)
 		{
 			_ntiWarningLetterCachedService = ntiWarningLetterCachedService;
 			_ntiWarningLetterStatusesCachedService = ntiWarningLetterStatusService;
+			_casePermissionsService = casePermissionsService;
 		}
 
 		public async Task<NtiWarningLetterModel> CreateNtiWarningLetter(NtiWarningLetterModel ntiWarningLetterModel)
@@ -46,6 +52,15 @@ namespace ConcernsCaseWork.Services.NtiWarningLetter
 			var statuses = await _ntiWarningLetterStatusesCachedService.GetAllStatusesAsync();
 
 			return NtiWarningLetterMappers.ToServiceModel(dto, statuses);
+		}
+
+		public async Task<NtiWarningLetterModel> GetNtiWarningLetterViewModel(long caseId, long warningLetterId)
+		{
+			var dto = await _ntiWarningLetterCachedService.GetNtiWarningLetterAsync(warningLetterId);
+			var statuses = await _ntiWarningLetterStatusesCachedService.GetAllStatusesAsync();
+			var permissionsResponse = await _casePermissionsService.GetCasePermissions(caseId);
+
+			return NtiWarningLetterMappers.ToServiceModel(dto, statuses, permissionsResponse);
 		}
 
 		public async Task StoreWarningLetter(NtiWarningLetterModel ntiWarningLetter, string continuationId)


### PR DESCRIPTION
**What is the change?**

added permissions to the nti warning letter page

**Why do we need the change?**

only users that created the case should be able to edit it

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/117713
