### PR TITLE
added environment banner, displayed when not production env

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_EnvironmentBanner.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_EnvironmentBanner.cshtml
@@ -1,0 +1,24 @@
+﻿@using Microsoft.AspNetCore.Hosting
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.Extensions.Hosting
+
+@inject IWebHostEnvironment _env
+
+@if (!_env.IsProduction())
+{
+    <div id="environment-banner" aria-label="environment banner" role="complementary">
+        @if (_env.IsDevelopment())
+        {
+            <strong class="govuk-tag govuk-tag--turquoise environment-banner environment-name">Development environment</strong>
+
+        }
+        else if (_env.IsStaging())
+        {
+            <strong class="govuk-tag govuk-tag--orange environment-banner environment-name">Test environment</strong>
+        }
+        else
+        {
+            <strong class="govuk-tag govuk-tag--red environment-banner environment-name">@_env.EnvironmentName environment</strong>
+        }
+    </div>
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Layout.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Layout.cshtml
@@ -17,11 +17,14 @@
     {
         <!-- Google Tag Manager -->
         <script nonce="@nonce">
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});let f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-NGC8DRV');
+            (function (w, d, s, l, i) {
+                w[l] = w[l] || []; w[l].push({
+                    'gtm.start':
+                        new Date().getTime(), event: 'gtm.js'
+                }); let f = d.getElementsByTagName(s)[0],
+                    j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+            })(window, document, 'script', 'dataLayer', 'GTM-NGC8DRV');
         </script>
         <!-- End Google Tag Manager -->
     }
@@ -42,8 +45,8 @@
     <link rel="stylesheet" href="~/dist/css/site.css" />
 
     <title>@ViewData["Title"] - Record concerns and support for trusts - GOV.UK</title>
-	@Html.Raw(JavaScriptSnippet.FullScript)
-    
+    @Html.Raw(JavaScriptSnippet.FullScript)
+
 </head>
 <body class="govuk-template__body ">
     <!-- Google Tag Manager (noscript) -->
@@ -54,8 +57,8 @@
     <script src="~/dist/vendor/jquery.min.js" nonce="@nonce"></script>
     <script nonce="@nonce">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
+    <partial name="_EnvironmentBanner" />
     <partial name="_CookiesBanner" />
-
     <header class="moj-header " role="banner">
         <div class="govuk-width-container">
             <div class="govuk-grid-row moj-header__container">
@@ -91,7 +94,7 @@
             </p>
         </div>
     </div>
-    
+
     @await RenderSectionAsync("Scripts", required: false)
     @await RenderSectionAsync("BeforeMain", required: false)
 

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/package-lock.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "wwwroot",
       "dependencies": {
         "@ministryofjustice/frontend": "^0.2.5",
         "accessible-autocomplete": "^2.0.3",

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
@@ -189,7 +189,7 @@ span.summary-validation-symbol {
   &__amber {
 	background-color: #f89360;
   }
-  
+
   &__green {
 	background-color:#2bbf7a;
   }
@@ -1644,7 +1644,7 @@ span.summary-validation-symbol {
 }
 
 .govuk-oneline-row {
-  overflow:hidden; 
+  overflow:hidden;
   white-space:nowrap;
   padding:0;
 }
@@ -1733,4 +1733,12 @@ label.govuk-label .govuk-tag {
 
 .concerns-secondary-text-colour {
   color: #505a5f;
+}
+
+/* ==========================================================================
+   #Environment Banners
+   ========================================================================== */
+.environment-name {
+	display: block;
+	text-transform: unset;
 }


### PR DESCRIPTION
**What is the change?**
show a banner with the current environment

**Why do we need the change?**
users have requested a banner indicating if they are accessing a non-production site

**What is the impact?**
ui only

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2039?workitem=122508