### PR TITLE
Changes to trust search hint text and error message

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Models/FindTrustModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/FindTrustModel.cs
@@ -6,6 +6,6 @@ public class FindTrustModel
 {
 	public string Nonce { get; set; }
 
-	[Required(ErrorMessage = "A trust is required", AllowEmptyStrings = false)]
+	[Required(ErrorMessage = "Select a trust", AllowEmptyStrings = false)]
 	public string SelectedTrustUkprn { get; set; }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -19,15 +19,14 @@
 <div class="govuk-form-group">
 	<fieldset class="govuk-fieldset" data-required data-error="Search cannot be blank" aria-required="true">
 
-		<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+		<legend class="govusk-fieldset__legend govuk-fieldset__legend--l">
 			<h2 class="govuk-fieldset__heading govuk-heading-m">
 				Find Trust
 			</h2>
 		</legend>
 
 		<label class="govuk-hint" for="search" id="outgoing-trust-search-query-hint">
-			Search by name, trust reference number or companies house number
-            <br /><text>(enter at least @trustSearchOptions.Value.MinCharsRequiredToSeach characters)</text>
+			<text>Enter at least @trustSearchOptions.Value.MinCharsRequiredToSeach characters of a trust name, trust reference number (UKPRN) or companies house number.</text>
             <div id="tooManyResultsWarning" style="display:none;">
                 <p>There are too many results for this search. Try a more specific search term.</p>
             </div>


### PR DESCRIPTION
Change to hint text to show 'nter at least x characters of a trust name, trust reference number (UKPRN) or companies house number.' 
Change to error to  say 'Select a trust'