### PR TITLE
Feature/cd 123853 decrease trust search delay

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.Development.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.Development.json
@@ -13,7 +13,7 @@
 	"TramsApi": {
 		"TrustsLimitByPage": "1",
 		"TrustsPerPage": "30",
-		"MilliSecondPauseBeforeSeach": "500",
+		"MilliSecondPauseBeforeSeach": "1000",
 		"MinCharsRequiredToSeach": "3",
 		"ShowWarningWhenTooManySearchResults": "true"
 	},

--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.Staging.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.Staging.json
@@ -14,7 +14,7 @@
 	"TramsApi": {
 		"TrustsLimitByPage": "1",
 		"TrustsPerPage": "30",
-		"MilliSecondPauseBeforeSeach": "3000",
+		"MilliSecondPauseBeforeSeach": "1000",
 		"MinCharsRequiredToSeach": "3",
 		"ShowWarningWhenTooManySearchResults": "true"
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
@@ -14,7 +14,7 @@
 	"TramsApi": {
 		"TrustsLimitByPage": "1",
 		"TrustsPerPage": "30",
-		"MilliSecondPauseBeforeSeach": "3000",
+		"MilliSecondPauseBeforeSeach": "1000",
 		"MinCharsRequiredToSeach": "3",
 		"ShowWarningWhenTooManySearchResults": "true"
 	},


### PR DESCRIPTION
**What is the change?**
decrease the trust search delay to 1 second

**Why do we need the change?**
Users have reported that the trust search is slow

**What is the impact?**
Less delay between starting trust search

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2039?workitem=123853