### PR TITLE
126690: fix components to validate in line with model state

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
@@ -1,10 +1,17 @@
+@using Microsoft.AspNetCore.Mvc.ModelBinding;
+@using System.ComponentModel.DataAnnotations;
 @model ConcernsCaseWork.Models.OptionalDateTimeUiComponent
 @{
-    var errors = Model.Validate();
-    var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
-
     var required = Model.Required == true ? "true" : "false";
     var displayName = !string.IsNullOrEmpty(Model.DisplayName) ? Model.DisplayName : Model.Heading;
+
+    var modelPath = $"{Model.Name}.{displayName}";
+    ViewContext.ModelState.TryGetValue(modelPath, out ModelStateEntry modelState);
+
+    var errors = modelState?.Errors.Select(e => new ValidationResult(e.ErrorMessage, new[] { displayName }));
+
+    var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
+
 }
 <div class="govuk-form-group">
 	<fieldset class="govuk-fieldset">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_RadioList.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_RadioList.cshtml
@@ -1,9 +1,15 @@
+@using Microsoft.AspNetCore.Mvc.ModelBinding;
+@using System.ComponentModel.DataAnnotations;
 @model ConcernsCaseWork.Models.RadioButtonsUiComponent
 
 @{
     var required = Model.Required == true ? "true" : "false";
-    var errors = Model.Validate();
-	var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
+
+    var modelPath = $"{Model.Name}.{Model.DisplayName}";
+    ViewContext.ModelState.TryGetValue(modelPath, out ModelStateEntry modelState);
+
+    var errors = modelState?.Errors.Select(e => new ValidationResult(e.ErrorMessage, new[] { Model.DisplayName })); ;
+    var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
 }
 
 <div class="govuk-form-group">


### PR DESCRIPTION
**What is the change?**

ensure that the components use the model state validation, instead of calling their own validation when the page loads. This makes sure that the component is only validated when the form was submitted

**Why do we need the change?**

This caused a problem with required validation, where the error appeared as soon as the page loaded

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=126690
