### PR TITLE
127180: add links to error summary so it scrolls to the element with the error

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_Checkbox.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_Checkbox.cshtml
@@ -13,7 +13,7 @@
     var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
 }
 
-<div class="govuk-form-group @errorClass">
+<div class="govuk-form-group @errorClass" id="container-@Model.ElementRootId">
     <partial name="Components/_ValidationErrorDetail" model="@errors" />
 
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
@@ -26,7 +26,7 @@
 		<div class="govuk-date-input" id="dtr-@Model.ElementRootId">
 			<div class="govuk-date-input__item">
 				<div class="govuk-form-group @errorClass">
-					<label class="govuk-label govuk-date-input__label" for="dtr-day-@Model.ElementRootId">
+                    <label class="govuk-label govuk-date-input__label" aria-label="@displayName Day" for="dtr-day-@Model.ElementRootId">
 						Day
 					</label>
 					<input
@@ -42,7 +42,7 @@
 			</div>
 			<div class="govuk-date-input__item">
 				<div class="govuk-form-group">
-					<label class="govuk-label govuk-date-input__label" for="dtr-month-@Model.ElementRootId">
+                    <label class="govuk-label govuk-date-input__label" aria-label="@displayName Month" for="dtr-month-@Model.ElementRootId">
 						Month
 					</label>
 					<input 
@@ -58,7 +58,7 @@
 			</div>
 			<div class="govuk-date-input__item">
 				<div class="govuk-form-group">
-					<label class="govuk-label govuk-date-input__label" for="dtr-year-@Model.ElementRootId">
+                    <label class="govuk-label govuk-date-input__label" aria-label="@displayName Year" for="dtr-year-@Model.ElementRootId">
 						Year
 					</label>
 					<input

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_DateTime.cshtml
@@ -13,7 +13,7 @@
     var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
 
 }
-<div class="govuk-form-group">
+<div class="govuk-form-group" id="container-@Model.ElementRootId">
 	<fieldset class="govuk-fieldset">
 		<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 			<h2 class="govuk-heading-m" id="@(Model.Name).Date.@Model.Heading">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_RadioList.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_RadioList.cshtml
@@ -12,7 +12,7 @@
     var errorClass = errors?.Any() ?? false ? " govuk-form-group--error" : string.Empty;
 }
 
-<div class="govuk-form-group">
+<div class="govuk-form-group" id="container-@Model.ElementRootId">
 	<fieldset class="govuk-fieldset">
          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 			<h2 class="govuk-heading-m">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_TextArea.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_TextArea.cshtml
@@ -5,7 +5,7 @@
     var nonce = Context.GetNonce();
     var displayName = !string.IsNullOrEmpty(@Model.Text.DisplayName) ? @Model.Text.DisplayName : @Model.Heading;
 }
-<div class="govuk-form-group">
+<div class="govuk-form-group" id="container-@Model.ElementRootId">
 	<fieldset class="govuk-fieldset">
 		<div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="@Model.Text.MaxLength">
 			<div class="govuk-form-group" id="@(Model.Name).Text.@Model.Heading">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_TextArea.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_TextArea.cshtml
@@ -14,7 +14,7 @@
                 {
                     <div class="govuk-hint">@Model.HintText</div>
                 }
-				<textarea class="govuk-textarea govuk-js-character-count concern-auto-resize" id="@Model.ElementRootId" data-testid="@Model.ElementRootId" name="@(Model.Name).Text.StringContents" rows="3" aria-describedby="@Model.ElementRootId-info">@Model.Text.StringContents</textarea>
+				<textarea class="govuk-textarea govuk-js-character-count concern-auto-resize" id="@Model.ElementRootId" data-testid="@Model.ElementRootId" name="@(Model.Name).Text.StringContents" rows="3" aria-label="@displayName">@Model.Text.StringContents</textarea>
 			</div>
 			<div id="@Model.ElementRootId-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
 				You can enter up to @Model.Text.MaxLength characters

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_TextBox.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_TextBox.cshtml
@@ -3,7 +3,7 @@
 @{
 	var nonce = Context.GetNonce();
 }
-<div class="govuk-form-group">
+<div class="govuk-form-group" id="container-@Model.ElementRootId">
 	<fieldset class="govuk-fieldset">
 		<div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="@Model.Text.MaxLength">
             <div class="govuk-form-group" id="@(Model.Name).Text.@Model.Heading">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ValidationErrors.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ValidationErrors.cshtml
@@ -1,3 +1,4 @@
+@using ConcernsCaseWork.Models;
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 @model ConcernsCaseWork.Pages.Base.AbstractPageModel
 
@@ -11,7 +12,19 @@
 					.Where(s => s.Value?.ValidationState == ModelValidationState.Invalid)
 					.Select(e => new { e.Key, Msg = string.Join("<br />", e.Value.Errors.Select(errs => errs?.ErrorMessage)) }))
 				{
-					<li><p class="govuk govuk-error-message">@error.Msg</p></li>			
+                    var propertyName = error.Key.Split(".").First();
+
+                    object selectedProperty = Model.GetType().GetProperty(propertyName)?.GetValue(Model);
+
+                    var containerId = "";
+
+                    if (selectedProperty is BaseUiComponent)
+                    {
+                        var component = selectedProperty as BaseUiComponent;
+                        containerId = $"container-{component.ElementRootId}";
+                    }
+
+                    <li><a class="govuk govuk-error-message scrollable-error" data-scroll-to="@containerId">@error.Msg</a></li>
 				}
 			</ul>
 		</div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ValidationErrors.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ValidationErrors.cshtml
@@ -24,7 +24,7 @@
                         containerId = $"container-{component.ElementRootId}";
                     }
 
-                    <li><a class="govuk govuk-error-message scrollable-error" data-scroll-to="@containerId">@error.Msg</a></li>
+                    <li><a href="javascript:;" class="govuk govuk-error-message scrollable-error" data-scroll-to="@containerId">@error.Msg</a></li>
 				}
 			</ul>
 		</div>

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
@@ -1502,13 +1502,15 @@ span.summary-validation-symbol {
   padding: 4px 4px 2px;
 }
 
+.scrollable-error {
+	cursor: pointer
+}
 /* ==========================================================================
    #RICH TEXT EDITOR
    ========================================================================== */
-
 .moj-rich-text-editor__toolbar {
-  @include govuk-clearfix;
-  margin-bottom: govuk-spacing(2);
+	@include govuk-clearfix;
+	margin-bottom: govuk-spacing(2);
 }
 
 .moj-rich-text-editor__toolbar-button {

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/js/site.js
@@ -14,6 +14,22 @@ CaseAim(1000);
 DeEscalationPoint(1000);
 NextSteps(4000);
 
+setScrollableErrorElements();
+
+function setScrollableErrorElements() {
+
+	var elements = $('.scrollable-error');
+
+	if (elements.length > 0) {
+		elements.click(function () {
+			var id = $(this).data('scroll-to');
+
+			var element = document.getElementById(id);
+			element.scrollIntoView({ behavior: 'smooth' });
+		});
+	}
+}
+
 // Write your JavaScript code.
 window.showGlobalError = function() {
 	$("#moj-banner-error").removeClass("govuk-!-display-none");


### PR DESCRIPTION
**What is the change?**

add links to error summary so it scrolls to the element with the error

**Why do we need the change?**

allow users to see which field caused the problem

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=127180
