### PR TITLE
Fix/cd allow lower case user context headers

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/SwaggerOptions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/SwaggerOptions.cs
@@ -52,6 +52,7 @@ namespace ConcernsCaseWork.API.StartupConfiguration
             };
             options.AddSecurityDefinition(ApiKeyName, securityScheme);
             options.OperationFilter<AuthenticationHeaderOperationFilter>();
+            options.OperationFilter<UserContextOperationFilter>();
         }
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/UserContextOperationFilter.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/UserContextOperationFilter.cs
@@ -1,0 +1,36 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+public class UserContextOperationFilter : IOperationFilter
+{
+	public void Apply(OpenApiOperation operation, OperationFilterContext context)
+	{
+		if (operation.Parameters is null)
+		{
+			operation.Parameters = new List<OpenApiParameter>();
+		}
+
+		operation.Parameters.Add(new OpenApiParameter
+		{
+			Name = "x-user-context-name",
+			In = ParameterLocation.Header,
+			Description = "user name",
+			Required = true
+		});
+
+		operation.Parameters.Add(new OpenApiParameter
+		{
+			Name = "x-user-context-role-0",
+			In = ParameterLocation.Header,
+			Description = "user-role. API calls support 1..* users roles in the format x-user-context-role-* where the index starts from zero",
+			Examples = new Dictionary<string, OpenApiExample>()
+			{
+				{ "caseworker", new OpenApiExample(){ Value = new OpenApiString("concerns-casework.caseworker") } },
+				{ "team-leader", new OpenApiExample(){ Value = new OpenApiString("concerns-casework.teamleader") } },
+				{ "admin", new OpenApiExample(){ Value = new OpenApiString("concerns-casework.admin") } }
+			},
+			Required = true,
+		});
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/api/apiBase.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/api/apiBase.ts
@@ -7,8 +7,8 @@ export class ApiBase
         const result = {
             ApiKey: Cypress.env(EnvApiKey),
             "Content-type": "application/json",
-            "x-userContext-role-0" : CaseworkerClaim,
-            "x-userContext-name" : Cypress.env(EnvUsername)
+            "x-user-context-role-0" : CaseworkerClaim,
+            "x-user-context-name" : Cypress.env(EnvUsername)
         };
         return result;
     }

--- a/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.UserContext/UserInfo.cs
@@ -8,8 +8,8 @@ namespace ConcernsCaseWork.UserContext
 		public string Name { get; set; }
 		public string[] Roles { get; set; }
 
-		private const string NameHeaderKey = "x-userContext-name";
-		private const string RoleHeaderKeyPrefix = "x-userContext-role-";
+		private const string NameHeaderKey = "x-user-context-name";
+		private const string RoleHeaderKeyPrefix = "x-user-context-role-";
 
 		public static string[] ParseRoleClaims(string[] claims)
 		{
@@ -29,10 +29,10 @@ namespace ConcernsCaseWork.UserContext
 		public static UserInfo FromHeaders(KeyValuePair<string,string>[] headers)
 		{
 
-			var name = headers.FirstOrDefault(x => x.Key == NameHeaderKey).Value;
+			var name = headers.FirstOrDefault(x => x.Key.Equals(NameHeaderKey, StringComparison.InvariantCultureIgnoreCase)).Value;
 
 			var roles = headers
-				.Where(x => x.Key.StartsWith(RoleHeaderKeyPrefix) && x.Value.StartsWith(Claims.ClaimPrefix, StringComparison.InvariantCultureIgnoreCase))
+				.Where(x => x.Key.StartsWith(RoleHeaderKeyPrefix, StringComparison.InvariantCultureIgnoreCase) && x.Value.StartsWith(Claims.ClaimPrefix, StringComparison.InvariantCultureIgnoreCase))
 				.Select(x => x.Value)
 				.ToArray();
 

--- a/ConcernsCaseWork/ConcernsCasework.UserContext.Tests/UserInfoTests.cs
+++ b/ConcernsCaseWork/ConcernsCasework.UserContext.Tests/UserInfoTests.cs
@@ -25,7 +25,7 @@ namespace ConcernsCaseWork.API.Contracts.Tests.Context
 			};
 
 			var results = sut.ToHeadersKVP();
-			var nameResult = results.FirstOrDefault(x => x.Key == "x-userContext-name");
+			var nameResult = results.FirstOrDefault(x => string.Equals(x.Key, "x-user-context-name", StringComparison.InvariantCultureIgnoreCase));
 			nameResult.Value.Should().Be(sut.Name);
 		}
 
@@ -42,14 +42,14 @@ namespace ConcernsCaseWork.API.Contracts.Tests.Context
 			};
 
 			var results = sut.ToHeadersKVP();
-			var roleResults = results.Where(x => x.Key.StartsWith("x-userContext-role-")).ToArray();
+			var roleResults = results.Where(x => x.Key.StartsWith("x-user-context-role-", StringComparison.InvariantCultureIgnoreCase)).ToArray();
 			roleResults.Length.Should().Be(3);
 
