### PR TITLE
hotfix cherry pick into release 17

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustSearchServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustSearchServiceTests.cs
@@ -40,21 +40,10 @@ namespace ConcernsCaseWork.Service.Tests.Trusts
 			{
 				foreach (var expectedTrust in expectedTrusts)
 				{
-					Assert.That(trust.Establishments.Count, Is.EqualTo(expectedTrust.Establishments.Count));
 					Assert.That(trust.Urn, Is.EqualTo(expectedTrust.Urn));
 					Assert.That(trust.GroupName, Is.EqualTo(expectedTrust.GroupName));
 					Assert.That(trust.UkPrn, Is.EqualTo(expectedTrust.UkPrn));
 					Assert.That(trust.CompaniesHouseNumber, Is.EqualTo(expectedTrust.CompaniesHouseNumber));
-
-					foreach (var establishment in trust.Establishments)
-					{
-						foreach (var expectedEstablishment in expectedTrust.Establishments)
-						{
-							Assert.That(establishment.Name, Is.EqualTo(expectedEstablishment.Name));
-							Assert.That(establishment.Urn, Is.EqualTo(expectedEstablishment.Urn));
-							Assert.That(establishment.UkPrn, Is.EqualTo(expectedEstablishment.UkPrn));
-						}
-					}
 				}
 			}
 		}

--- a/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustServiceTests.cs
@@ -51,21 +51,10 @@ namespace ConcernsCaseWork.Service.Tests.Trusts
 			{
 				foreach (var expectedTrust in expectedTrusts)
 				{
-					Assert.That(trust.Establishments.Count, Is.EqualTo(expectedTrust.Establishments.Count));
 					Assert.That(trust.Urn, Is.EqualTo(expectedTrust.Urn));
 					Assert.That(trust.GroupName, Is.EqualTo(expectedTrust.GroupName));
 					Assert.That(trust.UkPrn, Is.EqualTo(expectedTrust.UkPrn));
 					Assert.That(trust.CompaniesHouseNumber, Is.EqualTo(expectedTrust.CompaniesHouseNumber));
-
-					foreach (var establishment in trust.Establishments)
-					{
-						foreach (var expectedEstablishment in expectedTrust.Establishments)
-						{
-							Assert.That(establishment.Name, Is.EqualTo(expectedEstablishment.Name));
-							Assert.That(establishment.Urn, Is.EqualTo(expectedEstablishment.Urn));
-							Assert.That(establishment.UkPrn, Is.EqualTo(expectedEstablishment.UkPrn));
-						}
-					}
 				}
 			}
 		}
@@ -98,11 +87,11 @@ namespace ConcernsCaseWork.Service.Tests.Trusts
 			Assert.ThrowsAsync<HttpRequestException>(() => trustService.GetTrustsByPagination(TrustFactory.BuildTrustSearch(), 100));
 		}
 
