### PR TITLE
117704: added permissions to the case details page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Management/IndexPageModelTests.cs
@@ -1,10 +1,12 @@
 ﻿using AutoFixture;
+using ConcernsCaseWork.API.Contracts.Permissions;
 using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Case.Management;
 using ConcernsCaseWork.Redis.NtiUnderConsideration;
 using ConcernsCaseWork.Redis.Status;
 using ConcernsCaseWork.Service.NtiUnderConsideration;
+using ConcernsCaseWork.Service.Permissions;
 using ConcernsCaseWork.Service.Status;
 using ConcernsCaseWork.Services.Actions;
 using ConcernsCaseWork.Services.Cases;
@@ -39,6 +41,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 		private Mock<INtiUnderConsiderationStatusesCachedService> _mockNtiStatusesCachedService = null;
 		private Mock<IActionsModelService> _actionsModelService = null;
 		private Mock<ICaseSummaryService> _caseSummaryService = null;
+		private Mock<ICasePermissionsService> _casePermissionsService = null;
 
 		private readonly static Fixture _fixture = new();
 
@@ -54,6 +57,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 			_mockNtiStatusesCachedService = new Mock<INtiUnderConsiderationStatusesCachedService>();
 			_actionsModelService = new Mock<IActionsModelService>();
 			_caseSummaryService = new Mock<ICaseSummaryService>();
+
+			_casePermissionsService = new Mock<ICasePermissionsService>();
+			_casePermissionsService.Setup(m => m.GetCasePermissions(It.IsAny<long>())).ReturnsAsync(new GetCasePermissionsResponse());
 		}
 
 		[Test]
@@ -208,6 +214,9 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 			_mockStatusCachedService.Setup(s => s.GetStatusByName(It.IsAny<string>()))
 				.ReturnsAsync(closeStatusModel);
 
+			var permissionsResponse = new GetCasePermissionsResponse() { Permissions = new List<CasePermission>() { CasePermission.Edit } };
+			_casePermissionsService.Setup(m => m.GetCasePermissions(It.IsAny<long>())).ReturnsAsync(permissionsResponse);
+
 			var pageModel = SetupIndexPageModel(isAuthenticated: true);
 
 			var routeData = pageModel.RouteData.Values;
