### PR TITLE
Cypress_Tests_updating_company_house_number_for_existing_cases_125313

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/api/apiDomain.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/api/apiDomain.ts
@@ -33,6 +33,7 @@ export type PatchCaseRequest =
 {
     urn: number;
     createdBy: string;
+    trustCompaniseHouseNumber: string;
 }
 
 export type PatchCaseResponse =

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
@@ -6,6 +6,7 @@ import CreateConcernPage from "cypress/pages/createCase/createConcernPage";
 import AddConcernDetailsPage from "cypress/pages/createCase/addConcernDetailsPage";
 import caseManagementPage from "cypress/pages/caseMangementPage";
 import concernsApi from "cypress/api/concernsApi";
+import caseApi from "cypress/api/caseApi";
 
 describe("Creating a case", () =>
 {
@@ -143,6 +144,13 @@ describe("Creating a case", () =>
             concernsApi.get(parseInt(caseId))
                 .then(response => {
                     expect(response[0].meansOfReferralId).to.eq(2);
+                });
+        });
+        Logger.Log("Verify Trust Companise House Number is set on the API");
+        caseManagementPage.getCaseIDText().then((caseId) => {
+            caseApi.get(parseInt(caseId))
+                .then(response => {
+                    expect(response[0].trustCompaniseHouseNumber).to.eq("09388819");
                 });
         });
     });


### PR DESCRIPTION
**What is the change?**

The change involves creating Cypress tests for ticket 125313 which is creating a script to update the company house number for existing cases

**Why do we need the change?**

We need this change to ensure that our testing suite is robust and covers all possible scenarios. By creating Cypress tests, we can automate the testing process and catch any potential issues before they become problems for end-users.

**What is the impact?**

The impact of this change is expected to be minimal. However, it will significantly improve the quality of our testing suite and ensure that we can deliver a high-quality product to our users.

**Azure DevOps Ticket**

[User Story 125313](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/125313): This story involves creating a script to update the company house number for existing cases in both staging and production environments.

[User Story 125717](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/125717): This story involves creating API Cypress automation tests to ensure that the above ticket works as expected and catches any potential issues early in the development cycle.