### PR TITLE
updated 'actions/setup-dotnet' to v3

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 


### PR DESCRIPTION

What is the change?

(Originally by mikestock-nimble
Updated to work with new pipeline)

updated setup dotnet action to v3

this will enable our verbosity flag on the test logs, so we get the passing and failing tests printed

Why do we need the change?

improve our test log

What is the impact?

Azure DevOps Ticket

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/123367