### PR TITLE
spike for removing redis

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/FinancialPlans/FinancialPlanStatus.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/FinancialPlans/FinancialPlanStatus.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+
+namespace ConcernsCaseWork.API.Contracts.FinancialPlans
+{
+	public enum FinancialPlanStatus
+	{
+		[Description("Viable Plan Received")]
+		ViablePlanReceived = 3,
+		[Description("Abandoned")]
+		Abandoned = 4
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Close.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Close.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/case/{urn:long}/management/action/financialplan/{financialplanid:long}/close"
+@using ConcernsCaseWork.Helpers;
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using NetEscapades.AspNetCore.SecurityHeaders
 @model ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan.ClosePageModel
@@ -69,15 +70,14 @@
                                 @{
                                     int id = 0;
                                 }
-                                @foreach (var status in Model.FinancialPlanStatuses)
+                                @foreach (var status in Model.FinancialPlanRadios)
                                 {
                                     var idStr = id++ == 0 ? "status" : "status-" + id;
-                                    var checkedStr = status.IsChecked ? "checked" : "";
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="@idStr" data-testid="@status.Id" name="status" type="radio" value="@status.Id" @checkedStr>
+                                        <input class="govuk-radios__input" id="@idStr" data-testid="@status" name="FinancialPlanModel.Status" type="radio" value="@status">
                                         <label class="govuk-label govuk-radios__label" for="@idStr">
                                             <span>
-                                                @status.Text
+                                                @EnumHelper.GetEnumDescription(status)
                                             </span>
                                         </label>
                                     </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Close.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Close.cshtml.cs
@@ -11,6 +11,7 @@ using ConcernsCaseWork.Service.FinancialPlan;
 using ConcernsCaseWork.Mappers;
 using System.Linq;
 using ConcernsCaseWork.Models;
+using ConcernsCaseWork.API.Contracts.FinancialPlans;
 
 namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 {
@@ -21,6 +22,9 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.FinancialPlan
 		private readonly ILogger<ClosePageModel> _logger;
 		private readonly IFinancialPlanModelService _financialPlanModelService;
 		private readonly IFinancialPlanStatusCachedService _financialPlanStatusCachedService;
+		public List<FinancialPlanStatus> FinancialPlanRadios => Enum.GetValues<FinancialPlanStatus>().ToList();
+
+
 
 		public ClosePageModel(
 			IFinancialPlanModelService financialPlanModelService, IFinancialPlanStatusCachedService financialPlanStatusService, ILogger<ClosePageModel> logger)

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/SRMAService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/SRMAService.cs
@@ -12,26 +12,26 @@ namespace ConcernsCaseWork.Services.Cases
 {
 	public class SRMAService : ISRMAService
 	{
-		private readonly CachedSRMAProvider _cachedSrmaProvider;
+		private readonly Service.CaseActions.SRMAProvider _srmaProvider;
 		private readonly ICasePermissionsService _casePermissionsService;
 
 		public SRMAService(
-			CachedSRMAProvider cachedSrmaProvider,
+			Service.CaseActions.SRMAProvider srmaProvider,
 			ICasePermissionsService casePermissionsService)
 		{
-			_cachedSrmaProvider = cachedSrmaProvider;
+			_srmaProvider = srmaProvider;
 			_casePermissionsService = casePermissionsService;
 		}
 
 		public async Task<SRMAModel> GetSRMAById(long srmaId)
 		{
-			var srmaDto = await _cachedSrmaProvider.GetSRMAById(srmaId);
+			var srmaDto = await _srmaProvider.GetSRMAById(srmaId);
 			return CaseActionsMapping.Map(srmaDto);
 		}
 
 		public async Task<SRMAModel> GetSRMAViewModel(long caseId, long srmaId)
 		{
-			var srmaDto = await _cachedSrmaProvider.GetSRMAById(srmaId);
+			var srmaDto = await _srmaProvider.GetSRMAById(srmaId);
 			var permissionsResponse = await _casePermissionsService.GetCasePermissions(caseId);
 
 			return CaseActionsMapping.Map(srmaDto, permissionsResponse);
@@ -39,53 +39,53 @@ namespace ConcernsCaseWork.Services.Cases
 
 		public async Task SaveSRMA(SRMAModel srma)
 		{
-			await _cachedSrmaProvider.SaveSRMA(CaseActionsMapping.Map(srma));
+			await _srmaProvider.SaveSRMA(CaseActionsMapping.Map(srma));
 		}
 
 		public async Task<IEnumerable<SRMAModel>> GetSRMAsForCase(long caseUrn)
 		{
-			var srmas = await _cachedSrmaProvider.GetSRMAsForCase(caseUrn);
+			var srmas = await _srmaProvider.GetSRMAsForCase(caseUrn);
 			return srmas?.Select(dto => CaseActionsMapping.Map(dto));
 		}
 
 		public async Task SetDateAccepted(long srmaId, DateTime? acceptedDate)
 		{
-			await _cachedSrmaProvider.SetDateAccepted(srmaId, acceptedDate);
+			await _srmaProvider.SetDateAccepted(srmaId, acceptedDate);
 		}
 
 		public async Task SetDateClosed(long srmaId)
 		{
-			await _cachedSrmaProvider.SetDateClosed(srmaId);
+			await _srmaProvider.SetDateClosed(srmaId);
 		}
 
 		public async Task SetDateReportSent(long srmaId, DateTime? reportSentDate)
 		{
-			await _cachedSrmaProvider.SetDateReportSent(srmaId, reportSentDate);
+			await _srmaProvider.SetDateReportSent(srmaId, reportSentDate);
 		}
 
 		public async Task SetNotes(long srmaId, string notes)
 		{
-			await _cachedSrmaProvider.SetNotes(srmaId, notes);
+			await _srmaProvider.SetNotes(srmaId, notes);
 		}
 
 		public async Task SetOfferedDate(long srmaId, DateTime offeredDate)
 		{
-			await _cachedSrmaProvider.SetOfferedDate(srmaId, offeredDate);
+			await _srmaProvider.SetOfferedDate(srmaId, offeredDate);
 		}
 
 		public async Task SetReason(long srmaId, SRMAReasonOffered reason)
 		{
-			await _cachedSrmaProvider.SetReason(srmaId, (ConcernsCaseWork.Service.CaseActions.SRMAReasonOffered)reason);
+			await _srmaProvider.SetReason(srmaId, (ConcernsCaseWork.Service.CaseActions.SRMAReasonOffered)reason);
 		}
 
 		public async Task SetStatus(long srmaId, SRMAStatus status)
 		{
-			await _cachedSrmaProvider.SetStatus(srmaId, (ConcernsCaseWork.Service.CaseActions.SRMAStatus)status);
+			await _srmaProvider.SetStatus(srmaId, (ConcernsCaseWork.Service.CaseActions.SRMAStatus)status);
 		}
 
 		public async Task SetVisitDates(long srmaId, DateTime startDate, DateTime? endDate)
 		{
-			await _cachedSrmaProvider.SetVisitDates(srmaId, startDate, endDate);
+			await _srmaProvider.SetVisitDates(srmaId, startDate, endDate);
 		}
 	}
 }


### PR DESCRIPTION
**What is the change?**

srma works by just switching the provider to the non cached one financial plan status needs more work, but the idea is to use an enum and map it, see decision outcome for how to do this

financial plan may need a bit of an overhaul

most of the redis removal will be done using this strategy

For radio buttons it might make sense to create a component so we can reuse it

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**