-			roleResults[0].Key.Should().Be("x-userContext-role-0");
+			roleResults[0].Key.Should().Be("x-user-context-role-0");
 			roleResults[0].Value.Should().Be(Claims.CaseWorkerRoleClaim);
-			roleResults[1].Key.Should().Be("x-userContext-role-1");
+			roleResults[1].Key.Should().Be("x-user-context-role-1");
 			roleResults[1].Value.Should().Be(Claims.TeamLeaderRoleClaim);
-			roleResults[2].Key.Should().Be("x-userContext-role-2");
+			roleResults[2].Key.Should().Be("x-user-context-role-2");
 			roleResults[2].Value.Should().Be(Claims.AdminRoleClaim);
 		}
 
@@ -74,15 +74,18 @@ namespace ConcernsCaseWork.API.Contracts.Tests.Context
 			results[2].Should().Be(Claims.AdminRoleClaim);
 		}
 
-		[Fact]
-		public void FromHeaders_Returns_Populated_UserInfo()
+		[Theory]
+		[InlineData("x-user-context-name", "x-user-context-role-0", "x-user-context-role-1", "x-user-context-role-2")]
+		[InlineData("X-USER-CONTEXT-NAME", "X-USER-CONTEXT-ROLE-0", "X-USER-CONTEXT-ROLE-1", "X-USER-CONTEXT-ROLE-2")]
+		[InlineData("X-user-CONTEXT-NAME", "X-user-CONTEXT-ROLE-0", "X-user-CONTEXT-ROLE-1", "X-user-CONTEXT-ROLE-2")]
+		public void FromHeaders_Is_Case_Insensitive_And_Returns_Populated_UserInfo(string nameHeader, string roleHeader1, string roleHeader2, string roleHeader3)
 		{
 			var inputs = new KeyValuePair<string,string>[]
 			{
-				new("x-userContext-name" ,"John"),
-				new("x-userContext-role-0", Claims.CaseWorkerRoleClaim),
-				new("x-userContext-role-1", Claims.TeamLeaderRoleClaim),
-				new("x-userContext-role-2", Claims.AdminRoleClaim)
+				new(nameHeader ,"John"),
+				new(roleHeader1, Claims.CaseWorkerRoleClaim),
+				new(roleHeader2, Claims.TeamLeaderRoleClaim),
+				new(roleHeader3, Claims.AdminRoleClaim)
 			};
 
 			var sut = UserInfo.FromHeaders(inputs);
@@ -91,6 +94,41 @@ namespace ConcernsCaseWork.API.Contracts.Tests.Context
 			sut.Roles.Should().Contain(Claims.CaseWorkerRoleClaim);
 			sut.Roles.Should().Contain(Claims.TeamLeaderRoleClaim);
 			sut.Roles.Should().Contain(Claims.AdminRoleClaim);
+		}
+
+		[Theory]
+		[InlineData("x-user-context-role-0", "x-user-context-role-1", "x-user-context-role-2")]
+		[InlineData("X-USER-CONTEXT-ROLE-0", "X-USER-CONTEXT-ROLE-1", "X-USER-CONTEXT-ROLE-2")]
+		[InlineData("X-user-CONTEXT-ROLE-0", "X-user-CONTEXT-ROLE-1", "X-user-CONTEXT-ROLE-2")]
+		public void FromHeaders_Without_Name_Returns_Null(string roleHeader1, string roleHeader2, string roleHeader3)
+		{
+			var inputs = new KeyValuePair<string,string>[]
+			{
+				new("invalid-header" ,"John"),
+				new(roleHeader1, Claims.CaseWorkerRoleClaim),
+				new(roleHeader2, Claims.TeamLeaderRoleClaim),
+				new(roleHeader3, Claims.AdminRoleClaim)
+			};
+
+			var sut = UserInfo.FromHeaders(inputs);
+			sut.Should().BeNull();
+		}
+
+		[Theory]
+		[InlineData("x-user-context-name")]
+		[InlineData("X-USER-CONTEXT-NAME")]
+		[InlineData("X-user-CONTEXT-NAME")]
+		public void FromHeaders_Without_Roles_Returns_Null(string nameHeader)
+		{
+			var inputs = new KeyValuePair<string,string>[]
+			{
+				new(nameHeader ,"John"),
+				new("x-invalid-header-role-0", Claims.CaseWorkerRoleClaim),
+			};
+
+
+			var sut = UserInfo.FromHeaders(inputs);
+			sut.Should().BeNull();
 		}
 	}
 }


### PR DESCRIPTION
**What is the change?**
change x-userContext headers to x-user-context. 
Make checking headers case-insensitive.
Add user-context headers to swagger ui

**Why do we need the change?**
bug fixes

**What is the impact?**
low

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/Iteration%20-%2036?workitem=119072