### PR TITLE
fixed broken cypress tests

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case-route.cy.js
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case-route.cy.js
@@ -30,7 +30,7 @@ describe("User interactions via Create Case route", () => {
 		cy.get('[href="/case"]').click();
 		cy.get("#search").should("be.visible");
 		cy.get("#search").type(searchTerm .substring(0,1)+'{enter}');
-        cy.get('.govuk-list.govuk-error-summary__list a').should('contain.text', 'Select a trust')
+		cy.getById("errorSummary").should("contain.text", 'Select a trust');
     });
 
 	it('Should display a warning if too many results', () => {

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/find-trust-route.cy.js
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/find-trust-route.cy.js
@@ -27,7 +27,6 @@ describe("User interactions via Find Trust route", () => {
 
 		Logger.Log("It should display an error when the user does not enter a trust");
 		cy.get("#search").type(searchTerm .substring(0,1)+'{enter}');
-        cy.get('.govuk-list.govuk-error-summary__list a').should('contain.text', 'Select a trust')
-
+        cy.getById("errorSummary").should("contain.text", 'Select a trust');
 	});
 });


### PR DESCRIPTION
**What is the change?**

the tests were unable to target the error element using the class selector used the more stable id selector instead

**Why do we need the change?**

fix the broken cypress tests

**What is the impact?**

**Azure DevOps Ticket**
