### PR TITLE
bumping version to 19 for next release

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -5,7 +5,7 @@
 		<CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
 		<UserSecretsId>ac20b61d-9280-4be5-bbad-ad27aaff2f24</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-		<Version>18.0.1</Version>
+		<Version>19.0.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Label="custom">

--- a/ConcernsCaseWork/release-notes.md
+++ b/ConcernsCaseWork/release-notes.md
@@ -1,3 +1,9 @@
+## 19.0.0
+
+[To be completed]
+
+---
+
 ## 18.0.1
 * CSS styling fix on the Re-Assign page.
 * Changed 'Edit' link to 'Change' on the Case/Management/Index page


### PR DESCRIPTION
**What is the change?**
Bumping version number to 19 for next end of sprint release.

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Concerns%20Casework/Academies-and-Free-Schools-SIP/CC/CC%20-%20Iteration%2040?workitem=124329