### PR TITLE
Feature/116704 cd require user context on all api calls

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/UserContextReceiverMiddleware.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/UserContextReceiverMiddleware.cs
@@ -1,13 +1,7 @@
 ﻿using Ardalis.GuardClauses;
-using ConcernsCaseWork.Logging;
 using ConcernsCaseWork.UserContext;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.API.Middleware
 {
@@ -31,15 +25,23 @@ namespace ConcernsCaseWork.API.Middleware
 
 				if (userInfoService.UserInfo == null)
 				{
-					logger.LogError($"Call to {httpContext.Request.Path} received without user information headers. Responding with bad request");
+					logger.LogError($"Call to {httpContext.Request.Path} received without user information headers. Responding with unauthorized request. Headers:{HeadersToStrings(httpContext.Request)}");
 					httpContext.Response.Clear();
 					httpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-					await httpContext.Response.WriteAsync("Unauthorized. Requests must supply user-context information");
+					await httpContext.Response.WriteAsync($"Unauthorized. Requests must supply user-context information. Requested path: {httpContext.Request.Path}, Headers:{HeadersToStrings(httpContext.Request)}");
 					return;
 				}
 			}
 
 			await _next(httpContext);
+		}
+
+		private string HeadersToStrings(HttpRequest httpContextRequest)
+		{
+			var sb = new StringBuilder();
+			var headerStrings = httpContextRequest.Headers.Select(x => $"Key:{x.Key}, Value'{x.Value.ToString()}'; ").ToArray();
+			sb.AppendJoin(';', headerStrings);
+			return sb.ToString();
 		}
 
 		private bool IsPageRequest(string path) => path.StartsWith("/v2/") && !path.Contains("swagger");

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/UserContextReceiverMiddleware.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Middleware/UserContextReceiverMiddleware.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.UserContext;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -23,21 +24,25 @@ namespace ConcernsCaseWork.API.Middleware
 		{
 			Guard.Against.Null(userInfoService);
 			Guard.Against.Null(logger);
-			
+
 			if (IsPageRequest(httpContext.Request.Path))
 			{
 				userInfoService.ReceiveRequestHeaders(httpContext.Request.Headers);
 
 				if (userInfoService.UserInfo == null)
 				{
-					logger.LogWarningMsg($"Call to {httpContext.Request.Path}");
+					logger.LogError($"Call to {httpContext.Request.Path} received without user information headers. Responding with bad request");
+					httpContext.Response.Clear();
+					httpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+					await httpContext.Response.WriteAsync("Unauthorized. Requests must supply user-context information");
+					return;
 				}
 			}
 
 			await _next(httpContext);
 		}
 
