### PR TITLE
Added liveness probes for CDN + Container

### DIFF
--- a/terraform.gpaas-azure-migration/README.md
+++ b/terraform.gpaas-azure-migration/README.md
@@ -139,7 +139,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.13.0 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | n/a |
 
 ## Resources
 
@@ -156,9 +156,11 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_custom_domains"></a> [cdn\_frontdoor\_custom\_domains](#input\_cdn\_frontdoor\_custom\_domains) | Azure CDN Front Door custom domains. If they are within the DNS zone (optionally created), the Validation TXT records and ALIAS/CNAME records will be created | `list(string)` | `[]` | no |
+| <a name="input_cdn_frontdoor_health_probe_path"></a> [cdn\_frontdoor\_health\_probe\_path](#input\_cdn\_frontdoor\_health\_probe\_path) | Specifies the path relative to the origin that is used to determine the health of the origin. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_host_add_response_headers"></a> [cdn\_frontdoor\_host\_add\_response\_headers](#input\_cdn\_frontdoor\_host\_add\_response\_headers) | List of response headers to add at the CDN Front Door `[{ "name" = "Strict-Transport-Security", "value" = "max-age=31536000" }]` | `list(map(string))` | n/a | yes |
 | <a name="input_cdn_frontdoor_host_redirects"></a> [cdn\_frontdoor\_host\_redirects](#input\_cdn\_frontdoor\_host\_redirects) | CDN Front Door host redirects `[{ "from" = "example.com", "to" = "www.example.com" }]` | `list(map(string))` | `[]` | no |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | n/a | yes |
+| <a name="input_container_health_probe_path"></a> [container\_health\_probe\_path](#input\_container\_health\_probe\_path) | Specifies the path that is used to determine the liveness of the Container | `string` | n/a | yes |
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | `""` | no |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin. | `bool` | `false` | no |

--- a/terraform.gpaas-azure-migration/container-apps-hosting.tf
+++ b/terraform.gpaas-azure-migration/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.13.0"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting"
 
   environment    = local.environment
   project_name   = local.project_name
@@ -13,6 +13,7 @@ module "azure_container_apps_hosting" {
   image_name                             = local.image_name
   container_command                      = local.container_command
   container_secret_environment_variables = local.container_secret_environment_variables
+  container_health_probe_path            = local.container_health_probe_path
 
   enable_mssql_database = local.enable_mssql_database
 
@@ -24,6 +25,7 @@ module "azure_container_apps_hosting" {
   cdn_frontdoor_custom_domains            = local.cdn_frontdoor_custom_domains
   cdn_frontdoor_host_redirects            = local.cdn_frontdoor_host_redirects
   cdn_frontdoor_host_add_response_headers = local.cdn_frontdoor_host_add_response_headers
+  cdn_frontdoor_health_probe_path         = local.cdn_frontdoor_health_probe_path
 
   enable_dns_zone      = local.enable_dns_zone
   dns_zone_domain_name = local.dns_zone_domain_name

--- a/terraform.gpaas-azure-migration/locals.tf
+++ b/terraform.gpaas-azure-migration/locals.tf
@@ -8,6 +8,7 @@ locals {
   image_name                              = var.image_name
   container_command                       = var.container_command
   container_secret_environment_variables  = var.container_secret_environment_variables
+  container_health_probe_path             = var.container_health_probe_path
   enable_mssql_database                   = var.enable_mssql_database
   enable_redis_cache                      = var.enable_redis_cache
   redis_cache_sku                         = var.redis_cache_sku
@@ -18,6 +19,7 @@ locals {
   cdn_frontdoor_custom_domains            = var.cdn_frontdoor_custom_domains
   cdn_frontdoor_host_redirects            = var.cdn_frontdoor_host_redirects
   cdn_frontdoor_host_add_response_headers = var.cdn_frontdoor_host_add_response_headers
+  cdn_frontdoor_health_probe_path         = var.cdn_frontdoor_health_probe_path
   key_vault_access_users                  = toset(var.key_vault_access_users)
   tfvars_filename                         = var.tfvars_filename
   enable_event_hub                        = var.enable_event_hub

--- a/terraform.gpaas-azure-migration/variables.tf
+++ b/terraform.gpaas-azure-migration/variables.tf
@@ -127,3 +127,13 @@ variable "monitor_endpoint_healthcheck" {
   description = "Specify a route that should be monitored for a 200 OK status"
   type        = string
 }
+
+variable "container_health_probe_path" {
+  description = "Specifies the path that is used to determine the liveness of the Container"
+  type        = string
+}
+
+variable "cdn_frontdoor_health_probe_path" {
+  description = "Specifies the path relative to the origin that is used to determine the health of the origin."
+  type        = string
+}


### PR DESCRIPTION
Set a health probe for the CDN to check the availability of the container, and a Liveness probe for the Container App. The path to check can be set per environment. For Dev it is currently set to `/health`