### PR TITLE
128960: handle non concerns when user state is not found

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Create/SelectTrustPageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Create/SelectTrustPageModelTests.cs
@@ -9,7 +9,6 @@ using ConcernsCaseWork.Shared.Tests.Factory;
 using ConcernsCaseWork.Shared.Tests.MockHelpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -19,8 +18,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading.Tasks;
 
@@ -132,16 +129,10 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Create
 		{
 			// arrange
 			var mockLogger = new Mock<ILogger<SelectTrustPageModel>>();
-			var mockTrustService = new Mock<ITrustModelService>();
 			var mockUserService = new Mock<IUserStateCachedService>();
 			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
 
-			var searchResults = TrustFactory.BuildListTrustSummaryModel();
-			var searchResultsPageData = new TrustSearchModelPageResponseData { IsMoreDataOnServer = false, TotalMatchesFromApi = searchResults.Count };
-
-			mockTrustService
-				.Setup(t => t.GetTrustsBySearchCriteria(It.Is<TrustSearch>(s => s.Ukprn == searchString && s.GroupName == searchString && s.CompaniesHouseNumber == searchString)))
-				.ReturnsAsync((searchResultsPageData, searchResults));
+			var mockTrustService = CreateTrustServiceMock(searchString);
 
 			var sut = SetupPageModel(mockLogger, mockTrustService, mockUserService, mockClaimsPrincipalHelper);
 
@@ -170,230 +161,46 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Create
 			mockLogger.VerifyNoOtherCalls();
 		}
 
-		//[Test]
-		//[TestCase("abc")]
-		//[TestCase("1234")]
-		//public async Task WhenOnGetTrustsSearchResult_WithValidSearchQuery_ReturnsSearchResults(string searchString)
-		//{
-		//	// arrange
-		//	var mockLogger = new Mock<ILogger<SelectTrustPageModel>>();
-		//	var mockTrustService = new Mock<ITrustModelService>();
-		//	var mockUserService = new Mock<IUserStateCachedService>();
-		//	var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
+		[Test]
+		public async Task When_OnPost_WithValidSearchQuery_UserStateNotPopulated_ReturnsSearchResults()
+		{
+			// This can happen if the user navigates directly to the page rather than through the homepage
+			// The homepage creates the user state
+			// arrange
+			var searchString = "abc";
+			var mockLogger = new Mock<ILogger<SelectTrustPageModel>>();
+			var mockUserService = new Mock<IUserStateCachedService>();
+			var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
 
-		//	var searchResults = TrustFactory.BuildListTrustSummaryModel();
+			var mockTrustService = CreateTrustServiceMock(searchString);
 
-		//	mockTrustService
-		//		.Setup(t => t.GetTrustsBySearchCriteria(It.Is<TrustSearch>(s => s.Ukprn == searchString && s.GroupName == searchString && s.CompaniesHouseNumber == searchString)))
-		//		.ReturnsAsync(searchResults);
+			var sut = SetupPageModel(mockLogger, mockTrustService, mockUserService, mockClaimsPrincipalHelper);
 
-		//	var sut = SetupPageModel(mockLogger, mockTrustService, mockUserService, mockClaimsPrincipalHelper);
+			var userName = sut.User.Identity.Name;
+			var userState = new UserState(userName);
+			mockUserService.Setup(x => x.GetData(It.IsAny<string>())).ReturnsAsync(() => null);
+			mockUserService.Setup(x => x.StoreData(userName, userState)).Returns(Task.CompletedTask);
 
-		//	// act
-		//	sut.FindTrustModel.SelectedTrustUkprn = searchString;
-		//	var result = await sut.OnPostSelectedTrust();
+			// act
+			sut.FindTrustModel.SelectedTrustUkprn = searchString;
+			var result = await sut.OnPostSelectedTrust();
 
-		//	// assert
-		//	Assert.Multiple(() =>
-		//	{
-		//		Assert.That(sut.TrustAddress, Is.Null);
-		//		Assert.That(sut.TempData["Error.Message"], Is.Null);
+			Assert.That(result, Is.TypeOf<RedirectToPageResult>());
+		}
 
