### PR TITLE
121405: spike for handling trusts without a UK PRN

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Models/FindTrustModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/FindTrustModel.cs
@@ -6,6 +6,7 @@ public class FindTrustModel
 {
 	public string Nonce { get; set; }
 
-	[Required(ErrorMessage = "Select a trust", AllowEmptyStrings = false)]
 	public string SelectedTrustUkprn { get; set; }
+
+	public string SelectedCompaniesHouseNumber { get; set; }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml.cs
@@ -85,13 +85,6 @@ public class SelectTrustPageModel : AbstractPageModel
 		CreateCaseStep = CreateCaseSteps.SearchForTrust;
 	}
 
-	private async Task RestoreTrustUkprnFromCache()
-	{
-		ModelState.ClearValidationState(nameof(FindTrustModel.SelectedTrustUkprn));
-		FindTrustModel.SelectedTrustUkprn = (await GetUserState()).TrustUkPrn;
-		ModelState.SetModelValue(nameof(FindTrustModel.SelectedTrustUkprn), new ValueProviderResult(FindTrustModel.SelectedTrustUkprn));
-	}
-
 	public async Task<ActionResult> OnPostSelectedTrust()
 	{
 		_logger.LogMethodEntered();

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -40,7 +40,8 @@
 <ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="trustsearch__listbox" role="listbox">
 	<li class="autocomplete__option autocomplete__option--no-results">No results found.</li>
 </ul>
-<input type="hidden" id="selectedTrustUkprn" name="selectedTrustUkprn" required />
+<input type="hidden" id="selectedTrustUkprn" name="selectedTrustUkprn" />
+<input type="hidden" id="selectedCompaniesHouseNumber" name="selectedCompaniesHouseNumber" />
 
 <script type="application/javascript" nonce="@Model.Nonce">
     $(document).ready(function () {
@@ -52,11 +53,9 @@
             hideLoader();
         })
 
-
         const autocompleteContainer = document.getElementById("autocomplete-container");
         const trustSearchDelay = @trustSearchOptions.Value.MilliSecondPauseBeforeSeach;
         let trustSearchResults = undefined;
-        let selectedTrustUkprn = undefined;
         let xhr = undefined;
         let timeout = undefined;
 
@@ -75,8 +74,7 @@
 	            xhr.abort();
 	        }
             xhr = undefined;
-            trustSearchResults = undefined;
-            selectedTrustUkprn = undefined;
+            trustSearchResults = undefined;        
         }
 
         function searchForTrusts(queryStr, populateResults) {
@@ -128,8 +126,19 @@
             minLength: @trustSearchOptions.Value.MinCharsRequiredToSeach,
             showNoOptonsFound: true,
             onConfirm: (selected) => {
-                selectedTrustUkprn = trustSearchResults === undefined ? undefined : trustSearchResults.find(trust => trust.displayName === selected).ukPrn;
-                $('#selectedTrustUkprn').val(selectedTrustUkprn);
+
+                let selectedTrustUkPrn;
+                let selectedCompaniesHouseNumber;
+
+                let matchingResult = trustSearchResults === undefined ? undefined : trustSearchResults.find(trust => trust.displayName === selected);
+
+                if (matchingResult) {
+                    selectedTrustUkPrn = matchingResult.ukPrn;
+                    selectedCompaniesHouseNumber = matchingResult.companiesHouseNumber;
+                }
+
+                $('#selectedTrustUkprn').val(selectedTrustUkPrn);
+                $('#selectedCompaniesHouseNumber').val(selectedCompaniesHouseNumber);
             }
         });
     });


### PR DESCRIPTION
**What is the change?**

spike for handling trusts that do not have a uk prn but have a companies house

**Why do we need the change?**

certain trusts do not have a UK PRN as they were created and dissolved before a UK PRN was assigned

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/121405
