### PR TITLE
121651: notes fields on actions not displaying correctly

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Closed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Closed.cshtml
@@ -132,7 +132,7 @@
                         @{
                             if (!string.IsNullOrEmpty(Model.FinancialPlanModel.Notes))
                             {
-                                <span>@Model.FinancialPlanModel.Notes</span>
+                                <span class="dfe-text-area-display">@Model.FinancialPlanModel.Notes</span>
                             }
                             else
                             {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/FinancialPlan/Index.cshtml
@@ -106,7 +106,7 @@
                         @{
                             if (!string.IsNullOrEmpty(Model.FinancialPlanModel.Notes))
                             {
-                                <span>@Model.FinancialPlanModel.Notes</span>
+                                <span class="dfe-text-area-display">@Model.FinancialPlanModel.Notes</span>
                             }
                             else
                             {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Index.cshtml
@@ -237,7 +237,7 @@
 
                             if (!string.IsNullOrEmpty(Model.NtiModel.Notes))
                             {
-                                <span>@Model.NtiModel.Notes</span>
+                                <span class="dfe-text-area-display">@Model.NtiModel.Notes</span>
                             }
                             else
                             {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiUnderConsideration/Index.cshtml
@@ -116,7 +116,7 @@
 
                             if (!string.IsNullOrEmpty(Model.NTIUnderConsiderationModel.Notes))
                             {
-                                <span>@Model.NTIUnderConsiderationModel.Notes</span>
+                                <span class="dfe-text-area-display">@Model.NTIUnderConsiderationModel.Notes</span>
                             }
                             else
                             {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/NtiWarningLetter/Index.cshtml
@@ -161,7 +161,7 @@
 
                             if (!string.IsNullOrEmpty(Model.NtiWarningLetterModel.Notes))
                             {
-                                <span>@Model.NtiWarningLetterModel.Notes</span>
+                                <span class="dfe-text-area-display">@Model.NtiWarningLetterModel.Notes</span>
                             }
                             else
                             {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Closed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Closed.cshtml
@@ -127,7 +127,7 @@
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table-case-details__header">Notes (optional)</th>
                     <td class="govuk-table__cell" data-testid="notes">
-                        @Model.SRMAModel.Notes
+                        <span class="dfe-text-area-display">@Model.SRMAModel.Notes</span>
                     </td>
                 </tr>
             </tbody>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Index.cshtml
@@ -214,7 +214,7 @@
                     <th scope="row" class="govuk-table-case-details__header">Notes (optional)</th>
                     <td class="govuk-table__cell" data-testid="notes">
                         @{
-                            RenderValue(Model.SRMAModel.Notes);
+                            RenderTextAreaValue(Model.SRMAModel.Notes);
                         }
                     </td>
                     <td class="govuk-table__cell govuk-table__header__right">
@@ -249,6 +249,18 @@
         else
         {
             @value
+        }
+    }
+
+    private void RenderTextAreaValue<T>(T value)
+    {
+        if (IsEmpty(value))
+        {
+            RenderEmptyLabel();
+        }
+        else
+        {
+            <span class="dfe-text-area-display">@value</span>
         }
     }
 


### PR DESCRIPTION
**What is the change?**

added the style dfe-text-area-display to all notes fields for actions

**Why do we need the change?**

styling to improve the look when viewing notes

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/121651
