### PR TITLE
Feature/cd 118131 audit all entity types

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/Tests/EntityStateToAuditChangeTypeMapTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/Tests/EntityStateToAuditChangeTypeMapTests.cs
@@ -1,0 +1,57 @@
+﻿using ConcernsCaseWork.Data.Auditing;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcernsCaseWork.Data.Tests.Tests
+{
+	[TestFixture]
+	public class EntityStateToAuditChangeTypeMapTests
+	{
+		[Test]
+		public void Map_When_EntityState_Added_Should_Return_INSERT()
+		{
+			var result = EntityStateToAuditChangeTypeMap.Map(EntityState.Added);
+			result.Should().Be(Models.AuditChangeType.INSERT);
+		}
+
+		[Test]
+		public void Map_When_EntityState_Modified_Should_Return_UPDATE()
+		{
+			var result = EntityStateToAuditChangeTypeMap.Map(EntityState.Modified);
+			result.Should().Be(Models.AuditChangeType.UPDATE);
+		}
+
+		[Test]
+		public void Map_When_EntityState_Deleted_Should_Return_DELETE()
+		{
+			var result = EntityStateToAuditChangeTypeMap.Map(EntityState.Deleted);
+			result.Should().Be(Models.AuditChangeType.DELETE);
+		}
+
+		[TestCase(EntityState.Detached)]
+		[TestCase(EntityState.Unchanged)]
+		public void Map_When_EntityState_Not_Supported_Should_Throw_NotSupportedException(EntityState entityState)
+		{
+			Assert.Throws<NotSupportedException>(() => EntityStateToAuditChangeTypeMap.Map(entityState));
+		}
+
+		[TestCase(EntityState.Added)]
+		[TestCase(EntityState.Modified)]
+		[TestCase(EntityState.Deleted)]
+
+		public void IsSupported_When_Supported_Entity_State_Returns_True(EntityState entityState)
+		{
+			var result = EntityStateToAuditChangeTypeMap.IsSupported(entityState);
+			result.Should().BeTrue();
+		}
+
+		[TestCase(EntityState.Detached)]
+		[TestCase(EntityState.Unchanged)]
+
+		public void IsSupported_When_Unsupported_Entity_State_Returns_False(EntityState entityState)
+		{
+			var result = EntityStateToAuditChangeTypeMap.IsSupported(entityState);
+			result.Should().BeFalse();
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Auditing/EntityStateToAuditChangeTypeMap.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Auditing/EntityStateToAuditChangeTypeMap.cs
@@ -1,0 +1,38 @@
+﻿using ConcernsCaseWork.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcernsCaseWork.Data.Auditing
+{
+	public static class EntityStateToAuditChangeTypeMap
+	{
+		public static AuditChangeType Map(EntityState entityState)
+		{
+			switch (entityState)
+			{
+				case EntityState.Added:
+					return AuditChangeType.INSERT;
+
+				case EntityState.Modified:
+					return AuditChangeType.UPDATE;
+
+				case EntityState.Deleted:
+					return AuditChangeType.DELETE;
+
+				default: throw new NotSupportedException($"Entity state not supported for auditing: State: {entityState}");
+			}
+		}
+
+		public static bool IsSupported(EntityState entityState)
+		{
+			switch (entityState)
+			{
+				case EntityState.Added:
+				case EntityState.Modified:
+				case EntityState.Deleted:
+					return true;
+				default:
+					return false;
+			}
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/AuditChangeType.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/AuditChangeType.cs
@@ -3,5 +3,6 @@ namespace ConcernsCaseWork.Data.Models;
 public enum AuditChangeType
 {
 	INSERT,
-	UPDATE
+	UPDATE,
+	DELETE,
 }


### PR DESCRIPTION
**What is the change?**
Include deletions as an audit type

**Why do we need the change?**
If deletions are introduced, we won't have a way to audit them without this change.
It will save the current version of the type, with 'DELETE' as the action

**What is the impact?**
Extra audit entries

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2037?workitem=118131