-		//		Assert.That(result, Is.TypeOf<JsonResult>());
+		private static Mock<ITrustModelService> CreateTrustServiceMock(string searchString)
+		{
+			var result = new Mock<ITrustModelService>();
 
-		//		var jsonResult = result as JsonResult;
-		//		Assert.That(jsonResult?.Value, Is.Not.Null);
-		//		Assert.That(jsonResult.Value, Is.TypeOf<List<TrustSearchModel>>());
+			var searchResults = TrustFactory.BuildListTrustSummaryModel();
+			var searchResultsPageData = new TrustSearchModelPageResponseData { IsMoreDataOnServer = false, TotalMatchesFromApi = searchResults.Count };
 
-		//		var searchModelResult = jsonResult.Value as List<TrustSearchModel>;
-		//		Assert.That(searchModelResult, Is.Not.Null);
-		//		Assert.That(searchModelResult, Has.Count.EqualTo(searchResults.Count));
-		//	});
+			result
+				.Setup(t => t.GetTrustsBySearchCriteria(It.Is<TrustSearch>(s => s.Ukprn == searchString && s.GroupName == searchString && s.CompaniesHouseNumber == searchString)))
+				.ReturnsAsync((searchResultsPageData, searchResults));
 
-		//	mockLogger.VerifyLogInformationWasCalled("OnGetTrustsSearchResult");
-		//	mockLogger.VerifyLogErrorWasNotCalled();
-		//	mockLogger.VerifyNoOtherCalls();
-		//}
-
-		//[Test]
-		//[TestCase("ab")]
-		//[TestCase("1")]
-		//[TestCase("")]
-		//[TestCase(null)]
-		//public async Task WhenOnGetTrustsSearchResult_WithInvalidSearchQuery_DoesNotErrorAndReturnsEmptySearchResults(string searchString)
-		//{
-		//	// arrange
-		//	var mockLogger = new Mock<ILogger<SelectTrustPageModel>>();
-		//	var mockTrustService = new Mock<ITrustModelService>();
-		//	var mockUserService = new Mock<IUserStateCachedService>();
-		//	var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
-
-		//	var sut = SetupPageModel(mockLogger, mockTrustService, mockUserService, mockClaimsPrincipalHelper);
-
-		//	// act
-		//	sut.FindTrustModel.SelectedTrustUkprn = searchString;
-		//	var result = await sut.OnPostSelectedTrust();
-
-		//	// assert
-		//	Assert.Multiple(() =>
-		//	{
-		//		Assert.That(sut.TrustAddress, Is.Null);
-		//		Assert.That(sut.TempData["Error.Message"], Is.Null);
-		//		Assert.That(result, Is.TypeOf<JsonResult>());
-
-		//		var jsonResult = result as JsonResult;
-		//		Assert.That(jsonResult?.Value, Is.Not.Null);
-		//		Assert.That(jsonResult.Value, Is.TypeOf<List<TrustSearchModel>>());
-
-		//		var searchModelResult = jsonResult.Value as List<TrustSearchModel>;
-		//		Assert.That(searchModelResult, Is.Not.Null);
-		//		Assert.That(searchModelResult, Has.Count.EqualTo(0));
-		//	});
-
-		//	mockLogger.VerifyLogInformationWasCalled("OnGetTrustsSearchResult");
-		//	mockLogger.VerifyLogErrorWasNotCalled();
-		//	mockLogger.VerifyNoOtherCalls();
-		//}
-
-		//[Test]
-		//[TestCase("abc")]
-		//[TestCase("123")]
-		//public async Task WhenOnGetTrustsSearchResult_WithErrorThrownBySearchService_ReturnsErrorStatusCode(string searchString)
-		//{
-		//	// arrange
-		//	var mockLogger = new Mock<ILogger<SelectTrustPageModel>>();
-		//	var mockTrustService = new Mock<ITrustModelService>();
-		//	var mockUserService = new Mock<IUserStateCachedService>();
-		//	var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
-
-		//	var sut = SetupPageModel(mockLogger, mockTrustService, mockUserService, mockClaimsPrincipalHelper);
-
-		//	mockTrustService
-		//		.Setup(t => t.GetTrustsBySearchCriteria(It.Is<TrustSearch>(s => s.Ukprn == searchString && s.GroupName == searchString && s.CompaniesHouseNumber == searchString)))
-		//		.Throws(() => new Exception("some error message"));
-
-		//	// act
-		//	sut.FindTrustModel.SelectedTrustUkprn = searchString;
-		//	var result = await sut.OnPostSelectedTrust();
-
-		//	// assert
-		//	Assert.Multiple(() =>
-		//	{
-		//		Assert.That(sut.TrustAddress, Is.Null);
-		//		Assert.That(sut.TempData["Error.Message"], Is.Null);
-		//		Assert.That(result, Is.TypeOf<ObjectResult>());
-
-		//		Assert.That(result, Is.Not.Null);
-		//		Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo((int)HttpStatusCode.InternalServerError));
-		//	});
-
-		//	mockLogger.VerifyLogInformationWasCalled("OnGetTrustsSearchResult");
-		//	mockLogger.VerifyLogErrorWasCalled("some error message");
-		//	mockLogger.VerifyNoOtherCalls();
-		//}
-
-		//[Test]
-		//[TestCase("abcdef")]
-		//[TestCase("1234")]
-		//public async Task WhenOnGetSelectedTrust_WithValidTrustUkPrn_CachesTrustAndRedirectsToNextStep(string trustUkPrn)
-		//{
-		//	// arrange
-		//	var mockLogger = new Mock<ILogger<SelectTrustPageModel>>();
-		//	var mockTrustService = new Mock<ITrustModelService>();
-		//	var mockUserService = new Mock<IUserStateCachedService>();
-		//	var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
-
-		//	var userName = "some name of a user";
-
-		//	mockUserService
-		//		.Setup(s => s.GetData(userName))
-		//		.ReturnsAsync(new UserState(userName){TrustUkPrn = trustUkPrn});
-
-		//	mockUserService
-		//		.Setup(s => s.StoreData(It.IsAny<string>(), It.IsAny<UserState>()))
-		//		.Verifiable();
-
-		//	mockClaimsPrincipalHelper
-		//		.Setup(t => t.GetPrincipalName(It.IsAny<ClaimsPrincipal>()))
-		//		.Returns(userName);
-
-		//	var sut = SetupPageModel(mockLogger, mockTrustService, mockUserService, mockClaimsPrincipalHelper);
-
-		//	// act
-		//	sut.FindTrustModel.SelectedTrustUkprn = trustUkPrn;
-		//	var result = await sut.OnPostSelectedTrust();
-
-		//	// assert
-		//	Assert.Multiple(() =>
-		//	{
-		//		Assert.That(sut.TrustAddress, Is.Null);
-		//		Assert.That(sut.TempData["Error.Message"], Is.Null);
-
-		//		Assert.That(result, Is.TypeOf<JsonResult>());
-
-		//		var jsonResult = result as JsonResult;
-		//		Assert.That(jsonResult?.Value, Is.Not.Null);
-		//		Assert.That(jsonResult.Value?.ToString(), Is.EqualTo("{ redirectUrl = /case/create/type }"));
-
-		//	});
-
-		//	mockUserService.Verify(s => s.StoreData(userName, It.Is<UserState>(us => us.TrustUkPrn == trustUkPrn)));
-		//	mockLogger.VerifyLogInformationWasCalled("OnGetSelectedTrust");
-		//	mockLogger.VerifyLogErrorWasNotCalled();
-		//	mockLogger.VerifyNoOtherCalls();
-		//}
-
-		//[Test]
-		//[TestCase(null)]
-		//[TestCase("")]
-		//[TestCase("12")]
-		//[TestCase("1")]
-		//[TestCase("contains-hyphen")]
-		//public async Task WhenOnGetSelectedTrust_WithInvalidTrustUkPrn_Errors(string trustUkPrn)
-		//{
-		//	// arrange
-		//	var mockLogger = new Mock<ILogger<SelectTrustPageModel>>();
-		//	var mockTrustService = new Mock<ITrustModelService>();
-		//	var mockUserService = new Mock<IUserStateCachedService>();
-		//	var mockClaimsPrincipalHelper = new Mock<IClaimsPrincipalHelper>();
-
-		//	var userName = "some name of a user";
-
-		//	mockUserService
-		//		.Setup(s => s.GetData(userName))
-		//		.ReturnsAsync(new UserState(userName){TrustUkPrn = trustUkPrn});
-
-		//	mockUserService
-		//		.Setup(s => s.StoreData(It.IsAny<string>(), It.IsAny<UserState>()))
-		//		.Verifiable();
-
-		//	mockClaimsPrincipalHelper
-		//		.Setup(t => t.GetPrincipalName(It.IsAny<ClaimsPrincipal>()))
-		//		.Returns(userName);
-
-		//	var sut = SetupPageModel(mockLogger, mockTrustService, mockUserService, mockClaimsPrincipalHelper);
-
-		//	// act
-		//	sut.FindTrustModel.SelectedTrustUkprn = trustUkPrn;
-		//	var result = await sut.OnPostSelectedTrust();
-
-		//	// assert
-		//	Assert.Multiple(() =>
-		//	{
-		//		Assert.That(sut.TrustAddress, Is.Null);
-		//		Assert.That(sut.TempData["Error.Message"], Is.Null);
-		//		Assert.That(result, Is.TypeOf<ObjectResult>());
-
-		//		Assert.That(result, Is.Not.Null);
-		//		Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo((int)HttpStatusCode.InternalServerError));
-		//	});
-
-		//	mockUserService.Verify(s => s.StoreData(userName, It.Is<UserState>(us => us.TrustUkPrn == trustUkPrn)),
-		//		Times.Never);
-		//	mockLogger.VerifyLogInformationWasCalled("OnGetSelectedTrust");
-		//	mockLogger.VerifyLogErrorWasCalled($"Selected trust is incorrect - {trustUkPrn}");
-		//	mockLogger.VerifyNoOtherCalls();
-		//}
+			return result;
+		}
 
 		private static SelectTrustPageModel SetupPageModel(
 			IMock<ILogger<SelectTrustPageModel>> mockLogger,

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml.cs
@@ -87,13 +87,6 @@ public class SelectTrustPageModel : AbstractPageModel
 		CreateCaseStep = CreateCaseSteps.SearchForTrust;
 	}
 
