### PR TITLE
127826 non concerns action filter

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/financial-plan-add-to-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/financial-plan-add-to-case.cy.ts
@@ -219,8 +219,8 @@ describe("User can add Financial Plan case action to an existing case", () => {
         Logger.Log("Try to add second financial plan to case");
         addFinancialPlanToCase();
 
-        cy.getByTestId("error-text")
-            .should("contain.text", "There is already an open Financial Plan action linked to this case. Please resolve that before opening another one.");
+        AddToCasePage
+            .hasValidationError("There is already an open Financial Plan action linked to this case. Please resolve that before opening another one.");
     });
 
     function checkFormValidation()

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/nti.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/nti.cy.ts
@@ -193,8 +193,8 @@ describe("Testing case action NTI", () =>
         Logger.Log("Try to add second nti to case should result in an error");
         addNtiToCase();
 
-        cy.getByTestId("error-text")
-            .should("contain.text", "There is already an open NTI action linked to this case. Please resolve that before opening another one.");
+        AddToCasePage
+            .hasValidationError("There is already an open NTI action linked to this case. Please resolve that before opening another one.");
     });
 
     it("should be able to cancel an NTI", () =>

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/trust-financial-forecast.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/trust-financial-forecast.cy.ts
@@ -83,9 +83,8 @@ describe("User can add trust financial forecast to an existing case", () => {
 
 		addTFFToCase();
 
-		cy
-			.getByTestId("error-text")
-			.should("contain.text", "There is already an open trust financial forecast action linked to this case. Please resolve that before opening another one.");
+		AddToCasePage
+			.hasValidationError("There is already an open trust financial forecast action linked to this case. Please resolve that before opening another one.");
 	});
 
 	it("Creating a TFF with empty values", function () {

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
@@ -5,6 +5,8 @@ import caseManagementPage from "cypress/pages/caseMangementPage";
 import { SelectCaseTypePage } from "cypress/pages/createCase/selectCaseTypePage";
 import { EnvUsername } from "cypress/constants/cypressConstants";
 import { CreateCasePage } from "cypress/pages/createCase/createCasePage";
+import CaseManagementPage from "../../pages/caseMangementPage";
+import AddToCasePage from "../../pages/caseActions/addToCasePage";
 
 describe("Creating a case", () => {
     let email: string;
@@ -33,7 +35,7 @@ describe("Creating a case", () => {
         Logger.Log("You must select a case error");
         selectCaseTypePage
             .continue()
-            .hasValidationError("Select Case type")
+            .hasValidationError("Select case type")
 
         Logger.Log("Create a valid Non-concern case type");
         selectCaseTypePage
@@ -62,6 +64,13 @@ describe("Creating a case", () => {
             .hasCaseHistory(caseHistoryData)
             .hasCaseOwner(name);
 
-
+        Logger.Log("Verify case actions for non concerns");
+        CaseManagementPage.getAddToCaseBtn().click();
+        
+        AddToCasePage.hasActions([
+            "Decision", 
+            "SRMA (School Resource Management Adviser)", 
+            "TFF (Trust Financial Forecast)"
+        ]);
     });
 });

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
@@ -7,6 +7,9 @@ import { EnvUsername } from "cypress/constants/cypressConstants";
 import { CreateCasePage } from "cypress/pages/createCase/createCasePage";
 import CaseManagementPage from "../../pages/caseMangementPage";
 import AddToCasePage from "../../pages/caseActions/addToCasePage";
+import { EditSrmaPage } from "cypress/pages/caseActions/srma/editSrmaPage";
+import { ViewSrmaPage } from "cypress/pages/caseActions/srma/viewSrmaPage";
+import actionSummaryTable from "cypress/pages/caseActions/summary/actionSummaryTable";
 
 describe("Creating a case", () => {
     let email: string;
@@ -15,6 +18,10 @@ describe("Creating a case", () => {
     const addTerritoryPage = new AddTerritoryPage();
     const addConcernDetailsPage = new AddConcernDetailsPage();
     const createCasePage = new CreateCasePage();
+
+    const editSrmaPage = new EditSrmaPage();
+    const viewSrmaPage = new ViewSrmaPage();
+
     beforeEach(() => {
         cy.login();
         cy.visit(Cypress.env('url') + '/case/create');
@@ -72,5 +79,32 @@ describe("Creating a case", () => {
             "SRMA (School Resource Management Adviser)", 
             "TFF (Trust Financial Forecast)"
         ]);
+
+        Logger.Log("Create an SRMA on non concerns");
+
+        AddToCasePage.addToCase('Srma')
+        AddToCasePage.getAddToCaseBtn().click();
+
+        editSrmaPage
+            .withStatus("TrustConsidering")
+            .withDayTrustContacted("05")
+            .withMonthTrustContacted("06")
+            .withYearTrustContacted("2022")
+            .withNotes("This is my notes")
+            .save();
+
+        actionSummaryTable
+			.getOpenAction("SRMA")
+			.then(row =>
+			{
+				row.hasName("SRMA")
+				row.hasStatus("Trust considering")
+				row.select();
+			});
+
+        viewSrmaPage
+            .hasStatus("Trust considering")
+            .hasDateTrustContacted("05 June 2022")
+            .hasNotes("This is my notes");
     });
 });

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
@@ -244,6 +244,6 @@ describe("Editing a case", () =>
 
         CaseManagementPage.getAddToCaseBtn().click();
         AddToCasePage.getAddToCaseBtn().click();
-        AddToCasePage.hasValidationError("Please select an action to add.");
+        AddToCasePage.hasValidationError("Select an action or decision");
     });
 });

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/find-trust-route.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/find-trust-route.cy.ts
@@ -1,4 +1,4 @@
-const { Logger } = require("../../common/logger");
+import { Logger } from "../../common/logger";
 
 describe("User interactions via Find Trust route", () => {
 	beforeEach(() => {

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/addToCasePage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/addToCasePage.ts
@@ -1,21 +1,36 @@
+import { Logger } from "../../common/logger";
+
 class AddToCasePage {
 
     constructor() {
     }
 
-    getAddToCaseBtn() {
+    public getAddToCaseBtn() {
         return cy.get('[data-prevent-double-click="true"]', { timeout: 30000 }).contains('Add to case');
     }
 
-    getCaseActionRadio(option: string) {
-        return cy.get('[value="' + option + '"]');
+    public getCaseActionRadio(option: string) {
+        return cy.getByTestId(option);
     }
 
-    addToCase(option: string) {
+    public addToCase(option: string) {
         this.getCaseActionRadio(option).click();
     }
 
-    hasValidationError(value: string) {
+    public hasActions(actions: Array<string>): this
+    {
+        Logger.Log(`Case has available actions ${actions.join(",")}`);
+
+        cy.get('.govuk-radios__label')
+            .should("have.length", actions.length)
+            .each(($elem, index) => {
+                expect($elem.text().trim()).to.equal(actions[index]);
+            });
+
+        return this;
+    }
+
+    public hasValidationError(value: string) {
         cy.getById("errorSummary").should("contain.text", value);
 
         return this;

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -472,7 +472,7 @@ class CaseManagementPage {
     {
         Logger.Log(`Adding case action ${action}`);
         this.getAddCaseAction().click();
-        cy.get(`[value=${action}]`).check();
+        cy.getByTestId(action).check();
         cy.getByTestId("add-action-to-case").click();
 
         return this;

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Cases/CaseActionEnum.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Cases/CaseActionEnum.cs
@@ -1,19 +1,28 @@
-﻿namespace ConcernsCaseWork.Service.Cases
+﻿using System.ComponentModel;
+
+namespace ConcernsCaseWork.Service.Cases
 {
 	public enum CaseActionEnum
 	{
+		[Description("Decision")]
 		Decision,
 		DfESupport,
 		FinancialForecast,
+		[Description("Financial plan")]
 		FinancialPlan,
 		FinancialReturns,
 		FinancialSupport,
 		ForcedTermination,
+		[Description("NTI: Notice to improve")]
 		Nti,
 		RecoveryPlan,
+		[Description("SRMA (School Resource Management Adviser)")]
 		Srma,
+		[Description("TFF (Trust Financial Forecast)")]
 		TrustFinancialForecast,
+		[Description("NTI: Under consideration")]
 		NtiUnderConsideration,
+		[Description("NTI: Warning letter")]
 		NtiWarningLetter
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml.cs
@@ -120,7 +120,7 @@ public class SelectCaseTypePageModel : AbstractPageModel
 			RadioItems = radioItems,
 			SelectedId = selectedId,
 			Required = true,
-			DisplayName = "Case type"
+			DisplayName = "case type"
 		};
 	}
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Index.cshtml
@@ -1,5 +1,6 @@
 ﻿@page "/case/{urn:long}/management/action"
 @model ConcernsCaseWork.Pages.Case.Management.Action.IndexPageModel
+@using ConcernsCaseWork.Helpers;
 @using ConcernsCaseWork.Service.Cases;
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using NetEscapades.AspNetCore.SecurityHeaders
@@ -20,156 +21,14 @@
     {
         <h1 class="govuk-heading-l">Add to case</h1>
 
-        @if (!string.IsNullOrEmpty((string)TempData.Peek("CaseAction.Error")))
-        {
-            <div tabindex="-1" role="group" id="errorSummary" class="govuk-error-summary" data-module="error-summary" aria-labelledby="errorSummary-heading">
-                <h2 id="error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
-                <div class="govuk-error-summary__body">
-                    <ul class="govuk-list govuk-error-summary__list">
-                        <li>
-                            <a data-testid="error-text" href="#">@TempData["CaseAction.Error"]</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        }
-
-        <h2 class="govuk-heading-m">What action are you taking?</h2>
-
-        <div tabindex="-1" role="group" id="errorSummary" class="govuk-error-summary moj-hidden" aria-labelledby="error-summary-title" data-module="error-summary"></div>
+        <partial name="_ValidationErrors" />
 
         <!-- FORM -->
         <form role="form" method="post" id="case-action-form" novalidate>
 
             <div class="govuk-form-group govuk-!-margin-top-6">
                 <fieldset class="govuk-fieldset">
-
-                    <legend class="govuk-fieldset__legend govuk-!-font-weight-bold">
-                    </legend>
-
-                    <div class="govuk-radios" data-module="govuk-radios">
-
-                        <!--Case Action radios-->
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="action" name="action" type="radio" value="@CaseActionEnum.Decision">
-                            <label class="govuk-label govuk-radios__label" for="action">
-                                <span>
-                                    Decision
-                                </span>
-                            </label>
-                        </div>
-
-
-                        <div class="govuk-radios__item govuk-visually-hidden">
-                            <input class="govuk-radios__input" id="action" name="action" type="radio" value="@CaseActionEnum.DfESupport" disabled="disabled">
-                            <label class="govuk-label govuk-radios__label" for="action">
-                                <span>
-                                    DfE support
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item govuk-visually-hidden">
-                            <input class="govuk-radios__input" id="action-2" name="action" type="radio" value="@CaseActionEnum.FinancialForecast" disabled="disabled">
-                            <label class="govuk-label govuk-radios__label" for="action-2">
-                                <span>
-                                    Financial forecast
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="action-3" name="action" type="radio" value="@CaseActionEnum.FinancialPlan">
-                            <label class="govuk-label govuk-radios__label" for="action-3">
-                                <span>
-                                    Financial plan
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item govuk-visually-hidden">
-                            <input class="govuk-radios__input" id="action-4" name="action" type="radio" value="@CaseActionEnum.FinancialReturns" disabled="disabled">
-                            <label class="govuk-label govuk-radios__label" for="action-4">
-                                <span>
-                                    Financial returns
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item govuk-visually-hidden">
-                            <input class="govuk-radios__input" id="action-5" name="action" type="radio" value="@CaseActionEnum.FinancialSupport" disabled="disabled">
-                            <label class="govuk-label govuk-radios__label" for="action-5">
-                                <span>
-                                    Financial support
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item govuk-visually-hidden">
-                            <input class="govuk-radios__input" id="action-6" name="action" type="radio" value="@CaseActionEnum.ForcedTermination" disabled="disabled">
-                            <label class="govuk-label govuk-radios__label" for="action-6">
-                                <span>
-                                    Forced termination
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item govuk-visually-hidden">
-                            <input class="govuk-radios__input" id="action-8" name="action" type="radio" value="@CaseActionEnum.RecoveryPlan" disabled="disabled">
-                            <label class="govuk-label govuk-radios__label" for="action-8">
-                                <span>
-                                    Recovery plan
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="action-nti-uc" name="action" type="radio" value="@CaseActionEnum.NtiUnderConsideration">
-                            <label class="govuk-label govuk-radios__label" for="action-nti-uc">
-                                <span>
-                                    NTI: Under consideration
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="action-nti-wl" name="action" type="radio" value="@CaseActionEnum.NtiWarningLetter">
-                            <label class="govuk-label govuk-radios__label" for="action-nti-wl">
-                                <span>
-                                    NTI: Warning letter
-                                </span>
-                            </label>
-                        </div>
-
-
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="action-nti" name="action" type="radio" value="@CaseActionEnum.Nti">
-                            <label class="govuk-label govuk-radios__label" for="action-nti">
-                                <span>
-                                    NTI: Notice to improve
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="action-9" name="action" type="radio" value="@CaseActionEnum.Srma">
-                            <label class="govuk-label govuk-radios__label" for="action-9">
-                                <span>
-                                    SRMA (School Resource Management Adviser)
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="action-10" name="action" type="radio" value="@CaseActionEnum.TrustFinancialForecast">
-                            <label class="govuk-label govuk-radios__label" for="action-10">
-                                <span>
-                                    TFF (Trust Financial Forecast)
-                                </span>
-                            </label>
-                        </div>
-
-                    </div>
+                    <partial name="Components/_RadioList" model="Model.CaseActionEnum" />
 
                 </fieldset>
             </div>
@@ -183,12 +42,5 @@
             </div>
 
         </form>
-
-        <script type="application/javascript" nonce="@nonce">
-            $(function () {
-                let validator = formValidator($("#case-action-form")[0]);
-                addCaseActionValidator(validator);
-            });
-        </script>
     }
 </div>


### PR DESCRIPTION
**What is the change?**

only available actions for non concerns are decision, TFF and SRMA

moved the select case action page over to the component framework

added basic srma create to the non concerns journey

**Why do we need the change?**

only certain case actions are allowed for non concerns

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=127826
