### PR TITLE
fix flaky nti test as there is a timing issue on javascript validation

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/nti.spec.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/integration/casework-regression/CaseActions/nti.spec.ts
@@ -37,7 +37,6 @@ describe("Testing case action NTI", () =>
 
         Logger.Log("Notes Exceeding allowed limit")
         editNtiPage
-            .clearDateFields()
             .withNotesExceedingLimit()
             .save()
             .hasValidationError("Notes must be 2000 characters or less");
@@ -188,7 +187,7 @@ describe("Testing case action NTI", () =>
             .cancel()
             .hasValidationError("Notes must be 2000 characters or less");
 
-        cy.wait(500);
+        cy.waitForJavascript();
 
         cancelNtiPage
             .withNotes("This is my final notes")
@@ -217,6 +216,7 @@ describe("Testing case action NTI", () =>
             .hasValidationError("Please enter a complete date (DD MM YYYY)");
 
         liftNtiPage.clearDateFields();
+        cy.waitForJavascript();
 
         liftNtiPage
             .withNotesExceedingLimit()
@@ -252,6 +252,7 @@ describe("Testing case action NTI", () =>
             .hasValidationError("Please enter a complete date (DD MM YYYY)");
 
         closeNtiPage.clearDateFields();
+        cy.waitForJavascript();
 
         closeNtiPage
             .withNotesExceedingLimit()


### PR DESCRIPTION
**What is the change?**

fix flaky nti test as there is a timing issue on javascript validation

eventually we will figure out how to detect if the validator has re-evaluated the input, for now we just wait until it has happened

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**
