### PR TITLE
121101: increase the thread count from 200 to 400

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -185,7 +185,7 @@ namespace ConcernsCaseWork
 			// Setting the min higher means there will not be that delay in creating threads up to the min
 			// Re-evaluate this based on performance tests
 			// Found because redis kept timing out because it was delayed too long waiting for a thread to execute
-			ThreadPool.SetMinThreads(200, 200);
+			ThreadPool.SetMinThreads(400, 400);
 		}
 
 		/// <summary>


### PR DESCRIPTION
**What is the change?**

during performance testing this was a required optimisation after hitting the system with a large number of users

**Why do we need the change?**

improve the performance of the system

**What is the impact?**

low

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/121101
