### PR TITLE
127179: added field highlighting in red when a date error occurs

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
@@ -10,7 +10,10 @@
 
     var errors = modelState?.Errors.Select(e => new ValidationResult(e.ErrorMessage, new[] { displayName }));
 
-    var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
+    var hasErrors = errors?.Any() ?? false;
+
+    var bannerErrorClass = hasErrors ? "govuk-form-group--error" : string.Empty;
+    var inputErrorClass = hasErrors ? "govuk-input--error" : string.Empty;
 
 }
 <div class="govuk-form-group">
@@ -25,13 +28,12 @@
 		
 		<div class="govuk-date-input" id="dtr-@Model.ElementRootId">
 			<div class="govuk-date-input__item">
-				<div class="govuk-form-group @errorClass">
+				<div class="govuk-form-group @bannerErrorClass">
 					<label class="govuk-label govuk-date-input__label" for="dtr-day-@Model.ElementRootId">
 						Day
 					</label>
-					<input
-						class="govuk-input govuk-date-input__input govuk-input--width-4" 
-						id="dtr-day-@Model.ElementRootId"
+					<input class="govuk-input govuk-date-input__input govuk-input--width-4 @inputErrorClass"
+                           id="dtr-day-@Model.ElementRootId"
 						data-testid="dtr-day-@Model.ElementRootId"
 						type="text" 
 						maxlength="2" 
@@ -46,7 +48,7 @@
 						Month
 					</label>
 					<input 
-						class="govuk-input govuk-date-input__input govuk-input--width-4"
+						class="govuk-input govuk-date-input__input govuk-input--width-4 @inputErrorClass"
 						id="dtr-month-@Model.ElementRootId"
 						data-testid="dtr-month-@Model.ElementRootId"
 						type="text" 
@@ -62,7 +64,7 @@
 						Year
 					</label>
 					<input
-						class="govuk-input govuk-date-input__input govuk-input--width-4" 
+						class="govuk-input govuk-date-input__input govuk-input--width-4 @inputErrorClass" 
 						id="dtr-year-@Model.ElementRootId"
 						data-testid="dtr-year-@Model.ElementRootId"
 						type="text" 


### PR DESCRIPTION
**What is the change?**

added field highlighting in red when a date error occurs

**Why do we need the change?**

ensure it matches the design

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=127179