### PR TITLE
Fix bug where more than one concerns can't be added

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/CaseModelService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/CaseModelService.cs
@@ -269,9 +269,9 @@ namespace ConcernsCaseWork.Services.Cases
 				var newCase = await _caseService.PostCase(CaseMapping.Map(createCaseModel));
 
 				// Create records
-				var currentDate = DateTimeOffset.Now;
 				var recordTasks = createCaseModel.CreateRecordsModel.Select(recordModel => 
 				{
+					var currentDate = DateTimeOffset.Now;
 					var createRecordDto = new CreateRecordDto(
 						currentDate, 
 						currentDate,


### PR DESCRIPTION
**What is the change?**
Fix bug where more than one concerns can't be added when creating a case - make sure CreatedBy is unique so the unique constraint doesn't fail.

**Why do we need the change?**
Otherwise it isn't possible to create more than one concern when creating a case

**What is the impact?**
Sets CreatedAt date to be slightly different for each Concern so the duplicate constraint doesn't fail

**Azure DevOps Ticket**
119352