### PR TITLE
120178: turn off trust financial forecast case action

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/trust-financial-forecast.spec.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/trust-financial-forecast.spec.ts
@@ -8,7 +8,7 @@ const axe = require("axe-core");
 import "cypress-axe";
 
 
-describe(("User can add trust financial forecast to an existing case"), () => {
+describe.skip("User can add trust financial forecast to an existing case", () => {
 
 	const editTFFPage = new EditTrustFinancialForecastPage();
 	const viewTFFPage = new ViewTrustFinancialForecastPage();
@@ -18,11 +18,6 @@ describe(("User can add trust financial forecast to an existing case"), () => {
 		cy.login();
 		cy.basicCreateCase();
 		addTFFToCase();
-	});
-
-    after(function () {
-		cy.clearLocalStorage();
-		cy.clearCookies();
 	});
 
     it("Concern TFF - Creatiion of a TFF", function () {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Index.cshtml
@@ -160,6 +160,7 @@
                             </label>
                         </div>
 
+                        @*
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="action-10" name="action" type="radio" value="@CaseActionEnum.TrustFinancialForecast">
                             <label class="govuk-label govuk-radios__label" for="action-10">
@@ -168,6 +169,7 @@
                                 </span>
                             </label>
                         </div>
+                        *@
 
                     </div>
 


### PR DESCRIPTION
**What is the change?**

turn off trust financial forecast case action
skip the trust financial forecast tests

**Why do we need the change?**

trust financial forecast is not for MVP

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/120178
