### PR TITLE
Only use sentry tracing in non-development environments. 

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -161,7 +161,11 @@ namespace ConcernsCaseWork
 			app.UseRouting();
 
 			// Enable Sentry middleware for performance monitoring
-			app.UseSentryTracing();
+			if (!env.IsDevelopment())
+			{
+				app.UseSentryTracing();
+			}
+
 			app.UseAuthentication();
 			app.UseAuthorization();
 			app.UseMiddleware<CorrelationIdMiddleware>();


### PR DESCRIPTION
**What is the change?**
Only use sentry tracing in non-development environments. 

**Why do we need the change?**
We currently send Sentry logging for all local development requests which makes it difficult / impossible to see real errors on the server environment or check performance. 

**What is the impact?**
This should block sentry tracing on local development but hopefully not block it on the server development environment.

**Azure DevOps Ticket**
118824
