### PR TITLE
Update Key Vault Terraform module

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -137,7 +137,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.17.1 |
-| <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.1.1 |
+| <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.1.2 |
 
 ## Resources
 
@@ -176,6 +176,7 @@ No resources.
 | <a name="input_existing_network_watcher_name"></a> [existing\_network\_watcher\_name](#input\_existing\_network\_watcher\_name) | Use an existing network watcher to add flow logs. | `string` | n/a | yes |
 | <a name="input_existing_network_watcher_resource_group_name"></a> [existing\_network\_watcher\_resource\_group\_name](#input\_existing\_network\_watcher\_resource\_group\_name) | Existing network watcher resource group. | `string` | n/a | yes |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image name | `string` | n/a | yes |
+| <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |
 | <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that will receive alerts from App Insights | `list(string)` | n/a | yes |
 | <a name="input_monitor_enable_slack_webhook"></a> [monitor\_enable\_slack\_webhook](#input\_monitor\_enable\_slack\_webhook) | Enable slack webhooks to send monitoring notifications to a channel | `bool` | n/a | yes |

--- a/terraform/key-vault-tfvars-secrets.tf
+++ b/terraform/key-vault-tfvars-secrets.tf
@@ -1,11 +1,12 @@
 module "azurerm_key_vault" {
-  source = "github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars?ref=v0.1.1"
+  source = "github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars?ref=v0.1.2"
 
   environment                           = local.environment
   project_name                          = local.project_name
-  resource_group_name                   = module.azure_container_apps_hosting.azurerm_resource_group_default.name
+  existing_resource_group               = module.azure_container_apps_hosting.azurerm_resource_group_default.name
   azure_location                        = local.azure_location
   key_vault_access_users                = local.key_vault_access_users
+  key_vault_access_ipv4                 = local.key_vault_access_ipv4
   tfvars_filename                       = local.tfvars_filename
   diagnostic_log_analytics_workspace_id = module.azure_container_apps_hosting.azurerm_log_analytics_workspace_container_app.id
   diagnostic_eventhub_name              = local.enable_event_hub ? module.azure_container_apps_hosting.azurerm_eventhub_container_app.name : ""

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -32,6 +32,7 @@ locals {
   cdn_frontdoor_enable_rate_limiting            = var.cdn_frontdoor_enable_rate_limiting
   cdn_frontdoor_rate_limiting_threshold         = var.cdn_frontdoor_rate_limiting_threshold
   key_vault_access_users                        = toset(var.key_vault_access_users)
+  key_vault_access_ipv4                         = var.key_vault_access_ipv4
   tfvars_filename                               = var.tfvars_filename
   enable_event_hub                              = var.enable_event_hub
   enable_monitoring                             = var.enable_monitoring

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,6 +8,11 @@ variable "key_vault_access_users" {
   type        = list(string)
 }
 
+variable "key_vault_access_ipv4" {
+  description = "List of IPv4 Addresses that are permitted to access the Key Vault"
+  type        = list(string)
+}
+
 variable "tfvars_filename" {
   description = "tfvars filename. This file is uploaded and stored encrupted within Key Vault, to ensure that the latest tfvars are stored in a shared place."
   type        = string


### PR DESCRIPTION
**What is the change?**
Updates the Terraform Key Vault module to the latest version which allows us to specify a list of IP addresses that are permitted to access the Key Vault that contains the Terraform Variable files.

**Why do we need the change?**
This is a suggested Security Posture remediation for Azure and will improve the access control security for the Key Vault

**What is the impact?**
Operators that download from the Azure Key Vault, must be connecting via a trusted IP address, otherwise their connection will be rejected.