### PR TITLE
Only automate deployments from 'Develop' branch

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -12,7 +12,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
 
 env:
   DOCKER_IMAGE: amsd-app


### PR DESCRIPTION
Stops conflicting deployment runs when `develop` branch is merged into `main`.