### PR TITLE
124053: reassign automation

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/auth/authenticationInterceptor.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/auth/authenticationInterceptor.ts
@@ -2,7 +2,7 @@ import { EnvUrl, EnvAuthKey, CaseworkerClaim, EnvUsername } from "../constants/c
 
 export class AuthenticationInterceptor {
 
-    register() {
+    register(params?: AuthenticationInterceptorParams) {
         cy.intercept(
             {
                 url: Cypress.env(EnvUrl) + "/**",
@@ -14,10 +14,14 @@ export class AuthenticationInterceptor {
                 req.headers = {
                     ...req.headers,
                     'Authorization': `Bearer ${Cypress.env(EnvAuthKey)}`,
-                    "x-user-context-role-0": CaseworkerClaim,
+                    "x-user-context-role-0": params?.role ? params.role : CaseworkerClaim,
                     "x-user-context-name": Cypress.env(EnvUsername)
                 };
             }
         ).as("AuthInterceptor");
     }
+}
+
+export type AuthenticationInterceptorParams = {
+    role?: string
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
@@ -48,7 +48,7 @@ describe("Testing permissions on cases and case actions", () => {
         }));
     });
 
-    it("Should not allow a user to edit a case that they did not create", () => {
+    it.only("Should not allow a user to edit a case that they did not create", () => {
 
         Logger.Log("Check that we can edit if we did create the case");
         caseMangementPage
@@ -57,6 +57,7 @@ describe("Testing permissions on cases and case actions", () => {
             .canEditRiskToTrust()
             .canEditDirectionOfTravel()
             .canEditTerritory()
+            .canEditCaseOwner()
             .canEditIssue()
             .canEditCurrentStatus()
             .canEditCaseAim()
@@ -74,6 +75,7 @@ describe("Testing permissions on cases and case actions", () => {
             .cannotEditRiskToTrust()
             .cannotEditDirectionOfTravel()
             .cannotEditTerritory()
+            .cannotEditCaseOwner()
             .cannotEditIssue()
             .cannotEditCurrentStatus()
             .cannotEditCaseAim()

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
@@ -48,7 +48,7 @@ describe("Testing permissions on cases and case actions", () => {
         }));
     });
 
-    it.only("Should not allow a user to edit a case that they did not create", () => {
+    it("Should not allow a user to edit a case that they did not create", () => {
 
         Logger.Log("Check that we can edit if we did create the case");
         caseMangementPage

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/reassign-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/reassign-case.cy.ts
@@ -1,0 +1,86 @@
+import caseApi from "cypress/api/caseApi";
+import { Logger } from "cypress/common/logger";
+import { AdminClaim, EnvUsername } from "cypress/constants/cypressConstants";
+import caseMangementPage from "../../pages/caseMangementPage";
+import editCaseMangementPage from "../../pages/editCaseManagementPage";
+
+
+describe("Testing reassigning cases", () =>
+{
+    let caseId: number;
+    let email: string;
+    let name: string;
+
+    beforeEach(() =>
+    {
+        // Testing reassign requires admin permission
+        cy.login(
+            {
+                role: AdminClaim
+            }
+        );
+
+        cy.basicCreateCase()
+        .then((id =>
+        {
+            caseId = id;
+        }));
+
+        email = Cypress.env(EnvUsername);
+        name = email.split("@")[0];
+    });
+
+    it("Should be able to edit an existing case owner", () =>
+    {
+        Logger.Log("editing the existing case owner");
+
+        // switch the case owner
+        updateCaseOwner(caseId);
+
+        caseMangementPage
+            .hasCaseOwner("Automation User")
+            .editCaseOwner();
+
+        editCaseMangementPage
+            .hasCaseOwner("Automation.User@education.gov.uk")
+            .withCaseOwner("sv")
+            .selectCaseOwnerOption()
+            .hasCaseOwner(email)
+            .save();
+
+        caseMangementPage
+            .hasCaseOwnerReassignedBanner()
+            .hasCaseOwner(name);
+
+        caseMangementPage.editCaseOwner();
+
+        Logger.Log("We get no results found if there are no matching results");
+            editCaseMangementPage
+                .withCaseOwner("fghhj")
+                .hasNoCaseOwnerResults();
+
+        Logger.Log("We cannot set a blank case owner");
+        editCaseMangementPage
+            .clearCaseOwner()
+            .save()
+            .hasValidationError("A valid case owner must be selected")
+            .hasCaseOwner(email);
+
+        Logger.Log("We do not get a notification if we do not change the case owner");
+        editCaseMangementPage.save();
+        caseMangementPage
+            .hasNoCaseOwnerReassignedBanner()
+            .hasCaseOwner(name);
+    });
+    
+    function updateCaseOwner(caseId: number) {
+        caseApi.get(caseId)
+        .then((caseResponse) =>
+        {
+            caseResponse.createdBy = "Automation.User@education.gov.uk";
+            caseApi.patch(caseId, caseResponse);
+            cy.reload();
+        })
+    }
+
+});

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -252,6 +252,32 @@ class CaseManagementPage {
         return this;
     }
 
+    public editCaseOwner(): this
+    {
+        Logger.Log("Editing case owner");
+
+        this.getEditCaseOwner().click();
+
+        return this;
+    }
+
+    public canEditCaseOwner(): this
+    {
+        Logger.Log("Can edit case owner");
+
+        this.getEditCaseOwner();
+
+        return this;
+    }
+
+    public cannotEditCaseOwner(): this
+    {
+        Logger.Log("Cannot edit case owner");
+        this.getEditCaseOwner().should("not.exist");
+
+        return this;
+    }
+
     public editIssue(): this
     {
         Logger.Log("Editing the issue");
@@ -449,6 +475,11 @@ class CaseManagementPage {
     private getEditTerritory()
     {
         return cy.getByTestId("edit_Button_SFSO");
+    }
+
+    private getEditCaseOwner()
+    {
+        return cy.getByTestId("edit-case-owner");
     }
 
     private getEditIssue()

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -252,6 +252,17 @@ class CaseManagementPage {
         return this;
     }
 
+    public hasCaseOwner(value: string): this {
+        Logger.Log(`Has case owner ${value}`);
+
+        // Can be improved later
+        // Currently its driven by the casing of the email when the user logs in
+        // We can't control this, so safer to ignore case for now
+        cy.getByTestId("case owner_field").contains(value, { matchCase: false });
+
+        return this;
+    }
+
     public editCaseOwner(): this
     {
         Logger.Log("Editing case owner");
@@ -274,6 +285,24 @@ class CaseManagementPage {
     {
         Logger.Log("Cannot edit case owner");
         this.getEditCaseOwner().should("not.exist");
+
+        return this;
+    }
+
+    public hasCaseOwnerReassignedBanner(): this
+    {
+        Logger.Log("Has case reassigned banner");
+
+        this.getCaseOwnerReassignedBanner().should("contain.text", "Case has been reassigned");
+
+        return this;
+    }
+
+    public hasNoCaseOwnerReassignedBanner(): this
+    {
+        Logger.Log("Has no case reassigned banner");
+
+        this.getCaseOwnerReassignedBanner().should("not.exist");
 
         return this;
     }
@@ -480,6 +509,11 @@ class CaseManagementPage {
     private getEditCaseOwner()
     {
         return cy.getByTestId("edit-case-owner");
+    }
+
+    private getCaseOwnerReassignedBanner()
+    {
+        return cy.getByTestId("case-reassigned-success");
     }
 
     private getEditIssue()

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/editCaseManagementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/editCaseManagementPage.ts
@@ -2,6 +2,39 @@ import { Logger } from "cypress/common/logger";
 
 class EditCaseManagementPage
 {
+    public withCaseOwner(value: string): this
+    {
+        Logger.Log(`With case owner ${value}`);
+
+        cy.getById("case-owner-input").clear().type(value);
+
+        return this;
+    }
+
+    public hasNoCaseOwnerResults(): this {
+        Logger.Log("Has case owner option");
+        cy.get(".autocomplete__option").should("contain.text", "No results found");
+
+        return this;
+    }
+
+    public selectCaseOwnerOption(): this
+    {
+        Logger.Log("Selecting first case owner option");
+        cy.get(".autocomplete__option").first().click();
+
+        return this;
+    }
+    
+    public clearCaseOwner(): this
+    {
+        Logger.Log(`Clearing the case owner`);
+
+        cy.getById("case-owner-input").clear();
+
+        return this;
+    }
+
     public withIssue(value: string): this
     {
         Logger.Log(`With issue ${value}`);
@@ -24,6 +57,22 @@ class EditCaseManagementPage
         Logger.Log(`With case history exceeding limit`);
 
         cy.getById('case-history').clear().invoke("val", "x 1".repeat(2001));
+
+        return this;
+    }
+
+    public hasCaseOwner(value: string): this {
+        Logger.Log(`Has case owner ${value}`);
+
+        // Can be improved later
+        // Currently its driven by the casing of the email when the user logs in
+        // We can't control this, so safer to ignore case for now
+        cy.getById("case-owner-input")
+            .then((element: any) =>
+            {
+                expect(element.val().toLowerCase()).eq(value.toLowerCase());
+            });
+
 
         return this;
     }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.js
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.js
@@ -58,13 +58,13 @@ Cypress.Commands.add("waitForJavascript", () => {
 	cy.wait(1000);
 });
 
-Cypress.Commands.add("login", () => {
+Cypress.Commands.add("login", (params) => {
 	cy.clearCookies();
 	cy.clearLocalStorage();
 
 	// Intercept all browser requests and add our special auth header
 	// Means we don't have to use azure to authenticate 
-	new AuthenticationInterceptor().register();
+	new AuthenticationInterceptor().register(params);
 
 	// Old method of using azure to login
 	// const username = Cypress.env("username");

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/e2e.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/e2e.ts
@@ -14,6 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
+import { AuthenticationInterceptorParams } from 'cypress/auth/authenticationInterceptor';
 import { CaseworkerClaim, EnvApiKey, EnvAuthKey, EnvUrl, EnvUsername } from 'cypress/constants/cypressConstants';
 import './commands'
 import './utils'
@@ -24,7 +25,7 @@ declare global {
             getByTestId(id: string): Chainable<Element>;
             getById(id: string): Chainable<Element>;
             waitForJavascript(): Chainable<Element>;
-            login(): Chainable<Element>;
+            login(params?: AuthenticationInterceptorParams): Chainable<Element>;
             storeSessionData(): Chainable<Element>;
             selectMoR(): Chainable<Element>;
             createCase(): Chainable<Element>;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
@@ -43,7 +43,7 @@
 	    
         <!--Button group-->
         <div class="govuk-button-group govuk-!-margin-top-3">
-            <button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" data-testid="continue">
+            <button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" data-testid="save-case">
                 Continue
             </button>
             <partial name="_Cancel" />

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -36,14 +36,14 @@
 		{
 			<div class="govuk-notification-banner govuk-notification-banner--success" role="alert"
 			     aria-labelledby="govuk-notification-banner-title"
-			     data-module="govuk-notification-banner">
+                 data-module="govuk-notification-banner">
 				<div class="govuk-notification-banner__header">
 					<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
 						Success
 					</h2>
 				</div>
 				<div class="govuk-notification-banner__content">
-					<h3 class="govuk-notification-banner__heading">
+                    <h3 class="govuk-notification-banner__heading" data-testid="case-reassigned-success">
 						Case has been reassigned
 					</h3>
 				


### PR DESCRIPTION
**What is the change?**

check permissions on reassign
reassign a case and notify it has been reassigned
validation scenarios
reassign the same owner results in no notification

**Why do we need the change?**

automation to cover the reassign stories

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/124053
