### PR TITLE
Add ipv4 addresses to MSSQL Firewall

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -184,6 +184,7 @@ No resources.
 | <a name="input_monitor_slack_channel"></a> [monitor\_slack\_channel](#input\_monitor\_slack\_channel) | Slack channel name/id to send messages to | `string` | n/a | yes |
 | <a name="input_monitor_slack_webhook_receiver"></a> [monitor\_slack\_webhook\_receiver](#input\_monitor\_slack\_webhook\_receiver) | A Slack App webhook URL | `string` | n/a | yes |
 | <a name="input_mssql_database_name"></a> [mssql\_database\_name](#input\_mssql\_database\_name) | The name of the MSSQL database to create. Must be set if `enable_mssql_database` is true | `string` | n/a | yes |
+| <a name="input_mssql_firewall_ipv4_allow_list"></a> [mssql\_firewall\_ipv4\_allow\_list](#input\_mssql\_firewall\_ipv4\_allow\_list) | A list of IPv4 Addresses that require remote access to the MSSQL Server | `list(string)` | `[]` | no |
 | <a name="input_mssql_server_admin_password"></a> [mssql\_server\_admin\_password](#input\_mssql\_server\_admin\_password) | The administrator password for the MSSQL server. Must be set if `enable_mssql_database` is true | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_redis_cache_capacity"></a> [redis\_cache\_capacity](#input\_redis\_cache\_capacity) | Redis Cache Capacity | `number` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -10,9 +10,10 @@ module "azure_container_apps_hosting" {
 
   enable_container_registry = local.enable_container_registry
 
-  enable_mssql_database       = local.enable_mssql_database
-  mssql_server_admin_password = local.mssql_server_admin_password
-  mssql_database_name         = local.mssql_database_name
+  enable_mssql_database          = local.enable_mssql_database
+  mssql_server_admin_password    = local.mssql_server_admin_password
+  mssql_database_name            = local.mssql_database_name
+  mssql_firewall_ipv4_allow_list = local.mssql_firewall_ipv4_allow_list
 
   image_name = local.image_name
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -18,6 +18,7 @@ locals {
   enable_mssql_database                         = var.enable_mssql_database
   mssql_server_admin_password                   = var.mssql_server_admin_password
   mssql_database_name                           = var.mssql_database_name
+  mssql_firewall_ipv4_allow_list                = var.mssql_firewall_ipv4_allow_list
   redis_cache_sku                               = var.redis_cache_sku
   redis_cache_capacity                          = var.redis_cache_capacity
   enable_cdn_frontdoor                          = var.enable_cdn_frontdoor

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -231,3 +231,9 @@ variable "mssql_database_name" {
   description = "The name of the MSSQL database to create. Must be set if `enable_mssql_database` is true"
   type        = string
 }
+
+variable "mssql_firewall_ipv4_allow_list" {
+  description = "A list of IPv4 Addresses that require remote access to the MSSQL Server"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
**What is the change?**
Permit a set of IPv4 Addresses to connect to the MSSQL Server

**Why do we need the change?**
Allows trusted engineers to connect remotely to the MSSQL Server