-		private bool IsPageRequest(string path) => path.StartsWith("/v2/");
+		private bool IsPageRequest(string path) => path.StartsWith("/v2/") && !path.Contains("swagger");
 
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/api/apiBase.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/api/apiBase.ts
@@ -1,4 +1,4 @@
-import { EnvApiKey } from "cypress/constants/cypressConstants";
+import { EnvApiKey, EnvUsername, CaseworkerClaim } from "cypress/constants/cypressConstants";
 
 export class ApiBase
 {
@@ -6,9 +6,10 @@ export class ApiBase
     {
         const result = {
             ApiKey: Cypress.env(EnvApiKey),
-            "Content-type": "application/json"
+            "Content-type": "application/json",
+            "x-userContext-role-0" : CaseworkerClaim,
+            "x-userContext-name" : Cypress.env(EnvUsername)
         };
-
         return result;
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/constants/cypressConstants.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/constants/cypressConstants.ts
@@ -1,3 +1,6 @@
 export const EnvApi = "api";
 export const EnvApiKey = "apiKey";
 export const EnvUsername = "username";
+export const CaseworkerClaim = "concerns-casework.caseworker";
+export const TeamLeaderClaim = "concerns-casework.teamleader";
+export const AdminClaim = "concerns-casework.admin";

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/CaseServiceIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/CaseServiceIntegrationTests.cs
@@ -1,7 +1,9 @@
 ﻿using ConcernsCaseWork.Integration.Tests.Factory;
+using ConcernsCaseWork.Integration.Tests.Helpers;
 using ConcernsCaseWork.Service.Cases;
 using ConcernsCaseWork.Service.Trusts;
 using ConcernsCaseWork.Shared.Tests.Factory;
+using ConcernsCaseWork.UserContext;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -25,14 +27,14 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		/// Future work can be to delete the records from the SQLServer.
 		/// </summary>
 		private const string CaseWorker = "case.service.integration";
-		
+
 		[OneTimeSetUp]
 		public void OneTimeSetup()
 		{
 			_configuration = new ConfigurationBuilder().ConfigurationUserSecretsBuilder().Build();
 			_factory = new WebAppFactory(_configuration);
 		}
-		
+
 		[OneTimeTearDown]
 		public void OneTimeTearDown()
 		{
@@ -44,6 +46,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var caseService = serviceScope.ServiceProvider.GetRequiredService<ICaseService>();
 			var trustSummaryDto = await FetchRandomTrust(serviceScope, "Senior");
 
@@ -63,6 +66,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var caseService = serviceScope.ServiceProvider.GetRequiredService<ICaseService>();
 			var trustSummaryDto = await FetchRandomTrust(serviceScope, "Senior");
 
@@ -76,12 +80,13 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 			Assert.That(postCaseDto, Is.Not.Null);
 			Assert.That(caseDto, Is.Not.Null);
 		}
-		
+
 		[Test]
 		public async Task WhenGetCasesByTrustUkPrn_ReturnsApiWrapperCaseDto()
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var caseService = serviceScope.ServiceProvider.GetRequiredService<ICaseService>();
 			var trustSummaryDto = await FetchRandomTrust(serviceScope, "Senior");
 
@@ -103,6 +108,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var caseService = serviceScope.ServiceProvider.GetRequiredService<ICaseService>();
 
 			var trustSummaryDto = await FetchRandomTrust(serviceScope, "Senior");
@@ -167,10 +173,10 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 			var trustService = serviceScope.ServiceProvider.GetRequiredService<ITrustService>();
 			var apiWrapperTrusts= await trustService.GetTrustsByPagination(
 				TrustFactory.BuildTrustSearch(searchParameter, searchParameter, searchParameter));
-			
+
 			Assert.That(apiWrapperTrusts, Is.Not.Null);
 			Assert.That(apiWrapperTrusts.Data, Is.Not.Null);
-			
+
 			var random = new Random();
 			int index = random.Next(apiWrapperTrusts.Data.Count);
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/RatingServiceIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/RatingServiceIntegrationTests.cs
@@ -1,6 +1,8 @@
 ﻿using ConcernsCaseWork.Integration.Tests.Factory;
+using ConcernsCaseWork.Integration.Tests.Helpers;
 using ConcernsCaseWork.Service.Ratings;
 using ConcernsCaseWork.Shared.Tests.Factory;
+using ConcernsCaseWork.UserContext;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -41,6 +43,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var ratingService = serviceScope.ServiceProvider.GetRequiredService<IRatingService>();
 
 			//act 

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/RecordServiceIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/RecordServiceIntegrationTests.cs
@@ -1,4 +1,5 @@
 ﻿using ConcernsCaseWork.Integration.Tests.Factory;
+using ConcernsCaseWork.Integration.Tests.Helpers;
 using ConcernsCaseWork.Service.Cases;
 using ConcernsCaseWork.Service.MeansOfReferral;
 using ConcernsCaseWork.Service.Ratings;
@@ -6,6 +7,7 @@ using ConcernsCaseWork.Service.Records;
 using ConcernsCaseWork.Service.Trusts;
 using ConcernsCaseWork.Service.Types;
 using ConcernsCaseWork.Shared.Tests.Factory;
+using ConcernsCaseWork.UserContext;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -50,6 +52,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var startTime = DateTime.UtcNow;
 			var recordService = serviceScope.ServiceProvider.GetRequiredService<IRecordService>();
 			var caseUrn = await FetchRandomCaseUrn(serviceScope);
@@ -85,6 +88,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange 
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var recordService = serviceScope.ServiceProvider.GetRequiredService<IRecordService>();
 			var caseUrn = await FetchRandomCaseUrn(serviceScope);
 			var typeId = await FetchRandomTypeId(serviceScope);

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/StatusServiceIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/StatusServiceIntegrationTests.cs
@@ -1,6 +1,8 @@
 ﻿using ConcernsCaseWork.Integration.Tests.Factory;
+using ConcernsCaseWork.Integration.Tests.Helpers;
 using ConcernsCaseWork.Service.Status;
 using ConcernsCaseWork.Shared.Tests.Factory;
+using ConcernsCaseWork.UserContext;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -36,6 +38,7 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var statusService = serviceScope.ServiceProvider.GetRequiredService<IStatusService>();
 			
 			// act

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/TypeServiceIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Concerns/TypeServiceIntegrationTests.cs
@@ -1,6 +1,8 @@
 ﻿using ConcernsCaseWork.Integration.Tests.Factory;
+using ConcernsCaseWork.Integration.Tests.Helpers;
 using ConcernsCaseWork.Service.Types;
 using ConcernsCaseWork.Shared.Tests.Factory;
+using ConcernsCaseWork.UserContext;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -20,14 +22,14 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		/// Variables for caseworker and trustukprn, creates cases on Academies API.
 		/// Future work can be to delete the records from the SQLServer.
 		/// </summary>
-		
+
 		[OneTimeSetUp]
 		public void OneTimeSetup()
 		{
 			_configuration = new ConfigurationBuilder().ConfigurationUserSecretsBuilder().Build();
 			_factory = new WebAppFactory(_configuration);
 		}
-		
+
 		[OneTimeTearDown]
 		public void OneTimeTearDown()
 		{
@@ -39,9 +41,10 @@ namespace ConcernsCaseWork.Integration.Tests.Concerns
 		{
 			// arrange
 			using var serviceScope = _factory.Services.CreateScope();
+			serviceScope.ServiceProvider.GetService<IClientUserInfoService>().SetPrincipal(ClaimsPrincipalTestHelper.CreateCaseWorkerPrincipal());
 			var typeService = serviceScope.ServiceProvider.GetRequiredService<ITypeService>();
 
-			//act 
+			//act
 			var typesDto = await typeService.GetTypes();
 
 			// assert

--- a/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Helpers/ClaimsPrincipalTestHelper.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Integration.Tests/Helpers/ClaimsPrincipalTestHelper.cs
@@ -1,0 +1,41 @@
+﻿using ConcernsCaseWork.UserContext;
+using System.Security.Claims;
+
+namespace ConcernsCaseWork.Integration.Tests.Helpers
+{
+	public static class ClaimsPrincipalTestHelper
+	{
+		public static ClaimsPrincipal CreateCaseWorkerPrincipal(string name = null)
+		{
+
+			return new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+			{
+				new Claim(ClaimTypes.Name, name ?? "some.one@education.gov.uk"),
+				new Claim(ClaimTypes.NameIdentifier, "1"),
+				new Claim(Claims.CaseWorkerRoleClaim, Claims.CaseWorkerRoleClaim)
+			}, "mock"));
+		}
+
+		public static ClaimsPrincipal CreateTeamLeaderPrincipal(string name = null)
+		{
+
+			return new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+			{
+				new Claim(ClaimTypes.Name, name ?? "some.one@education.gov.uk"),
+				new Claim(ClaimTypes.NameIdentifier, "1"),
+				new Claim(Claims.CaseWorkerRoleClaim, Claims.TeamLeaderRoleClaim)
+			}, "mock"));
+		}
+
+		public static ClaimsPrincipal CreateAdminPrincipal(string name = null)
+		{
+
+			return new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+			{
+				new Claim(ClaimTypes.Name, name ?? "some.one@education.gov.uk"),
+				new Claim(ClaimTypes.NameIdentifier, "1"),
+				new Claim(Claims.CaseWorkerRoleClaim, Claims.TeamLeaderRoleClaim)
+			}, "mock"));
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Base/AbstractService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Base/AbstractService.cs
@@ -19,16 +19,17 @@ namespace ConcernsCaseWork.Service.Base
 		private readonly ILogger<AbstractService> _logger;
 		private readonly IClientUserInfoService _userInfoService;
 
-		internal string HttpClientName { get; init; } = "TramsClient"; // was "Default";
+		private string HttpClientName { get; init; } = "TramsClient"; // was "Default";
 		internal string EndpointsVersion { get; } = "v2";
 		internal string EndpointPrefix { get; } = "concerns-cases";
 
-		protected AbstractService(IHttpClientFactory clientFactory, ILogger<AbstractService> logger, ICorrelationContext correlationContext, IClientUserInfoService userInfoService)
+		protected AbstractService(IHttpClientFactory clientFactory, ILogger<AbstractService> logger, ICorrelationContext correlationContext, IClientUserInfoService userInfoService, string httpClientName)
 		{
 			_clientFactory = Guard.Against.Null(clientFactory);
 			_logger = Guard.Against.Null(logger);
 			_correlationContext = Guard.Against.Null(correlationContext);
 			_userInfoService = Guard.Against.Null(userInfoService);
+			HttpClientName = httpClientName;
 		}
 
 		public Task<T> Get<T>(string endpoint, bool treatNoContentAsError = false) where T : class

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Base/AbstractService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Base/AbstractService.cs
@@ -96,7 +96,12 @@ namespace ConcernsCaseWork.Service.Base
 				_logger.LogWarning("Warning. Unable to add correlationId to request headers");
 			}
 
