### PR TITLE
128773: Add feature flag for Non Concerns page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -38,6 +38,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.5.1" />
 		<PackageReference Include="Microsoft.Identity.Web.UI" Version="1.25.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork/FeatureFlags/Constants.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/FeatureFlags/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace ConcernsCaseWork.FeatureFlags
+{
+	public static class Constants
+	{
+		public const string IsNonConcernsPageEnabled = "IsNonConcernsPageEnabled";
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement.Mvc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,6 +25,7 @@ namespace ConcernsCaseWork.Pages.Case.CreateCase;
 
 [Authorize]
 [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+[FeatureGate(FeatureFlags.Constants.IsNonConcernsPageEnabled)]
 public class SelectTrustPageModel : AbstractPageModel
 {
 	private readonly ITrustModelService _trustModelService;

--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
 using Microsoft.Identity.Web;
 using System;
 using System.Reflection;
@@ -56,6 +57,8 @@ namespace ConcernsCaseWork
 			{
 				options.HtmlHelperOptions.ClientValidationEnabled = false;
 			});
+
+			services.AddFeatureManagement();
 
 			// Configuration options
 			services.AddConfigurationOptions(Configuration);

--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
@@ -33,7 +33,7 @@
 		"ApiEndpoint": "http://localhost",
 		"ApiKey": "app-key",
 		"ReleaseTag": "insert-a-unique-release-tag-here-during-CD",
-		"CaseArchivePassword":  "insert-case-archive-password"
+		"CaseArchivePassword": "insert-case-archive-password"
 	},
 	"ConcernsCaseworkApi": {
 		"ApiKeys": "app-key"
@@ -57,6 +57,9 @@
 	"PreventRedisThreadTheft": false,
 	"ApplicationInsights": {
 		"ConnectionString": "secret"
+	},
+	"FeatureManagement": {
+		"IsNonConcernsPageEnabled": true // Feature flag set to on
 	}
 }
  


### PR DESCRIPTION
**What is the change?**
Added feature flag to allow toggling first page in non concerns creation flow on or off. No state allows user to access the page via the Url. Off state returns page not found message.

**Why do we need the change?**
Prevent users accessing functionality we are yet to fully release to them

**What is the impact?**
Gives us control over when the page is made available to user

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/128773
