### PR TITLE
121740: count spaces in javascript validation

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
@@ -41,7 +41,7 @@ window.addIssueValidator = function(validator) {
 	},
 	{
 		method: function(field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 2000;
+			return getFieldLengthWithNewLines(field.value) <= 2000;
 		},
 		message: 'Issue must be 2000 characters or less'
 	}]);
@@ -94,7 +94,7 @@ window.addConcernValidator = function(validator) {
 window.addCurrentStatusValidator = function(validator) {
 	validator.addValidator('current-status', [{
 		method: function(field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 4000;
+			return getFieldLengthWithNewLines(field.value) <= 4000;
 		},
 		message: 'Current status must be 4000 characters or less'
 	}]);
@@ -102,7 +102,7 @@ window.addCurrentStatusValidator = function(validator) {
 window.addNextStepsValidator = function(validator) {
 	validator.addValidator('next-steps', [{
 		method: function(field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 4000;
+			return getFieldLengthWithNewLines(field.value) <= 4000;
 		},
 		message: 'Next steps must be 4000 characters or less'
 	}]);
@@ -110,7 +110,7 @@ window.addNextStepsValidator = function(validator) {
 window.addDeEscalationPointValidator = function(validator) {
 	validator.addValidator('de-escalation-point', [{
 		method: function(field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 1000;
+			return getFieldLengthWithNewLines(field.value) <= 1000;
 		},
 		message: 'De-escalation point must be 1000 characters or less'
 	}]);
@@ -118,7 +118,7 @@ window.addDeEscalationPointValidator = function(validator) {
 window.addCaseAimValidator = function(validator) {
 	validator.addValidator('case-aim', [{
 		method: function(field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 1000;
+			return getFieldLengthWithNewLines(field.value) <= 1000;
 		},
 		message: 'Case aim must be 1000 characters or less'
 	}]);
@@ -126,7 +126,7 @@ window.addCaseAimValidator = function(validator) {
 window.addCaseHistoryValidator = function (validator) {
 	validator.addValidator('case-history', [{
 		method: function (field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 4300;
+			return getFieldLengthWithNewLines(field.value) <= 4300;
 		},
 		message: 'Case history must be 4300 characters or less'
 	}]);
@@ -168,7 +168,7 @@ window.addUsersValidator = function(validator) {
 window.addSRMANotesValidator = function (validator) {
 	validator.addValidator('srma-notes', [{
 		method: function (field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 2000;
+			return getFieldLengthWithNewLines(field.value) <= 2000;
 		},
 		message: 'Notes must be 2000 characters or less'
 	}]);
@@ -176,7 +176,7 @@ window.addSRMANotesValidator = function (validator) {
 window.addFinancialPlanNotesValidator = function (validator) {
 	validator.addValidator('financial-plan-notes', [{
 		method: function (field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 2000;
+			return getFieldLengthWithNewLines(field.value) <= 2000;
 		},
 		message: 'Notes must be 2000 characters or less'
 	}]);
@@ -185,7 +185,7 @@ window.addFinancialPlanNotesValidator = function (validator) {
 window.addNTINotesValidator = function (validator) {
 	validator.addValidator('nti-notes', [{
 		method: function (field) {
-			return getFieldLengthWithNewLines(field.value.trim()) <= 2000;
+			return getFieldLengthWithNewLines(field.value) <= 2000;
 		},
 		message: 'Notes must be 2000 characters or less'
 	}]);
@@ -252,8 +252,6 @@ window.getFieldLengthWithNewLines = function(field) {
 	// This code switches javascript to count like C# (\r and \n)
 
 	let numberOfNewLines = (field.match(/\n/g) || []).length;
-
-	console.log("Detected new lines " + numberOfNewLines);
 
 	// Add the \r for each \n
 	return field.length + numberOfNewLines;


### PR DESCRIPTION
**What is the change?**

javascript validation was stripping spaces, we have included them as they are characters that will be counted

**Why do we need the change?**

a user could put leading spaces in which would bypass the js validation only to fail the server validation

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/121740
