### PR TITLE
118962: prevent double click on add operations

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml
@@ -84,7 +84,7 @@
 			</div>
 
 			<div class="govuk-button-group">
-				<button data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button" data-testid="add-concern-button">
+				<button id="add-concern-button" data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button" data-testid="add-concern-button">
 					Add concern
 				</button>
 				<a data-prevent-double-click="true" class="govuk-link" asp-page-handler="Cancel" data-module="govuk-button" role="button">
@@ -100,6 +100,9 @@
 				addConcernValidator(validator);
 				addRatingValidator(validator);
 				addMeansOfReferralValidator(validator);
+
+                var submitButton = $('#add-concern-button')[0];
+                disableOnSubmitWithJsValidationCheck(validator, submitButton);
 			});
 		</script>
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml
@@ -59,7 +59,7 @@
                     <partial name="_CaseHistory"/>
 
 					<div class="govuk-button-group">
-						<button data-testid="create-case-button" data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button">
+                        <button id="create-case-button" data-testid="create-case-button" data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button">
 							Create case
 						</button>
 						<a data-prevent-double-click="true" class="govuk-link" asp-page="../home" data-module="govuk-button" role="button">
@@ -79,6 +79,9 @@
 				addDeEscalationPointValidator(validator);
 				addCaseAimValidator(validator);
 				addCaseHistoryValidator(validator);
+
+                var submitButton = $('#create-case-button')[0];
+                disableOnSubmitWithJsValidationCheck(validator, submitButton);
 
 				autoResizer();
 			});

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml
@@ -321,6 +321,9 @@
 							formatCurrency($totalAmountRequestedObj);
 						});
 
+                        var submitButton = $('#add-decision-button')[0];
+                        disableOnSubmit(submitButton);
+
 						autoResizer();
 					});
 				</script>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Outcome/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Outcome/Add.cshtml
@@ -341,6 +341,8 @@
 							formatCurrency($totalAmountRequestedObj);
 						});
 
+                        var submitButton = $('#add-decision-outcome-button')[0];
+                        disableOnSubmit(submitButton);
 
 						autoResizer();
 					});

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Add.cshtml
@@ -180,9 +180,12 @@
 
 				<script type="application/javascript" nonce="@nonce">
 					$(function () {
-						let validator = formValidator($("#add-financial-plan-form")[0]);
+                        let validator = formValidator($("#add-financial-plan-form")[0]);
 						addFinancialPlanNotesValidator(validator);
 						autoResizer();
+
+                        var submitButton = $('#add-financial-plan-button')[0];
+                        disableOnSubmitWithJsValidationCheck(validator, submitButton);
 					});
 				</script>
 			}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Add.cshtml
@@ -204,6 +204,9 @@
                             return missingValuesCount == 0 || missingValuesCount == 3; @* the date should be either empty or valid *@
                         }
 
+                        var submitButton = $('#add-nti-wl-button')[0];
+                        disableOnSubmitWithJsValidationCheck(validator, submitButton);
+
                         autoResizer();
                     });
                 </script>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Add.cshtml
@@ -101,6 +101,9 @@
             <script type="application/javascript" nonce="@nonce">
                     $(function () {
                         autoResizer();
+
+                        var submitButton = $('#add-nti-uc-button')[0];
+                        disableOnSubmit(submitButton);
                     });
             </script>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Add.cshtml
@@ -203,6 +203,9 @@
                             return missingValuesCount == 0 || missingValuesCount == 3; @* the date should be either empty or valid *@
                         }
 
+                        var submitButton = $('#add-nti-wl-button')[0];
+                        disableOnSubmitWithJsValidationCheck(validator, submitButton);
+
                         autoResizer();
                     });
                 </script>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Add.cshtml
@@ -173,6 +173,9 @@
 								&& date.day.value >= 1 && date.month.value <= 31;
 						}
 
+                        var submitButton = $('#add-srma-button')[0];
+                        disableOnSubmitWithJsValidationCheck(validator, submitButton);
+
 						autoResizer();
 					});
 				</script>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Concern/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Concern/Index.cshtml
@@ -79,7 +79,7 @@
 			</div>
 
 			<div class="govuk-button-group">
-				<button data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button" data-testid="add-concern-button">
+                <button id="add-concern-button" data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button" data-testid="add-concern-button">
 					Add concern
 				</button>
 				<a data-prevent-double-click="true" class="govuk-link" href="@Model.PreviousUrl" data-module="govuk-button" role="button">
@@ -95,6 +95,9 @@
 				addConcernValidator(validator);
 				addRatingValidator(validator);
 				addMeansOfReferralValidator(validator);
+
+                var submitButton = $('#add-concern-button')[0];
+                disableOnSubmitWithJsValidationCheck(validator, submitButton);
 			});
 		</script>
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
@@ -181,6 +181,7 @@ window.addFinancialPlanNotesValidator = function (validator) {
 		message: 'Notes must be 2000 characters or less'
 	}]);
 }
+
 window.addNTINotesValidator = function (validator) {
 	validator.addValidator('nti-notes', [{
 		method: function (field) {
@@ -188,6 +189,35 @@ window.addNTINotesValidator = function (validator) {
 		},
 		message: 'Notes must be 2000 characters or less'
 	}]);
+}
+
+window.disableOnSubmit = function (buttonToDisable) {
+	buttonToDisable.onclick = function () {
+		setTimeout(() => {
+			buttonToDisable.disabled = true;
+		}, 0);
+
+		// Renable the button a long period of time without action
+		setTimeout(() => {
+			buttonToDisable.disabled = false;
+		}, 30000);
+	}
+}
+
+window.disableOnSubmitWithJsValidationCheck = function(validator, buttonToDisable) {
+	buttonToDisable.onclick = function () {
+		setTimeout(() => {
+			var isValid = validator.validate();
+			if (isValid) {
+				buttonToDisable.disabled = true;
+			}
+		}, 0);
+
+		// Renable the button a long period of time without action
+		setTimeout(() => {
+			buttonToDisable.disabled = false;
+		}, 30000);
+	}
 }
 
 


### PR DESCRIPTION
**What is the change?**

prevents double clicking on add operations

covers:
- nti
- nti warning letter
- nti under consideration
- srma
- financial plan
- cases
- concerns
- decisions

**Why do we need the change?**

creating multiple actions, concerns or cases by mistake can cause incorrect reports

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/117823