-			_userInfoService.AddRequestHeaders(client);
+			var userInfoHeadersAdded = _userInfoService.AddUserInfoRequestHeaders(client);
+
+			if (!userInfoHeadersAdded)
+			{
+				_logger.LogWarning("Warning. Attempt to call api without user info headers");
+			}
 
 			return client;
 		}

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Base/ConcernsAbstractService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Base/ConcernsAbstractService.cs
@@ -6,9 +6,8 @@ namespace ConcernsCaseWork.Service.Base
 {
 	public abstract class ConcernsAbstractService : AbstractService
 	{
-		protected ConcernsAbstractService(IHttpClientFactory clientFactory, ILogger<ConcernsAbstractService> logger, ICorrelationContext correlationContext, IClientUserInfoService userInfoService) : base(clientFactory, logger, correlationContext, userInfoService)
+		protected ConcernsAbstractService(IHttpClientFactory clientFactory, ILogger<ConcernsAbstractService> logger, ICorrelationContext correlationContext, IClientUserInfoService userInfoService) : base(clientFactory, logger, correlationContext, userInfoService, "ConcernsClient")
 		{
-			HttpClientName = "ConcernsClient";
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Base/TramsAbstractService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Base/TramsAbstractService.cs
@@ -6,8 +6,7 @@ namespace ConcernsCaseWork.Service.Base;
 
 public abstract class TramsAbstractService : AbstractService
 {
-	protected TramsAbstractService(IHttpClientFactory clientFactory, ILogger<TramsAbstractService> logger, ICorrelationContext correlationContext, IClientUserInfoService userInfoService) : base(clientFactory, logger, correlationContext, userInfoService)
+	protected TramsAbstractService(IHttpClientFactory clientFactory, ILogger<TramsAbstractService> logger, ICorrelationContext correlationContext, IClientUserInfoService userInfoService) : base(clientFactory, logger, correlationContext, userInfoService, "TramsClient")
 	{
-		HttpClientName = "TramsClient";
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/CaseActions/SRMAProvider.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/CaseActions/SRMAProvider.cs
@@ -21,7 +21,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 
 		public async Task<SRMADto> GetSRMAById(long srmaId)
 		{
-			var client = _httpClientFactory.CreateClient(HttpClientName);
+			var client = CreateHttpClient();
 			var request = new HttpRequestMessage(HttpMethod.Get, $"{Url}?srmaId={srmaId}");
 
 			try
@@ -43,7 +43,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Get, $"{Url}/case/{caseUrn}");
 
 				var response = await client.SendAsync(request);
@@ -62,7 +62,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Post, $"{Url}");
 
 				request.Content = new StringContent(JsonConvert.SerializeObject(srma),
@@ -84,7 +84,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-date-accepted?acceptedDate={SerialiseDateTime(acceptedDate)}");
 
 				var response = await client.SendAsync(request); 
@@ -103,7 +103,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-closed-date");
 
 				var response = await client.SendAsync(request);
@@ -122,7 +122,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-date-report-sent?dateReportSent={SerialiseDateTime(reportSentDate)}");
 
 				var response = await client.SendAsync(request);
@@ -141,7 +141,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-notes?notes={notes ?? String.Empty}");
 
 				var response = await client.SendAsync(request);
@@ -160,7 +160,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-offered-date?offeredDate={SerialiseDateTime(offeredDate)}");
 
 				var response = await client.SendAsync(request);
@@ -179,7 +179,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-reason?reason={(int)reason}");
 
 				var response = await client.SendAsync(request);
@@ -198,7 +198,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-status?status={(int)status}");
 
 				var response = await client.SendAsync(request);
@@ -217,7 +217,7 @@ namespace ConcernsCaseWork.Service.CaseActions
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}/{srmaId}/update-visit-dates?startDate={SerialiseDateTime(startDate)}&endDate={SerialiseDateTime(endDate)}");
 
 				var response = await client.SendAsync(request);

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/NtiUnderConsideration/NtiUnderConsiderationService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/NtiUnderConsideration/NtiUnderConsiderationService.cs
@@ -24,7 +24,7 @@ namespace ConcernsCaseWork.Service.NtiUnderConsideration
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Post, $"{Url}");
 
 				request.Content = new StringContent(JsonConvert.SerializeObject(ntiDto),
@@ -46,7 +46,7 @@ namespace ConcernsCaseWork.Service.NtiUnderConsideration
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Get, $"{Url}/case/{caseUrn}");
 
 				var response = await client.SendAsync(request);
@@ -97,7 +97,7 @@ namespace ConcernsCaseWork.Service.NtiUnderConsideration
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{Url}");
 
 				request.Content = new StringContent(JsonConvert.SerializeObject(ntiDto),

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/NtiWarningLetter/NtiWarningLetterService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/NtiWarningLetter/NtiWarningLetterService.cs
@@ -24,7 +24,7 @@ namespace ConcernsCaseWork.Service.NtiWarningLetter
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Post, $"{_url}");
 
 				request.Content = new StringContent(JsonConvert.SerializeObject(newNtiWarningLetter),
@@ -75,7 +75,7 @@ namespace ConcernsCaseWork.Service.NtiWarningLetter
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Get, $"{_url}/case/{caseUrn}");
 
 				var response = await client.SendAsync(request);
@@ -94,7 +94,7 @@ namespace ConcernsCaseWork.Service.NtiWarningLetter
 		{
 			try
 			{
-				var client = _httpClientFactory.CreateClient(HttpClientName);
+				var client = CreateHttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Patch, $"{_url}");
 
 				request.Content = new StringContent(JsonConvert.SerializeObject(ntiWarningLetter),

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Security.Principal;
 using System.Threading.Tasks;
 
 namespace ConcernsCaseWork.Tests.Pages.Trust
@@ -270,7 +271,7 @@ namespace ConcernsCaseWork.Tests.Pages.Trust
 		private static IndexPageModel SetupIndexModel(ITrustModelService mockTrustModelService, IUserStateCachedService mockUSerStateCachedService, ILogger<IndexPageModel> mockLogger, bool isAuthenticated = false)
 		{
 			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
-			mockClaimsPrincipalHelper.Setup(x => x.GetPrincipalName(It.IsAny<ClaimsPrincipal>())).Returns("Tester");
+			mockClaimsPrincipalHelper.Setup(x => x.GetPrincipalName(It.IsAny<IPrincipal>())).Returns("Tester");
 
 			(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/Claims.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/Claims.cs
@@ -3,7 +3,7 @@
 	public abstract class Claims
 	{
 		public const string ClaimPrefix = "concerns-casework.";
-		public const string CaseWorkerRoleClaim = $"{ClaimPrefix}concerns-casework.caseworker";
+		public const string CaseWorkerRoleClaim = $"{ClaimPrefix}caseworker";
 		public const string TeamLeaderRoleClaim = $"{ClaimPrefix}teamleader";
 		public const string AdminRoleClaim = $"{ClaimPrefix}admin";
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/ClientUserInfoService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/ClientUserInfoService.cs
@@ -27,19 +27,20 @@ namespace ConcernsCaseWork.UserContext
 			};
 		}
 
-		public void AddRequestHeaders(HttpClient client)
+		public bool AddUserInfoRequestHeaders(HttpClient client)
 		{
 			Guard.Against.Null(client);
 
 			if (UserInfo == null)
 			{
-				return;
+				return false;
 			}
 
 			foreach (KeyValuePair<string, string> keyValuePair in UserInfo.ToHeadersKVP())
 			{
 				client.DefaultRequestHeaders.TryAddWithoutValidation(keyValuePair.Key, keyValuePair.Value);
 			}
+			return true;
 		}
 
 		private string GetPrincipalName(IPrincipal principal)

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/ClientUserInfoService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/ClientUserInfoService.cs
@@ -11,7 +11,7 @@ namespace ConcernsCaseWork.UserContext
 		{
 
 		}
-		public UserInfo? UserInfo { get; private set; }
+		public UserInfo UserInfo { get; private set; }
 
 		public void SetPrincipal(ClaimsPrincipal claimsPrincipal)
 		{

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/IClientUserInfoService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/IClientUserInfoService.cs
@@ -1,0 +1,11 @@
+﻿using System.Security.Claims;
+
+namespace ConcernsCaseWork.UserContext;
+
+public interface IClientUserInfoService
+{
+	void SetPrincipal(ClaimsPrincipal claimsPrincipal);
+
+	void AddRequestHeaders(HttpClient client);
+	UserInfo UserInfo { get; }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/IClientUserInfoService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/IClientUserInfoService.cs
@@ -6,6 +6,6 @@ public interface IClientUserInfoService
 {
 	void SetPrincipal(ClaimsPrincipal claimsPrincipal);
 
-	void AddRequestHeaders(HttpClient client);
+	bool AddUserInfoRequestHeaders(HttpClient client);
 	UserInfo UserInfo { get; }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/IServerUserInfoService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/IServerUserInfoService.cs
@@ -1,15 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
-using System.Security.Claims;
 
 namespace ConcernsCaseWork.UserContext;
-
-public interface IClientUserInfoService
-{
-	void SetPrincipal(ClaimsPrincipal claimsPrincipal);
-
-	void AddRequestHeaders(HttpClient client);
-	UserInfo? UserInfo { get; }
-}
 
 public interface IServerUserInfoService
 {

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
@@ -36,7 +36,14 @@ namespace ConcernsCaseWork.UserContext
 				.Select(x => x.Value)
 				.ToArray();
 
-			return new UserInfo() { Name = name, Roles = roles };
+			if (string.IsNullOrWhiteSpace(name))
+			{
+				return null;
+			}
+			else
+			{
+				return new UserInfo() { Name = name, Roles = roles };
+			}
 		}
 
 

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
@@ -36,7 +36,7 @@ namespace ConcernsCaseWork.UserContext
 				.Select(x => x.Value)
 				.ToArray();
 
-			if (string.IsNullOrWhiteSpace(name))
+			if (string.IsNullOrWhiteSpace(name) || roles.Length==0)
 			{
 				return null;
 			}

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
@@ -36,7 +36,7 @@ namespace ConcernsCaseWork.UserContext
 				.Select(x => x.Value)
 				.ToArray();
 
-			if (string.IsNullOrWhiteSpace(name) || roles.Length==0)
+			if (string.IsNullOrWhiteSpace(name))
 			{
 				return null;
 			}

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
@@ -36,7 +36,7 @@ namespace ConcernsCaseWork.UserContext
 				.Select(x => x.Value)
 				.ToArray();
 
-			if (string.IsNullOrWhiteSpace(name))
+			if (string.IsNullOrWhiteSpace(name) || roles.Length == 0)
 			{
 				return null;
 			}

--- a/ConcernsCaseWork/ConcernsCaseWork/Middleware/UserContextMiddleware.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Middleware/UserContextMiddleware.cs
@@ -17,7 +17,16 @@ public class UserContextMiddleware
 
 	public Task Invoke(HttpContext httpContext, IClientUserInfoService userInfoService)
 	{
-		userInfoService.SetPrincipal(httpContext.User);
-		return _next(httpContext);
+		if (httpContext.User.Identity != null && IsPageRequest(httpContext.Request.Path))
+		{
+			userInfoService.SetPrincipal(httpContext.User);
+			return _next(httpContext);
+		}
+		else
+		{
+			return _next(httpContext);
+		}
 	}
+
+	private bool IsPageRequest(string path) => !path.StartsWith("/v2/");
 }


### PR DESCRIPTION
**What is the change?**
All requests to the concerns API will pass user context, and all will be rejected if user context headers aren't received.

**Why do we need the change?**
To enable auditing and permissions.

**What is the impact?**
low

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/Iteration%20-%2036?workitem=118832