### PR TITLE
120080: change the io threads to match worker threads

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -187,9 +187,7 @@ namespace ConcernsCaseWork
 			// Setting the min higher means there will not be that delay in creating threads up to the min
 			// Re-evaluate this based on performance tests
 			// Found because redis kept timing out because it was delayed too long waiting for a thread to execute
-			int workerThreads, completionPortThreads;
-			ThreadPool.GetMinThreads(out workerThreads, out completionPortThreads);
-			ThreadPool.SetMinThreads(200, completionPortThreads);
+			ThreadPool.SetMinThreads(200, 200);
 		}
 
 		/// <summary>


### PR DESCRIPTION
**What is the change?**

both io and worker threads need to be scaled as per documentation
no explanation as to why, but I have to trust what they say

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/120080
