### PR TITLE
Hotfix/cd 122898 add missing authorise attributes

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/AuthorizeAttributeTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/AuthorizeAttributeTests.cs
@@ -1,0 +1,79 @@
+﻿using ConcernsCaseWork.Pages;
+using ConcernsCaseWork.Pages.Base;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ConcernsCaseWork.Tests.Security
+{
+	public class AuthorizeAttributeTests
+	{
+		public AuthorizeAttributeTests()
+		{
+			this.UnauthorizedPages = new Type[]
+			{
+				typeof(HealthModel),
+				typeof(ErrorPageModel),
+				typeof(LoginPageModel),
+				typeof(LogoutPageModel),
+			};
+		}
+
+		public Type[] UnauthorizedPages { get; }
+
+		[Test]
+		public void All_Pages_Include_Authorize_Attribute()
+		{
+			var pages = this.GetAllPagesExceptUnauthorizedPages();
+
+			pages.Length.Should().BeGreaterThan(0);
+
+			using (var scope = new AssertionScope())
+			{
+				foreach (Type page in pages)
+				{
+					var authAttributes = page.GetCustomAttributes<AuthorizeAttribute>();
+					if (authAttributes == null || !authAttributes.Any())
+					{
+						scope.AddPreFormattedFailure($"Could not find [Authorize] attribute and no exemption for the following page type: {page.Name} ({page.FullName})");
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void Open_Pages_Do_Not_Require_Authorization()
+		{
+			Type[] UnauthorizedPages = new[]
+			{
+				typeof(HealthModel),
+			};
+
+			using (var scope = new AssertionScope())
+			{
+				foreach (Type page in this.UnauthorizedPages)
+				{
+					var authAttribute = page.GetCustomAttribute<AuthorizeAttribute>();
+					if (authAttribute != null)
+					{
+						scope.AddPreFormattedFailure($"Expected page to be open and not require authorisation. But found [Authorize] attribute on the following page type: {page.Name} ({page.FullName})");
+					}
+				}
+			}
+		}
+
+		private Type[] GetAllPagesExceptUnauthorizedPages()
+		{
+			return Assembly
+				.GetAssembly(typeof(AbstractPageModel))
+				.GetTypes()
+				.Where(x => x.IsAssignableTo(typeof(PageModel)) && !this.UnauthorizedPages.Contains(x))
+				.ToArray();
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -5,7 +5,7 @@
 		<CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
 		<UserSecretsId>ac20b61d-9280-4be5-bbad-ad27aaff2f24</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-		<Version>17.0.1</Version>
+		<Version>17.0.2</Version>
 		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<FileVersion>1.0.*</FileVersion>
 	</PropertyGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Base/AbstractPageModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Base/AbstractPageModel.cs
@@ -2,11 +2,13 @@
 using ConcernsCaseWork.Extensions;
 using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Services.PageHistory;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Linq;
 
 namespace ConcernsCaseWork.Pages.Base
 {
+	[Authorize]
 	public class AbstractPageModel : PageModel
 	{
 		public const string ErrorOnGetPage = ErrorConstants.ErrorOnGetPage;


### PR DESCRIPTION
**What is the change?**
Website is secure but some pages log exceptions when the user accesses without a valid token

**Why do we need the change?**
Cut down on production errors logged.

**What is the impact?**
None. Only change is to apply auth token expectation to some pages.

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2039?workitem=122898