@@ -257,16 +266,17 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Management
 			bool isAuthenticated = false)
 		{
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
-			
-			return new IndexPageModel(_mockCaseModelService.Object, 
-				_mockTrustModelService.Object, 
-				_mockRecordModelService.Object, 
-				_mockRatingModelService.Object, 
-				_mockStatusCachedService.Object, 
+
+			return new IndexPageModel(_mockCaseModelService.Object,
+				_mockTrustModelService.Object,
+				_mockRecordModelService.Object,
+				_mockRatingModelService.Object,
+				_mockStatusCachedService.Object,
 				_mockNtiStatusesCachedService.Object,
-				_mockLogger.Object, 
+				_mockLogger.Object,
 				_actionsModelService.Object,
-				_caseSummaryService.Object)
+				_caseSummaryService.Object,
+				_casePermissionsService.Object)
 			{
 				PageContext = pageContext,
 				TempData = tempData,

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -8,8 +8,8 @@
 @using ConcernsCaseWork.Helpers;
 
 @{
-	ViewData["Title"] = "Case management";
-	var nonce = HttpContext.GetNonce();
+    ViewData["Title"] = "Case management";
+    var nonce = HttpContext.GetNonce();
 }
 
 <div class="govuk-width-container">
@@ -57,342 +57,345 @@
             <div class="govuk-tabs__panel" id="case-details">
 
                 <!-- Case Details -->
-            <table class="govuk-table">
-	            <caption class="govuk-table__caption govuk-table__caption--m"></caption>
-	            <thead>
-	            <tr>
-		            <th scope="col" class="govuk-!-width-one-quarter"></th>
-		            <th scope="col"></th>
-		            <th scope="col"></th>
-	            </tr>
-	            </thead>
-	            <tbody class="govuk-table__body">
-	            <tr class="govuk-table__row">
-		            <th scope="row" class="govuk-table-case-details__header">Trust</th>
-		            <td class="govuk-table__cell">
-			            @Model.TrustDetailsModel.GiasData.GroupName
-		            </td>
-		            <td class="govuk-table__cell govuk-table__header__right"></td>
-	            </tr>
+                <table class="govuk-table">
+                    <caption class="govuk-table__caption govuk-table__caption--m"></caption>
+                    <thead>
+                        <tr>
+                            <th scope="col" class="govuk-!-width-one-quarter"></th>
+                            <th scope="col"></th>
+                            <th scope="col"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table-case-details__header">Trust</th>
+                            <td class="govuk-table__cell">
+                                @Model.TrustDetailsModel.GiasData.GroupName
+                            </td>
+                            <td class="govuk-table__cell govuk-table__header__right"></td>
+                        </tr>
 
-	            @if (Model.IsConcernsCase)
-	            {
-		            <tr class="govuk-table__row">
-			            <th scope="row" class="govuk-table-case-details__header">Risk to trust</th>
-			            <td class="govuk-table__cell govuk-label-wrapper">
-				            @for (var index = 0; index < Model.CaseModel?.RatingModel?.RagRating?.Item2?.Count; ++index)
-				            {
-					            <span class="govuk-tag ragtag @Model.CaseModel?.RatingModel?.RagRatingCss?.ElementAt(index)">
-						            @Model.CaseModel?.RatingModel?.RagRating?.Item2?.ElementAt(index)
-					            </span>
-				            }
-			            </td>
-			            <td class="govuk-table__cell govuk-table__header__right">
-				            @if (Model.IsEditableCase)
-				            {
-					            <a class="govuk-link" href="@Request.Path/edit_rating" aria-label="Change risk to trust rating">
-						            Edit<span class="govuk-visually-hidden"> risk to trust rating</span>
-					            </a>
-				            }
-			            </td>
-		            </tr>
-		            <tr class="govuk-table__row">
-			            <th scope="row" class="govuk-table-case-details__header">Direction of travel</th>
-			            <td class="govuk-table__cell">
-				            @Model.CaseModel.DirectionOfTravel
-			            </td>
-			            <td class="govuk-table__cell govuk-table__header__right">
-				            @if (Model.IsEditableCase)
-				            {
-					            <a class="govuk-link" href="@Request.Path/edit_directionoftravel" aria-label="Change direction of travel">
-						            Edit<span class="govuk-visually-hidden"> direction of travel</span>
-					            </a>
-				            }
-			            </td>
-		            </tr>
-	            }
-	            <tr class="govuk-table__row">
-		            <th scope="row" class="govuk-table-case-details__header">Concerns</th>
-		            <td colspan="2" class="govuk-table__cell">
-			            @if (Model.CaseModel.RecordsModel.Any())
-			            {
-				            <table class="govuk-table">
-					            <tbody class="govuk-table__body">
-					            @foreach (var concern in Model.CaseModel.RecordsModel)
-					            {
-						            <tr class="govuk-table__row">
-							            <td>
-								            @concern.TypeModel.TypeDisplay
-							            </td>
-							            <td>
-								            <div class="govuk-ragtag-wrapper govuk-!-padding-bottom-1 govuk-!-padding-right-4">
-									            @{
-										            if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
-										            {
-											            <span class="govuk-tag ragtag ragtag__grey">
-												            Closed
-											            </span>
-										            }
-										            else
-										            {
-											            for (var index = 0; index < concern.RatingModel.RagRating.Item2.Count; ++index)
-											            {
-												            <span class="govuk-tag ragtag @concern.RatingModel.RagRatingCss.ElementAt(index)">
-													            @concern.RatingModel.RagRating.Item2.ElementAt(index)
-												            </span>
-											            }
-										            }
-									            }
-								            </div>
-							            </td>
-							            <td class="govuk-table__header__right">
-								            @{
-									            if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
-									            {
-										            <br />
-									            }
-									            else
-									            {
-										            <div class="govuk-!-padding-bottom-1">
-											            @if (Model.IsEditableCase)
-											            {
-												            <a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating" aria-label="Change @concern.TypeModel.TypeDisplay rating" data-testid="edit-concern">Edit</a>
-											            }
-										            </div>
-									            }
-								            }
-							            </td>
-						            </tr>
-					            }
-					            </tbody>
-				            </table>
-			            }
-			            <div class="govuk-o-grid__item--one-half">
-				            @if (Model.IsEditableCase)
-				            {
-					            <a href="@Request.Path/concern" class="govuk-link govuk-link-no-visited-state">Add concern</a>
-				            }
-			            </div>
-
-		            </td>
-		            <td class="govuk-table__cell__no_border"></td>
-	            </tr>
-
-	            <tr class="govuk-table__row">
-		            <th scope="row" class="govuk-table-case-details__header">SFSO territory</th>
-		            <td class="govuk-table__cell" data-testid="territory_Field">
-			            @if (Model.CaseModel.Territory == null)
-			            {
-				            <span class='govuk-tag ragtag ragtag__grey'>Empty</span>
-			            }
-			            else
-			            {
-				            @Model.CaseModel.Territory?.Description()
-			            }
-
-		            </td>
-		            <td class="govuk-table__cell govuk-table__header__right">
-			            @if (Model.IsEditableCase)
-			            {
-				            <a class="govuk-link" data-testid="edit_Button_SFSO" href="@Request.Path/edit-territory" aria-label="Change SFSO territory">
-					            Edit<span class="govuk-visually-hidden"> SFSO territory</span>
-				            </a>
-			            }
-		            </td>
-	            </tr>
-
-	            <tr class="govuk-table__row">
-		            <th scope="row" class="govuk-table-case-details__header">Caseworker</th>
-		            <td class="govuk-table__cell">
-			            @Model.CaseModel.CreatedBy.FromEmailToFullName()
-		            </td>
-		            <td class="govuk-table__cell govuk-table__header__right"></td>
-	            </tr>
-
-	            <tr class="govuk-table__row">
-		            <th scope="row" class="govuk-table-case-details__header">Date Created</th>
-		            <td class="govuk-table__cell">
-			            @DateTimeHelper.ParseToDisplayDate(Model.CaseModel.CreatedAt)
-		            </td>
-		            <td class="govuk-table__cell govuk-table__header__right"></td>
-	            </tr>
-
-	            </tbody>
-            </table>
-            
-            @if (Model.IsConcernsCase)
-            {
-	            <h2 class="govuk-heading-m">Concern details</h2>
-	            <hr class="govuk-section-break govuk-section-break--visible">
-	            
-	            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion">
-	            
-	                @* Issue *@
-		            <div class="govuk-accordion__section">
-			            <div class="govuk-accordion__section-header">
-				            <h2 class="govuk-accordion__section-heading">
-					            <span class="govuk-accordion__section-button" id="accordion-issue-heading">
-						            Issue
-					            </span>
-				            </h2>
-			            </div>
-			            <div id="accordion-issue-content" class="govuk-accordion__section-content" aria-labelledby="accordion-issue-heading">
-				            @if (Model.IsEditableCase)
-				            {
-					            <div><a class="govuk-link float__right" href="@Request.Path/edit_issue" aria-label="Change issue">Edit</a></div>
-				            }
-				            <div class="govuk-!-width-three-quarters">
-					            <span class="govuk-body dfe-text-area-display">@Model.CaseModel.Issue</span>
-					        </div>
-			            </div>
-		            </div>
-
-	                @* Status *@
-		            <div class="govuk-accordion__section">
-			            <div class="govuk-accordion__section-header">
-				            <h2 class="govuk-accordion__section-heading">
-					            <span class="govuk-accordion__section-button" id="accordion-status-heading">Current status</span>
-				            </h2>
-			            </div>
-		                <div id="accordion-status-content" class="govuk-accordion__section-content" aria-labelledby="accordion-status-heading">
-			                @if (Model.IsEditableCase)
-			                {       
-				                <div><a class="govuk-link float__right" href="@Request.Path/edit_current_status" aria-label="Change status">Edit</a></div>
-			                }
-				            <div class="govuk-!-width-three-quarters">
-					            <span class="govuk-body dfe-text-area-display">@Model.CaseModel.CurrentStatus</span>
-					        </div>
-		                </div>
-		            </div>
-	                
-		            @* Case aim *@
-		            <div class="govuk-accordion__section">
-			            <div class="govuk-accordion__section-header">
-				            <h2 class="govuk-accordion__section-heading">
-					            <span class="govuk-accordion__section-button" id="accordion-case-aim-heading">Case aim</span>
-				            </h2>
-			            </div>
-			            <div id="accordion-case-aim-content" class="govuk-accordion__section-content" aria-labelledby="accordion-case-aim-heading">
-				            @if (Model.IsEditableCase)
-				            {
-					            <div><a class="govuk-link float__right" href="@Request.Path/edit_case_aim" aria-label="Change case aim">Edit</a></div>
-				            }
-				            
-				            <div class="govuk-!-width-three-quarters">
-					            <span class="govuk-body dfe-text-area-display">@Model.CaseModel.CaseAim</span>
-					        </div>
-			            </div>
-		            </div>
-	                
-		            @* De-escalation point *@
-		            <div class="govuk-accordion__section">
-			            <div class="govuk-accordion__section-header">
-				            <h2 class="govuk-accordion__section-heading">
-					            <span class="govuk-accordion__section-button" id="accordion-de-escalation-point-heading">De-escalation point</span>
-				            </h2>
-			            </div>
-			            <div id="accordion-de-escalation-point-content" class="govuk-accordion__section-content" aria-labelledby="accordion-de-escalation-point-heading">
-				            @if (Model.IsEditableCase)
-				            {
-					            <div><a class="govuk-link float__right" href="@Request.Path/edit_de_escalation_point" aria-label="Change de-escalation point">Edit</a></div>
-				            }
-				            
-				            <div class="govuk-!-width-three-quarters">
-					            <span class="govuk-body dfe-text-area-display">@Model.CaseModel.DeEscalationPoint</span>
-					        </div>
-			            </div>
-		            </div>
-
-		            @* Next steps *@
-		            <div class="govuk-accordion__section">
-			            <div class="govuk-accordion__section-header">
-				            <h2 class="govuk-accordion__section-heading">
-					            <span class="govuk-accordion__section-button" id="accordion-next-steps-heading">Next steps</span>
-				            </h2>
-			            </div>
-			            <div id="accordion-next-steps-content" class="govuk-accordion__section-content" aria-labelledby="accordion-next-steps-heading">
-				            @if (Model.IsEditableCase)
-				            {
-					            <div><a class="govuk-link float__right" href="@Request.Path/edit_next_steps" aria-label="Change next steps">Edit</a></div>
-				            }
-				            
-				            <div class="govuk-!-width-three-quarters">
-					            <span class="govuk-body dfe-text-area-display">@Model.CaseModel.NextSteps</span>
-					        </div>
-			            </div>
-		            </div>
-	            
-		            @* Case history *@
-		            <div class="govuk-accordion__section">
-			            <div class="govuk-accordion__section-header">
-				            <h2 class="govuk-accordion__section-heading">
-					            <span class="govuk-accordion__section-button" id="accordion-case-history-heading">Case history</span>
-				            </h2>
-			            </div>
-		                <div id="accordion-case-history-content" class="govuk-accordion__section-content" aria-labelledby="accordion-case-history-heading">
-			                @if (Model.IsEditableCase)
-			                {
-				                <div><a class="govuk-link float__right" href="@Request.Path/casehistory" aria-label="Change case history">Edit</a></div>
-			                }
-			                
-				            <div class="govuk-!-width-three-quarters">
-					            <span class="govuk-body dfe-text-area-display ">@Model.CaseModel.CaseHistory</span>
-					            </div>
-		                </div>
-		            </div>
-				</div>
-	            
-            }
-            <h3 class="govuk-heading-m">Case actions and decisions</h3>
-            <a href="management/action" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                    Add to case
-                </a>
-
-                    <table id="open-case-actions" class="govuk-table">
-                        <thead class="govuk-table__head">
-                            <tr class="govuk-table__row tr__large">
-                                <th class="govuk-table__header govuk-table__cell__cases" scope="col">
-                                    Active actions and decisions
-                                </th>
-                                <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
-                                </th>
-                                <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
-                                    Date opened
-                                </th>
+                        @if (Model.IsConcernsCase)
+                        {
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table-case-details__header">Risk to trust</th>
+                                <td class="govuk-table__cell govuk-label-wrapper">
+                                    @for (var index = 0; index < Model.CaseModel?.RatingModel?.RagRating?.Item2?.Count; ++index)
+                                    {
+                                        <span class="govuk-tag ragtag @Model.CaseModel?.RatingModel?.RagRatingCss?.ElementAt(index)">
+                                            @Model.CaseModel?.RatingModel?.RagRating?.Item2?.ElementAt(index)
+                                        </span>
+                                    }
+                                </td>
+                                <td class="govuk-table__cell govuk-table__header__right">
+                                    @if (Model.IsEditableCase)
+                                    {
+                                        <a class="govuk-link" href="@Request.Path/edit_rating" aria-label="Change risk to trust rating">
+                                            Edit<span class="govuk-visually-hidden"> risk to trust rating</span>
+                                        </a>
+                                    }
+                                </td>
                             </tr>
-                        </thead>
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table-case-details__header">Direction of travel</th>
+                                <td class="govuk-table__cell">
+                                    @Model.CaseModel.DirectionOfTravel
+                                </td>
+                                <td class="govuk-table__cell govuk-table__header__right">
+                                    @if (Model.IsEditableCase)
+                                    {
+                                        <a class="govuk-link" href="@Request.Path/edit_directionoftravel" aria-label="Change direction of travel">
+                                            Edit<span class="govuk-visually-hidden"> direction of travel</span>
+                                        </a>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table-case-details__header">Concerns</th>
+                            <td colspan="2" class="govuk-table__cell">
+                                @if (Model.CaseModel.RecordsModel.Any())
+                                {
+                                    <table class="govuk-table">
+                                        <tbody class="govuk-table__body">
+                                            @foreach (var concern in Model.CaseModel.RecordsModel)
+                                            {
+                                                <tr class="govuk-table__row">
+                                                    <td>
+                                                        @concern.TypeModel.TypeDisplay
+                                                    </td>
+                                                    <td>
+                                                        <div class="govuk-ragtag-wrapper govuk-!-padding-bottom-1 govuk-!-padding-right-4">
+                                                            @{
+                                                                if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
+                                                                {
+                                                                    <span class="govuk-tag ragtag ragtag__grey">
+                                                                        Closed
+                                                                    </span>
+                                                                }
+                                                                else
+                                                                {
+                                                                    for (var index = 0; index < concern.RatingModel.RagRating.Item2.Count; ++index)
+                                                                    {
+                                                                        <span class="govuk-tag ragtag @concern.RatingModel.RagRatingCss.ElementAt(index)">
+                                                                            @concern.RatingModel.RagRating.Item2.ElementAt(index)
+                                                                        </span>
+                                                                    }
+                                                                }
+                                                            }
+                                                        </div>
+                                                    </td>
+                                                    <td class="govuk-table__header__right">
+                                                        @{
+                                                            if (concern.StatusModel.Name.Equals(StatusEnum.Close.ToString(), StringComparison.OrdinalIgnoreCase))
+                                                            {
+                                                                <br />
+                                                            }
+                                                            else
+                                                            {
+                                                                <div class="govuk-!-padding-bottom-1">
+                                                                    @if (Model.IsEditableCase)
+                                                                    {
+                                                                        <a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating" aria-label="Change @concern.TypeModel.TypeDisplay rating" data-testid="edit-concern">Edit</a>
+                                                                    }
+                                                                </div>
+                                                            }
+                                                        }
+                                                    </td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                }
+                                <div class="govuk-o-grid__item--one-half">
+                                    @if (Model.IsEditableCase)
+                                    {
+                                        <a href="@Request.Path/concern" class="govuk-link govuk-link-no-visited-state">Add concern</a>
+                                    }
+                                </div>
 
-                        <tbody class="govuk-table__body">
-	        
-	                        @if (!Model.OpenCaseActions.Any())
-	                        {
-	                            <tr class="govuk-table__row">
-	                                <td class="govuk-table__cell" colspan="3">
-	                                    There are no open actions or decisions added to this case.
-	                                </td>
-	                            </tr>
-	                        }
+                            </td>
+                            <td class="govuk-table__cell__no_border"></td>
+                        </tr>
 
-							@foreach (ActionSummaryModel action in Model.OpenCaseActions)
-							{
-								<tr class="govuk-table__row">
-									<td class="govuk-table__cell">
-									<a data-testid="@action.Name" href="@action.RelativeUrl" class="govuk-link govuk-link-no-visited-state">
-										<span>@action.Name</span>
-										</a>
-									</td>
-									<td class="govuk-table__cell">
-										<span>@action.StatusName</span>
-									</td>
-									<td class="govuk-table__cell govuk-table__header__right">
-										@action.OpenedDate
-									</td>
-								</tr>
-							}
-                        </tbody>
-                    </table>
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table-case-details__header">SFSO territory</th>
+                            <td class="govuk-table__cell" data-testid="territory_Field">
+                                @if (Model.CaseModel.Territory == null)
+                                {
+                                    <span class='govuk-tag ragtag ragtag__grey'>Empty</span>
+                                }
+                                else
+                                {
+                                    @Model.CaseModel.Territory?.Description()
+                                }
 
-				<partial name="Shared/_ListClosedActionsForCase" model="Model.ClosedCaseActions" />
+                            </td>
+                            <td class="govuk-table__cell govuk-table__header__right">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <a class="govuk-link" data-testid="edit_Button_SFSO" href="@Request.Path/edit-territory" aria-label="Change SFSO territory">
+                                        Edit<span class="govuk-visually-hidden"> SFSO territory</span>
+                                    </a>
+                                }
+                            </td>
+                        </tr>
+
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table-case-details__header">Caseworker</th>
+                            <td class="govuk-table__cell">
+                                @Model.CaseModel.CreatedBy.FromEmailToFullName()
+                            </td>
+                            <td class="govuk-table__cell govuk-table__header__right"></td>
+                        </tr>
+
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table-case-details__header">Date Created</th>
+                            <td class="govuk-table__cell">
+                                @DateTimeHelper.ParseToDisplayDate(Model.CaseModel.CreatedAt)
+                            </td>
+                            <td class="govuk-table__cell govuk-table__header__right"></td>
+                        </tr>
+
+                    </tbody>
+                </table>
+
+                @if (Model.IsConcernsCase)
+                {
+                    <h2 class="govuk-heading-m">Concern details</h2>
+                    <hr class="govuk-section-break govuk-section-break--visible">
+
+                    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion">
+
+                        @* Issue *@
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-issue-heading">
+                                        Issue
+                                    </span>
+                                </h2>
+                            </div>
+                            <div id="accordion-issue-content" class="govuk-accordion__section-content" aria-labelledby="accordion-issue-heading">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <div><a class="govuk-link float__right" href="@Request.Path/edit_issue" aria-label="Change issue">Edit</a></div>
+                                }
+                                <div class="govuk-!-width-three-quarters">
+                                    <span class="govuk-body dfe-text-area-display">@Model.CaseModel.Issue</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        @* Status *@
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-status-heading">Current status</span>
+                                </h2>
+                            </div>
+                            <div id="accordion-status-content" class="govuk-accordion__section-content" aria-labelledby="accordion-status-heading">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <div><a class="govuk-link float__right" href="@Request.Path/edit_current_status" aria-label="Change status">Edit</a></div>
+                                }
+                                <div class="govuk-!-width-three-quarters">
+                                    <span class="govuk-body dfe-text-area-display">@Model.CaseModel.CurrentStatus</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        @* Case aim *@
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-case-aim-heading">Case aim</span>
+                                </h2>
+                            </div>
+                            <div id="accordion-case-aim-content" class="govuk-accordion__section-content" aria-labelledby="accordion-case-aim-heading">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <div><a class="govuk-link float__right" href="@Request.Path/edit_case_aim" aria-label="Change case aim">Edit</a></div>
+                                }
+
+                                <div class="govuk-!-width-three-quarters">
+                                    <span class="govuk-body dfe-text-area-display">@Model.CaseModel.CaseAim</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        @* De-escalation point *@
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-de-escalation-point-heading">De-escalation point</span>
+                                </h2>
+                            </div>
+                            <div id="accordion-de-escalation-point-content" class="govuk-accordion__section-content" aria-labelledby="accordion-de-escalation-point-heading">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <div><a class="govuk-link float__right" href="@Request.Path/edit_de_escalation_point" aria-label="Change de-escalation point">Edit</a></div>
+                                }
+
+                                <div class="govuk-!-width-three-quarters">
+                                    <span class="govuk-body dfe-text-area-display">@Model.CaseModel.DeEscalationPoint</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        @* Next steps *@
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-next-steps-heading">Next steps</span>
+                                </h2>
+                            </div>
+                            <div id="accordion-next-steps-content" class="govuk-accordion__section-content" aria-labelledby="accordion-next-steps-heading">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <div><a class="govuk-link float__right" href="@Request.Path/edit_next_steps" aria-label="Change next steps">Edit</a></div>
+                                }
+
+                                <div class="govuk-!-width-three-quarters">
+                                    <span class="govuk-body dfe-text-area-display">@Model.CaseModel.NextSteps</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        @* Case history *@
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-case-history-heading">Case history</span>
+                                </h2>
+                            </div>
+                            <div id="accordion-case-history-content" class="govuk-accordion__section-content" aria-labelledby="accordion-case-history-heading">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <div><a class="govuk-link float__right" href="@Request.Path/casehistory" aria-label="Change case history">Edit</a></div>
+                                }
+
+                                <div class="govuk-!-width-three-quarters">
+                                    <span class="govuk-body dfe-text-area-display ">@Model.CaseModel.CaseHistory</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                }
+                <h3 class="govuk-heading-m">Case actions and decisions</h3>
+                @if (Model.IsEditableCase)
+                {
+                    <a href="management/action" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                        Add to case
+                    </a>
+                }
+
+                <table id="open-case-actions" class="govuk-table">
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row tr__large">
+                            <th class="govuk-table__header govuk-table__cell__cases" scope="col">
+                                Active actions and decisions
+                            </th>
+                            <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__width_15" scope="col">
+                            </th>
+                            <th class="govuk-table__header govuk-table__cell__cases govuk-table__header__right" scope="col">
+                                Date opened
+                            </th>
+                        </tr>
+                    </thead>
+
+                    <tbody class="govuk-table__body">
+
+                        @if (!Model.OpenCaseActions.Any())
+                        {
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell" colspan="3">
+                                    There are no open actions or decisions added to this case.
+                                </td>
+                            </tr>
+                        }
+
+                        @foreach (ActionSummaryModel action in Model.OpenCaseActions)
+                        {
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <a data-testid="@action.Name" href="@action.RelativeUrl" class="govuk-link govuk-link-no-visited-state">
+                                        <span>@action.Name</span>
+                                    </a>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    <span>@action.StatusName</span>
+                                </td>
+                                <td class="govuk-table__cell govuk-table__header__right">
+                                    @action.OpenedDate
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+
+                <partial name="Shared/_ListClosedActionsForCase" model="Model.ClosedCaseActions" />
 
             </div>
             <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="trust-overview">


### PR DESCRIPTION
**What is the change?**

add permissions to the case management page

**Why do we need the change?**

to only allow case owners to edit cases

**What is the impact?**

this commit will change the behaviour of the system currently it will re-enable case editing for anyone, because the permissions service always returns edit as allowed

when the server side is implemented, this will stop on cases and case actions, so we can make a decision on whether this is a problem to merge or not until that work is done

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/117704