-		[TestCase("", "", "", "page%3d1%26count%3d45")]
-		[TestCase("group-name", "", "", "groupName%3dgroup-name%26page%3d1%26count%3d45")]
-		[TestCase("", "ukprn", "", "ukprn%3dukprn%26page%3d1%26count%3d45")]
-		[TestCase("", "", "companies-house-number", "companiesHouseNumber%3dcompanies-house-number%26page%3d1%26count%3d45")]
-		[TestCase("group-name", "ukprn", "", "groupName%3dgroup-name%26ukprn%3dukprn%26page%3d1%26count%3d45")]
+		[TestCase("", "", "", "page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("group-name", "", "", "groupName%3dgroup-name%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "ukprn", "", "ukprn%3dukprn%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "", "companies-house-number", "companiesHouseNumber%3dcompanies-house-number%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("group-name", "ukprn", "", "groupName%3dgroup-name%26ukprn%3dukprn%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
 		public void WhenBuildRequestUri_ReturnsRequestUrl(string groupName, string ukprn, string companiesHouseNumber, string expectedRequestUri)
 		{
 			// arrange

--- a/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustServiceTests.cs
@@ -89,9 +89,11 @@ namespace ConcernsCaseWork.Service.Tests.Trusts
 
 		[TestCase("", "", "", "page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
 		[TestCase("group-name", "", "", "groupName%3dgroup-name%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("", "ukprn", "", "ukprn%3dukprn%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "ukprn", "", "page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "1234", "", "ukprn%3d1234%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
 		[TestCase("", "", "companies-house-number", "companiesHouseNumber%3dcompanies-house-number%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("group-name", "ukprn", "", "groupName%3dgroup-name%26ukprn%3dukprn%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("group-name", "ukprn", "", "groupName%3dgroup-name%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("group-name", "1234", "", "groupName%3dgroup-name%26ukprn%3d1234%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
 		public void WhenBuildRequestUri_ReturnsRequestUrl(string groupName, string ukprn, string companiesHouseNumber, string expectedRequestUri)
 		{
 			// arrange

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustSearchDto.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustSearchDto.cs
@@ -21,15 +21,11 @@ namespace ConcernsCaseWork.Service.Trusts
 		
 		[JsonProperty("trustAddress")]
 		public GroupContactAddressDto GroupContactAddress { get; }
-		
-		[JsonProperty("establishments")]
-		public List<EstablishmentSummaryDto> Establishments { get; }
 
 		[JsonConstructor]
 		public TrustSearchDto(string ukprn, string urn, string groupName, 
-			string companiesHouseNumber, string trustType, GroupContactAddressDto groupContactAddress,
-			List<EstablishmentSummaryDto> establishments) => 
-			(UkPrn, Urn, GroupName, CompaniesHouseNumber, TrustType, GroupContactAddress, Establishments) = 
-			(ukprn, urn, groupName, companiesHouseNumber, trustType, groupContactAddress, establishments);
+			string companiesHouseNumber, string trustType, GroupContactAddressDto groupContactAddress) => 
+			(UkPrn, Urn, GroupName, CompaniesHouseNumber, TrustType, GroupContactAddress) = 
+			(ukprn, urn, groupName, companiesHouseNumber, trustType, groupContactAddress);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
@@ -34,6 +34,7 @@ namespace ConcernsCaseWork.Service.Trusts
 			}
 			queryParams.Add("page", trustSearch.Page.ToString());
 			queryParams.Add("count", maxRecordsPerPage.ToString());
+			queryParams.Add("includeEstablishments", false.ToString());
 
 			return HttpUtility.UrlEncode(queryParams.ToString());
 		}

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
@@ -24,7 +24,7 @@ namespace ConcernsCaseWork.Service.Trusts
 			{
 				queryParams.Add("groupName", trustSearch.GroupName);
 			}
-			if (!string.IsNullOrEmpty(trustSearch.Ukprn))
+			if (IsNumeric(trustSearch.Ukprn))
 			{
 				queryParams.Add("ukprn", trustSearch.Ukprn);
 			}
@@ -100,6 +100,11 @@ namespace ConcernsCaseWork.Service.Trusts
 
 				throw;
 			}
+		}
+
+		private bool IsNumeric(string input)
+		{
+			return int.TryParse(input, out _ );
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/TrustFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Shared.Tests/Factory/TrustFactory.cs
@@ -8,23 +8,22 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 	public static class TrustFactory
 	{
 		private readonly static Fixture Fixture = new Fixture();
-		
+
 		public static IList<TrustSearchDto> BuildListTrustSummaryDto()
 		{
 			Fixture fixture = new Fixture();
 			return new List<TrustSearchDto>
 			{
 				new TrustSearchDto(
-					fixture.Create<string>(), 
-					fixture.Create<string>(), 
-					fixture.Create<string>(), 
 					fixture.Create<string>(),
 					fixture.Create<string>(),
-					GroupContactAddressFactory.BuildGroupContactAddressDto(),
-					EstablishmentFactory.BuildListEstablishmentSummaryDto())
+					fixture.Create<string>(),
+					fixture.Create<string>(),
+					fixture.Create<string>(),
+					GroupContactAddressFactory.BuildGroupContactAddressDto())
 			};
 		}
-		
+
 		public static TrustSearch BuildTrustSearch(string groupName = "", string ukprn = "", string companiesHouseNumber = "")
 		{
 			return new TrustSearch(groupName, ukprn, companiesHouseNumber);
@@ -36,13 +35,12 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 			return new List<TrustSearchModel>
 			{
 				new TrustSearchModel(
-					fixture.Create<string>(), 
-					fixture.Create<string>(), 
-					fixture.Create<string>(), 
 					fixture.Create<string>(),
 					fixture.Create<string>(),
-					GroupContactAddressFactory.BuildGroupContactAddressModel(),
-					EstablishmentFactory.BuildListEstablishmentSummaryModel())
+					fixture.Create<string>(),
+					fixture.Create<string>(),
+					fixture.Create<string>(),
+					GroupContactAddressFactory.BuildGroupContactAddressModel())
 			};
 		}
 
@@ -53,14 +51,14 @@ namespace ConcernsCaseWork.Shared.Tests.Factory
 				IfdDataFactory.BuildIfdDataDto(),
 				EstablishmentFactory.BuildListEstablishmentDto());
 		}
-		
+
 		public static TrustDetailsModel BuildTrustDetailsModel()
 		{
 			return new TrustDetailsModel(GiasDataFactory.BuildGiasDataModel(),
 				IfdDataFactory.BuildIfdDataModel(),
 				EstablishmentFactory.BuildListEstablishmentModel());
 		}
-		
+
 		public static TrustAddressModel BuildTrustAddressModel()
 		{
 			return Fixture.Create<TrustAddressModel>();

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/AutoMapperTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/AutoMapperTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using ConcernsCaseWork.Extensions;
 using ConcernsCaseWork.Mappers;
 using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Shared.Tests.Factory;
@@ -20,10 +21,10 @@ namespace ConcernsCaseWork.Tests.Mappers
 			var mapper = config.CreateMapper();
 
 			var trustsDto = TrustFactory.BuildListTrustSummaryDto();
-			
+
 			// act
 			var trustsModel = mapper.Map<IList<TrustSearchModel>>(trustsDto);
-			
+
 			// assert
 			Assert.IsAssignableFrom<List<TrustSearchModel>>(trustsModel);
 			Assert.That(trustsModel.Count, Is.EqualTo(trustsDto.Count));
@@ -31,25 +32,14 @@ namespace ConcernsCaseWork.Tests.Mappers
 			{
 				foreach (var actual in trustsDto.Where(actual => expected.UkPrn.Equals(actual.UkPrn)))
 				{
-					Assert.That(expected.Establishments.Count, Is.EqualTo(actual.Establishments.Count));
 					Assert.That(expected.Urn, Is.EqualTo(actual.Urn));
 					Assert.That(expected.UkPrn, Is.EqualTo(actual.UkPrn));
 					Assert.That(expected.GroupName, Is.EqualTo(actual.GroupName));
 					Assert.That(expected.CompaniesHouseNumber, Is.EqualTo(actual.CompaniesHouseNumber));
-					
-					foreach (var establishment in actual.Establishments)
-					{
-						foreach (var expectedEstablishment in expected.Establishments)
-						{
-							Assert.That(establishment.Name, Is.EqualTo(expectedEstablishment.Name));
-							Assert.That(establishment.Urn, Is.EqualTo(expectedEstablishment.Urn));
-							Assert.That(establishment.UkPrn, Is.EqualTo(expectedEstablishment.UkPrn));
-						}
-					}
 				}
 			}
 		}
-		
+
 		[Test]
 		public void ConvertFrom_TrustDetailsDto_To_TrustsDetailsModel_IsValid()
 		{
@@ -58,10 +48,10 @@ namespace ConcernsCaseWork.Tests.Mappers
 			var mapper = config.CreateMapper();
 
 			var trustDetailsDto = TrustFactory.BuildTrustDetailsDto();
-			
+
 			// act
 			var trustDetailsModel = mapper.Map<TrustDetailsModel>(trustDetailsDto);
-			
+
 			// assert
 			Assert.IsAssignableFrom<TrustDetailsModel>(trustDetailsModel);
 			Assert.That(trustDetailsModel.GiasData, Is.Not.Null);
@@ -77,7 +67,7 @@ namespace ConcernsCaseWork.Tests.Mappers
 			Assert.That(trustDetailsModel.GiasData.GroupContactAddress.Town, Is.EqualTo(trustDetailsDto.GiasData.GroupContactAddress.Town));
 			Assert.That(trustDetailsModel.GiasData.GroupContactAddress.AdditionalLine, Is.EqualTo(trustDetailsDto.GiasData.GroupContactAddress.AdditionalLine));
 		}
-		
+
 		[Test]
 		public void ConvertFrom_EstablishmentSummaryDto_To_EstablishmentSummaryModel_IsValid()
 		{
@@ -86,17 +76,17 @@ namespace ConcernsCaseWork.Tests.Mappers
 			var mapper = config.CreateMapper();
 
 			var establishmentSummaryDto = EstablishmentFactory.BuildEstablishmentSummaryDto();
-			
+
 			// act
 			var establishmentSummaryModel = mapper.Map<EstablishmentSummaryModel>(establishmentSummaryDto);
-			
+
 			// assert
 			Assert.IsAssignableFrom<EstablishmentSummaryModel>(establishmentSummaryModel);
 			Assert.That(establishmentSummaryModel.Name, Is.EqualTo(establishmentSummaryDto.Name));
 			Assert.That(establishmentSummaryModel.Urn, Is.EqualTo(establishmentSummaryDto.Urn));
 			Assert.That(establishmentSummaryModel.UkPrn, Is.EqualTo(establishmentSummaryDto.UkPrn));
 		}
-		
+
 		[Test]
 		public void ConvertFrom_GiasDataDto_To_GiasDataModel_IsValid()
 		{
@@ -105,10 +95,10 @@ namespace ConcernsCaseWork.Tests.Mappers
 			var mapper = config.CreateMapper();
 
 			var giasDataDto = GiasDataFactory.BuildGiasDataDto();
-			
+
 			// act
 			var giasDataModel = mapper.Map<GiasDataModel>(giasDataDto);
-			
+
 			// assert
 			Assert.IsAssignableFrom<GiasDataModel>(giasDataModel);
 			Assert.That(giasDataModel, Is.Not.Null);
@@ -125,7 +115,7 @@ namespace ConcernsCaseWork.Tests.Mappers
 			Assert.That(giasDataModel.GroupContactAddress.AdditionalLine, Is.EqualTo(giasDataDto.GroupContactAddress.AdditionalLine));
 			Assert.That(giasDataModel.CompaniesHouseWebsite, Is.EqualTo($"https://find-and-update.company-information.service.gov.uk/company/{giasDataDto.CompaniesHouseNumber}"));
 		}
-		
+
 		[Test]
 		public void ConvertFrom_EstablishmentDto_To_EstablishmentModel_IsValid()
 		{
@@ -134,10 +124,10 @@ namespace ConcernsCaseWork.Tests.Mappers
 			var mapper = config.CreateMapper();
 
 			var establishmentDto = EstablishmentFactory.BuildEstablishmentDto();
-			
+
 			// act
 			var establishmentModel = mapper.Map<EstablishmentModel>(establishmentDto);
-			
+
 			// assert
 			Assert.IsAssignableFrom<EstablishmentModel>(establishmentModel);
 			Assert.That(establishmentModel.Urn, Is.EqualTo(establishmentDto.Urn));
@@ -157,8 +147,9 @@ namespace ConcernsCaseWork.Tests.Mappers
 		public void Assert_MappingConfiguration_Is_Valid()
 		{
 			// Auto mapper includes functionality to check that config is valid for you.
-			var config = new MapperConfiguration(cfg => cfg.AddProfile<AutoMapping>());			
-			config.AssertConfigurationIsValid();
+			var config = new MapperConfiguration(cfg => cfg.AddProfile<AutoMapping>());
+			var mapper = new Mapper(config);
+			mapper.CompileAndValidate();
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Trust/IndexPageModelTests.cs
@@ -93,22 +93,11 @@ namespace ConcernsCaseWork.Tests.Pages.Trust
 			{
 				foreach (var actual in trustSummaryModel.Where(actual => expected.UkPrn.Equals(actual.UkPrn)))
 				{
-					Assert.That(expected.Establishments.Count, Is.EqualTo(actual.Establishments.Count));
 					Assert.That(expected.Urn, Is.EqualTo(actual.Urn));
 					Assert.That(expected.UkPrn, Is.EqualTo(actual.UkPrn));
 					Assert.That(expected.GroupName, Is.EqualTo(actual.GroupName));
 					Assert.That(expected.CompaniesHouseNumber, Is.EqualTo(actual.CompaniesHouseNumber));
 					Assert.That(expected.DisplayName, Is.EqualTo(SharedBuilder.BuildDisplayName(actual)));
-
-					foreach (var establishment in actual.Establishments)
-					{
-						foreach (var expectedEstablishment in expected.Establishments)
-						{
-							Assert.That(establishment.Name, Is.EqualTo(expectedEstablishment.Name));
-							Assert.That(establishment.Urn, Is.EqualTo(expectedEstablishment.Urn));
-							Assert.That(establishment.UkPrn, Is.EqualTo(expectedEstablishment.UkPrn));
-						}
-					}
 				}
 			}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Trusts/TrustModelServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Services/Trusts/TrustModelServiceTests.cs
@@ -48,7 +48,6 @@ namespace ConcernsCaseWork.Tests.Services.Trusts
 			{
 				foreach (var actual in trustSummaryDto.Where(actual => expected.UkPrn.Equals(actual.UkPrn)))
 				{
-					Assert.That(expected.Establishments.Count, Is.EqualTo(actual.Establishments.Count));
 					Assert.That(expected.Urn, Is.EqualTo(actual.Urn));
 					Assert.That(expected.UkPrn, Is.EqualTo(actual.UkPrn));
 					Assert.That(expected.GroupName, Is.EqualTo(actual.GroupName));
@@ -65,16 +64,6 @@ namespace ConcernsCaseWork.Tests.Services.Trusts
 					Assert.That(expected.GroupContactAddress.Town, Is.EqualTo(actual.GroupContactAddress.Town));
 					Assert.That(expected.GroupContactAddress.AdditionalLine, Is.EqualTo(actual.GroupContactAddress.AdditionalLine));
 					Assert.That(expected.GroupContactAddress.DisplayAddress, Is.EqualTo(SharedBuilder.BuildDisplayAddress(actual.GroupContactAddress)));
-
-					foreach (var establishment in actual.Establishments)
-					{
-						foreach (var expectedEstablishment in expected.Establishments)
-						{
-							Assert.That(establishment.Name, Is.EqualTo(expectedEstablishment.Name));
-							Assert.That(establishment.Urn, Is.EqualTo(expectedEstablishment.Urn));
-							Assert.That(establishment.UkPrn, Is.EqualTo(expectedEstablishment.UkPrn));
-						}
-					}
 				}
 			}
 		}

--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/AddAutomapperStartupExtension.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/AddAutomapperStartupExtension.cs
@@ -1,0 +1,24 @@
+﻿using AutoMapper;
+using ConcernsCaseWork.Mappers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ConcernsCaseWork.Extensions
+{
+	/// <summary>
+	/// Abstracts the steps necessarity to configure automapper in the way we want, which is that the mappings have been validated as being correct early rather than lazily fail. Should be caught by unit tests anyway.
+	/// </summary>
+	public static class AddAutomapperStartupExtension
+	{
+		public static void ConfigureAndAddAutoMapper(this IServiceCollection services)
+		{
+			services.AddAutoMapper(typeof(Startup));
+		}
+
+		public static void CompileAndValidate(this IMapper mapper)
+		{
+			mapper.ConfigurationProvider.CompileMappings();
+			mapper.ConfigurationProvider.AssertConfigurationIsValid();
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/TrustSearchModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/TrustSearchModel.cs
@@ -10,21 +10,19 @@ namespace ConcernsCaseWork.Models
 	public sealed class TrustSearchModel
 	{
 		private readonly string _isNullOrEmpty = "-".PadRight(2);
-		
+
 		public string UkPrn { get; }
-		
+
 		public string Urn { get; }
-		
+
 		public string GroupName { get; }
-		
+
 		public string CompaniesHouseNumber { get; }
-		
+
 		public string TrustType { get; }
-		
+
 		public GroupContactAddressModel GroupContactAddress { get; }
-		
-		public List<EstablishmentSummaryModel> Establishments { get; }
-		
+
 		public string DisplayName
 		{
 			get
@@ -37,15 +35,14 @@ namespace ConcernsCaseWork.Models
 				sb.Append(string.IsNullOrEmpty(CompaniesHouseNumber) ? _isNullOrEmpty : CompaniesHouseNumber);
 				sb.Append(" ");
 				sb.Append(string.IsNullOrEmpty(GroupContactAddress?.Town) ? _isNullOrEmpty : $"({GroupContactAddress.Town})");
-				
+
 				return sb.ToString();
 			}
 		}
 
-		public TrustSearchModel(string ukprn, string urn, string groupName, 
-			string companiesHouseNumber, string trustType, GroupContactAddressModel groupContactAddress, 
-			List<EstablishmentSummaryModel> establishments) 
-			=> (UkPrn, Urn, GroupName, CompaniesHouseNumber, TrustType, GroupContactAddress, Establishments) = 
-				(ukprn, urn, groupName, companiesHouseNumber, trustType, groupContactAddress, establishments);
+		public TrustSearchModel(string ukprn, string urn, string groupName,
+			string companiesHouseNumber, string trustType, GroupContactAddressModel groupContactAddress)
+			=> (UkPrn, Urn, GroupName, CompaniesHouseNumber, TrustType, GroupContactAddress) =
+				(ukprn, urn, groupName, companiesHouseNumber, trustType, groupContactAddress);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -1,3 +1,4 @@
+using AutoMapper;
 using ConcernsCaseWork.API.Extensions;
 using ConcernsCaseWork.API.Middleware;
 using ConcernsCaseWork.Constraints;
@@ -20,6 +21,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
 using System;
+using System.Reflection;
 using System.Security.Claims;
 using System.Threading;
 
@@ -82,7 +84,8 @@ namespace ConcernsCaseWork
 			services.AddConcernsApi(Configuration);
 
 			// AutoMapper
-			services.AddAutoMapper(typeof(Startup));
+			services.ConfigureAndAddAutoMapper();
+
 
 			// Route options
 			services.Configure<RouteOptions>(options => { options.LowercaseUrls = true; });
@@ -117,7 +120,7 @@ namespace ConcernsCaseWork
         }
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-		public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IApiVersionDescriptionProvider provider)
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IApiVersionDescriptionProvider provider, IMapper mapper)
 		{
 			AbstractPageModel.PageHistoryStorageHandler = app.ApplicationServices.GetService<IPageHistoryStorageHandler>();
 
@@ -163,7 +166,7 @@ namespace ConcernsCaseWork
 
 			app.UseRouting();
 
-			
+
 
 			app.UseAuthentication();
 			app.UseAuthorization();
@@ -178,6 +181,8 @@ namespace ConcernsCaseWork
 			{
 				endpoints.MapRazorPages();
 			});
+
+			mapper.CompileAndValidate();
 
 			// If our application gets hit really hard, then threads need to be spawned
 			// By default the number of threads that exist in the threadpool is the amount of CPUs (1)


### PR DESCRIPTION
What is the change?
Change to optimise the trust search used in the trams-api. This change will stop the trams api from returning establishments which aren't needed by the concerns website.
It will also exclude searching by trust ukprn when the search term is not numeric.

Why do we need the change?
Latency in trams-api trust search

What is the impact?
Faster trams-api trust search

Azure DevOps Ticket
(Story which will eventually be used to hotfix bug 121751)
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2038?workitem=121752
