### PR TITLE
Changes to branches which trigger workflows

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -3,7 +3,7 @@ name: Deploy to environment
 on:
   push:
     branches:
-      - develop
+      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
     - main
-    - develop
   pull_request:
-    branches: [ main, develop, release/** ]
+    branches: [ main, release/** ]
     types: [ opened, synchronize, reopened ]
 
 jobs:


### PR DESCRIPTION
**What is the change?**
Amended github actions to change trigger branches from develop to main. Remove reference to develop in all actions for completeness

**Why do we need the change?**
We have decided to adopt Main as our default branch making develop redundant and therefore no longer required in workflow.

**What is the impact?**
Github actions will no longer be triggered by any changes to develop branch

**Azure DevOps Ticket**
[129147](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/129147)

