### PR TITLE
iterate-reassign-hint-test

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
@@ -27,7 +27,7 @@
         <h1 class="govuk-heading-l">
             Change case owner
         </h1>
-		<p class="govuk-!-margin-bottom-0 govuk-hint">Enter the name or email address of the person you want to assign the case to</p>
+		<p class="govuk-!-margin-bottom-0 govuk-hint">Find and select the email address of the person you want to assign the case to</p>
         <div id="autocomplete-container" class="govuk-!-margin-top-0"></div>
 		  
         <div class="ccms-loader govuk-!-display-none"></div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -26,7 +26,7 @@
 		</legend>
 
         <label class="govuk-hint" for="search" id="outgoing-trust-search-query-hint">
-            <text>Enter at least @trustSearchOptions.Value.MinCharsRequiredToSeach characters of a trust name, UK provider reference number (UKPRN) or Companies House number.</text>
+            <text>Find and select the email address of the person you want to assign the case to</text>
 		</label>
         <div id="tooManyResultsWarning" style="display:none;">
             <p class="govuk-heading-s govuk-!-margin-top-3" aria-label="There are a large number of search results. Try a more specific search term">There are a large number of search results. Try a more specific search term.</p>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -26,7 +26,7 @@
 		</legend>
 
         <label class="govuk-hint" for="search" id="outgoing-trust-search-query-hint">
-            <text>Find and select the email address of the person you want to assign the case to</text>
+             <text>Enter at least @trustSearchOptions.Value.MinCharsRequiredToSeach characters of a trust name, UK provider reference number (UKPRN) or Companies House number.</text>
 		</label>
         <div id="tooManyResultsWarning" style="display:none;">
             <p class="govuk-heading-s govuk-!-margin-top-3" aria-label="There are a large number of search results. Try a more specific search term">There are a large number of search results. Try a more specific search term.</p>


### PR DESCRIPTION
**What is the change?**
 Iterating the hint text in the reassign function because it's inaccurate and users have struggled when reassigning a case.

**Why do we need the change?**
Per requirement

**What is the impact?**
Minimal 
**Azure DevOps Ticket**
Story Ticket - [User Story 125433](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/125433): Content & dev: iterate reassign hint text
Dev Ticket - [Task 125608](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/125608): Dev