-	private async Task RestoreTrustUkprnFromCache()
-	{
-		ModelState.ClearValidationState(nameof(FindTrustModel.SelectedTrustUkprn));
-		FindTrustModel.SelectedTrustUkprn = (await GetUserState()).TrustUkPrn;
-		ModelState.SetModelValue(nameof(FindTrustModel.SelectedTrustUkprn), new ValueProviderResult(FindTrustModel.SelectedTrustUkprn));
-	}
-
 	public async Task<ActionResult> OnPostSelectedTrust()
 	{
 		_logger.LogMethodEntered();
@@ -122,11 +115,10 @@ public class SelectTrustPageModel : AbstractPageModel
 			return HandleExceptionForAjaxCall(ex);
 		}
 
-
 		async Task CacheTrustUkPrn()
 		{
 			var userName = GetUserName();
-			var userState = await _cachedUserService.GetData(userName);
+			var userState = await _cachedUserService.GetData(userName) ??  new UserState(GetUserName());
 			userState.TrustUkPrn = FindTrustModel.SelectedTrustUkprn;
 			await _cachedUserService.StoreData(userName, userState);
 		}
@@ -163,8 +155,6 @@ public class SelectTrustPageModel : AbstractPageModel
 	}
 
 	private string GetUserName() => _claimsPrincipalHelper.GetPrincipalName(User);
-
-	async Task<UserState> GetUserState() => await _cachedUserService.GetData(GetUserName());
 
 	public enum CaseTypes
 	{


### PR DESCRIPTION
**What is the change?**

fix issue where non concerns page fails if the cache is empty

**Why do we need the change?**

when redis is empty there will be no user state, if you go straight to the non concerns page (which we have done for the demo) this error will occur

copied the existing fix from the create case page that creates a new user state if one does not already exist

in the future the users will go to non concerns from the home page, rather than a direct link

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=128960
