### PR TITLE
128773: Removed comments against feature in appsettings.json

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
@@ -59,7 +59,7 @@
 		"ConnectionString": "secret"
 	},
 	"FeatureManagement": {
-		"IsNonConcernsPageEnabled": true // Feature flag set to on
+		"IsNonConcernsPageEnabled": true
 	}
 }
  


### PR DESCRIPTION
**What is the change?**
Removal of comments in appsettings.json 

**Why do we need the change?**
Prevent error in github action when running set-appsettings-release-tag.sh to add the release tag to the appsettings.json file caused by // used for comments. The result is a blank appsettings.json file which prevents the application and a failed 
deployment.

Example of error message in [Build and push docker image](https://github.com/DFE-Digital/amsd-casework/actions/runs/4948440693/jobs/8849171910)  line 1135 

`#38 [final 13/13] RUN ./set-appsettings-release-tag.sh "1b9a23fdefe6890e3723fbb3b671b248443969cb"
#38 0.421 parse error: Invalid numeric literal at line 62, column 38
#38 DONE 0.6s`

Example of previous build with no error [Build and push docker image](https://github.com/DFE-Digital/amsd-casework/actions/runs/4947543784/jobs/8847064505) line 1152

`#38 [final 13/13] RUN ./set-appsettings-release-tag.sh "9ffa115b1d74f52e3d4ad18e3375152a6b86e0fa"
#38 DONE 0.5s`

**What is the impact?**
Allows set-appsettings-release-tag.sh to run successfully

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/128773
