### PR TITLE
Feature/cd script prepare release

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -32,7 +32,8 @@ read environment
 clear
 
 echo
-echo "--------------- SCRIPT OUTPUT ---------------"
+echo "-------------------------------- SCRIPT OUTPUT -------------------------------"
+echo "--------------- Check this script is correct BEFORE you run it ---------------"
 echo
 echo
 

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -2,9 +2,16 @@ clear
 echo "Concerns Casework GitHub Release Utility"
 echo "********************************************"
 echo
+echo "Before you begin, note down the following..."
+echo "...The commit sha that should be tagged"
+echo "...The release number you are going to use"
+echo "...The branch you are tagging"
+echo
+echo "When choosing a release number use the format 'Major.Minor.Revision'" 
+echo "If deploying to staging use a '-beta-xxx' suffix (and find out what the next beta number is first)"
+
+echo
 echo "Enter the release number being tagged."
-echo "* Use the format 'Major.Minor.Revision'" 
-echo "* If deploying to staging use a '-beta-xxx' suffix"
 read release_num
 clear
 
@@ -39,22 +46,22 @@ echo
 
 if [ $branch_name != "main" ]
 then
-    echo "git checkout main \\"
-    echo "git pull \\"
+    echo "git checkout main \"
+    echo "git pull \"
 fi
 
-echo "git checkout $branch_name \\"
-echo "git pull \\"
+echo "git checkout $branch_name \"
+echo "git pull \"
 
 # tag the sha with the release number + environment
 if [ $environment == "s" ]
 then
-    echo "git tag -a -m \"release $release_num\" $release_num $commit_sha \\"
+    echo "git tag -a -m \"release $release_num\" $release_num $commit_sha \"
 fi
 
 if [ $environment == "p" ]
 then
-    echo "git tag -a -m \"release $release_num\" $release_num $commit_sha \\"
+    echo "git tag -a -m \"release $release_num\" $release_num $commit_sha \"
 fi
 # push tags to server
 echo "git push --tags"
@@ -65,10 +72,12 @@ echo
 
 if [ $environment == "s" ]
 then
-    echo "Update '.github\workflows\build-and-push-image-test.yml' and set it to deploy tag '$release_num'"
+    echo "ON THE MAIN BRANCH: Update '.github\workflows\build-and-push-image-test.yml' and set it to deploy tag '$release_num'"
+    echo "https://github.com/DFE-Digital/amsd-casework/blob/main/.github/workflows/build-and-push-image-test.yml"
 fi
 
 if [ $environment == "p" ]
 then
-    echo "Update '.github\workflows\build-and-push-image-production.yml' and set it to deploy tag '$release_num'"
+    echo "ON THE MAIN BRANCH: Update '.github\workflows\build-and-push-image-production.yml' and set it to deploy tag '$release_num'"
+    echo "https://github.com/DFE-Digital/amsd-casework/blob/main/.github/workflows/build-and-push-image-production.yml"
 fi

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -1,0 +1,73 @@
+clear
+echo "Concerns Casework GitHub Release Utility"
+echo "********************************************"
+echo
+echo "Enter the release number being tagged."
+echo "* Use the format 'Major.Minor.Revision'" 
+echo "* If deploying to staging use a '-beta-xxx' suffix"
+read release_num
+clear
+
+echo
+echo "Enter the commit SHA being tagged"
+read commit_sha
+clear
+
+echo "Is this release being tagged on the 'main' branch (y/n)?"
+read is_main
+
+if [ $is_main == "y" ]
+then
+    $branch_name = "main"
+else 
+    echo
+    echo "Enter the GitHub branch being tagged"
+    read branch_name
+fi
+clear
+
+echo
+echo "Is this release for [s]taging or [p]roduction ?"
+read environment
+clear
+
+echo
+echo "--------------- SCRIPT OUTPUT ---------------"
+echo
+echo
+
+if [ $branch_name != "main" ]
+then
+    echo "git checkout main \\"
+    echo "git pull \\"
+fi
+
+echo "git checkout $branch_name \\"
+echo "git pull \\"
+
+# tag the sha with the release number + environment
+if [ $environment == "s" ]
+then
+    echo "git tag -a -m \"release $release_num\" $release_num $commit_sha \\"
+fi
+
+if [ $environment == "p" ]
+then
+    echo "git tag -a -m \"release $release_num\" $release_num $commit_sha \\"
+fi
+# push tags to server
+echo "git push --tags"
+
+echo
+echo "--------------- After running this script sucessfully ---------------"
+echo
+
+if [ $environment == "s" ]
+then
+    echo "Update '.github\workflows\build-and-push-image-test.yml' and set it to deploy tag '$release_num'"
+fi
+
+if [ $environment == "p" ]
+then
+    echo "Update '.github\workflows\build-and-push-image-production.yml' and set it to deploy tag '$release_num'"
+fi


### PR DESCRIPTION
**What is the change?**
Added a script to generate the steps needed to tag a branch point-in-time which can be released from

**Why do we need the change?**
Release steps are quite lengthy when using the Github UI. 
This script may help (onus is on the user to enter the correct information).
It makes no changes, but generates a set of cli steps that will tag a position in the source code.

**What is the impact?**
none

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2038?workitem=122308