### PR TITLE
129832: removed case history from non concerns cases

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -7,68 +7,16 @@ class CaseManagementPage {
         return cy.get('h1[class="govuk-heading-l"]');
     }
 
-    getHeadingInnerText() {
-        return cy.get('span.govuk-caption-m');
-    }
-
-    getSubHeadingText() {
-        return cy.get('[class="govuk-caption-m"]');
-    }
-
-    getTrustHeadingText() {
-        return cy.get('h2[class="govuk-heading-m"]');
-    }
-
-    getConcernEditBtn() {
-        return cy.get('.govuk-table-case-details__cell_no_border [href*="edit_rating"]');
-    }
-
-    getConcernTable() {
-        return cy.get('[class^="govuk-table-case-details"]');
-    }
-
-    getConcernTableAddConcernBtn() {
-        return cy.contains("Add concern");
-    }
-
     getAddToCaseBtn() {
         return cy.get('[role="button"]').contains('Add to case');
-    }
-
-    getCaseDetailsTab() {
-        return cy.get('[id="tab_case-details"]');
     }
 
     getTrustOverviewTab() {
         return cy.get('[id="tab_trust-overview"]');
     }
 
-    getOpenActionsTable() {
-        return cy.get('[id="open-case-actions"]');
-    }
-
-    getClosedActionsTable() {
-        return cy.get('[id="close-case-actions"]');
-    }
-
     getCloseCaseBtn() {
         return cy.get('#close-case-button');
-    }
-
-    getLiveSRMALink() {
-        return cy.get('a[id="open-case-actions"][href*="/action/srma/"]');
-    }
-
-    getOpenActionLink(action) {
-        return cy.get('[id="open-case-actions"] [href*="/action/' + action + '/"]');
-    }
-
-    getClosedActionLink(action) {
-        return cy.get('[id="closed-case-actions"] [href*="/action/' + action + '/"]');
-    }
-
-    geBackToCaseworkBtn() {
-        return cy.get('[class="buttons-topOfPage"]');
     }
 
     getCaseID() {
@@ -77,46 +25,6 @@ class CaseManagementPage {
 
     getBackBtn() {
         return cy.get('[id="back-link-event"]');
-    }
-
-    //methods
-
-    closeAllOpenConcerns() {
-        const elem = '.govuk-table-case-details__cell_no_border [href*="edit_rating"]';
-        if (Cypress.$(elem).length > 0) { //Cypress.$ needed to handle element missing exception
-
-            this.getConcernEditBtn().its('length').then(($elLen) => {
-
-                while ($elLen > 0) {
-
-                    const $elem = Cypress.$('.govuk-table-case-details__cell_no_border [href*="edit_rating"]');
-                    cy.log("About to close all lopen concerns");
-                    cy.log("$elem.length =" + ($elem).length)
-
-                    if (($elem).length > 0) { //Cypress.$ needed to handle element missing exception
-
-                        this.getConcernEditBtn().its('length').then(($elLen) => {
-                            cy.log("Method $elLen " + $elLen)
-                            while ($elLen > 0) {
-
-                                this.getConcernEditBtn().eq($elLen - 1).click();
-                                cy.get('[href*="closure"]').click();
-                                cy.get('.govuk-button-group [href*="edit_rating/closure"]:nth-of-type(1)').click();
-                                $elLen = $elLen - 1
-                                cy.log($elLen + " more open concerns")
-                            }
-                        });
-                    } else {
-                        cy.log('All concerns closed')
-                    }
-                }
-            });
-        }
-    }
-
-    checkForOpenActions() {
-        const $elem = Cypress.$('[id="open-case-actions"]');
-        return ($elem.length);
     }
 
     getCaseIDText() {
@@ -791,7 +699,14 @@ class CaseManagementPage {
 
         return this;
     }
+    
+    public hasNoCaseNarritiveFields(): this
+    {
+        Logger.Log("Has no case narritive fields");
+        cy.getByTestId("case-narritive-fields-container").should("not.exist");
 
+        return this;
+    }
 }
 
 export default new CaseManagementPage();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/viewClosedCasePage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/viewClosedCasePage.ts
@@ -11,11 +11,55 @@ export class ViewClosedCasePage
         return this;
     }
 
+    public hasTrust(value: string): this
+    {
+        Logger.Log(`Has trust ${value}`);
+
+        cy.getByTestId("trust-name").should("contain.text", value);
+
+        return this;
+    }
+
     public hasTerritory(value: string): this
     {
         Logger.Log(`Has territory ${value}`);
 
         cy.getByTestId(`territory_field`).should(`contain.text`, value);
+
+        return this;
+    }
+
+    public hasCaseOwner(value: string): this
+    {
+        Logger.Log(`Has case owner ${value}`);
+
+        cy.getByTestId("case-owner-field").contains(value, { matchCase: false });
+
+        return this;
+    }
+
+    public hasDateCreated(value: string): this
+    {
+        Logger.Log(`Has date created ${value}`);
+
+        cy.getByTestId("date-created-field").should("contain.text", value);
+
+        return this;
+    }
+
+    public hasDateClosed(value: string): this
+    {
+        Logger.Log(`Has date closed ${value}`);
+
+        cy.getByTestId("date-closed-field").should("contain.text", value);
+
+        return this;
+    }
+
+    public hasNoCaseNarritiveFields(): this
+    {
+        Logger.Log("Has no case narritive fields");
+        cy.getByTestId("case-narritive-fields-container").should("not.exist");
 
         return this;
     }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/Details.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/Details.cshtml
@@ -32,9 +32,6 @@
                 <!-- FORM -->
                 <form role="form" method="post" id="case-details-form" novalidate>
 
-                    <!-- Q Case History -->
-                    <partial name="Components/_TextArea" model="Model.CaseHistory" />
-
                     <div class="govuk-button-group">
                         <button id="create-case-button" data-testid="create-case-button" data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button">
                             Create case

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/Details.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/Details.cshtml.cs
@@ -29,9 +29,6 @@ namespace ConcernsCaseWork.Pages.Case.CreateCase.NonConcernsCase
 		public TrustDetailsModel TrustDetailsModel { get; private set; }
 		public IList<CreateRecordModel> CreateRecordsModel { get; private set; }
 
-		[BindProperty]
-		public TextAreaUiComponent CaseHistory { get; set; }
-
 		public DetailsPageModel(ICaseModelService caseModelService,
 			ITrustModelService trustModelService,
 			IUserStateCachedService userStateCache,
@@ -52,7 +49,6 @@ namespace ConcernsCaseWork.Pages.Case.CreateCase.NonConcernsCase
 			try
 			{
 				await LoadPageData();
-				LoadComponents();
 
 				return Page();
 			}
@@ -70,14 +66,6 @@ namespace ConcernsCaseWork.Pages.Case.CreateCase.NonConcernsCase
 			try
 			{
 				_logger.LogMethodEntered();
-
-				if (!ModelState.IsValid)
-				{
-					await LoadPageData();
-					LoadComponents();
-
-					return Page();
-				}
 
 				var createCaseModel = await BuildCreateCaseModel();
 
@@ -107,11 +95,6 @@ namespace ConcernsCaseWork.Pages.Case.CreateCase.NonConcernsCase
 			TrustDetailsModel = await _trustModelService.GetTrustByUkPrn(trustUkPrn);
 		}
 
-		private void LoadComponents()
-		{
-			CaseHistory = BuildCaseHistoryComponent(CaseHistory?.Text.StringContents);
-		}
-
 		private async Task<UserState> GetUserState()
 		{
 			var userState = await _userStateCache.GetData(User.Identity?.Name);
@@ -121,31 +104,16 @@ namespace ConcernsCaseWork.Pages.Case.CreateCase.NonConcernsCase
 			return userState;
 		}
 
-		private TextAreaUiComponent BuildCaseHistoryComponent(string contents = "")
-		=> new("case-history", nameof(CaseHistory), "Case history (optional)")
-		{
-			HintText = "You can record any information that gives you additional context to the case",
-			Text = new ValidateableString()
-			{
-				MaxLength = 4300,
-				StringContents = contents,
-				DisplayName = "Case history"
-			}
-		};
-
 		private async Task<CreateCaseModel> BuildCreateCaseModel()
 		{
 			var userState = await GetUserState();
 
 			var result = userState.CreateCaseModel;
 
-			var caseHistory = CaseHistory.Text.StringContents;
-
 			// get the trust being used for the case
 			var trust = await _trustService.GetTrustByUkPrn(userState.TrustUkPrn);
 
 			result.TrustUkPrn = trust.GiasData.UkPrn;
-			result.CaseHistory = caseHistory;
 			result.TrustCompaniesHouseNumber = trust.GiasData.CompaniesHouseNumber;
 
 			result.StatusId = (long)CaseStatus.Live;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -251,10 +251,10 @@
                     </tbody>
                 </table>
 
-                <h2 class="govuk-heading-m">Case details</h2>
-
                 @if (Model.CaseModel.IsConcernsCase())
                 {
+                    <h2 class="govuk-heading-m">Case details</h2>
+
                     <div class="govuk-accordion" data-module="govuk-accordion" id="accordion" data-testid="case-narritive-fields-container">
 
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -253,9 +253,10 @@
 
                 <h2 class="govuk-heading-m">Case details</h2>
 
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion">
-                    @if (Model.CaseModel.IsConcernsCase())
-                    {
+                @if (Model.CaseModel.IsConcernsCase())
+                {
+                    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion" data-testid="case-narritive-fields-container">
+
 
                         @* Issue *@
                         <div class="govuk-accordion__section">
@@ -366,27 +367,27 @@
                                 </div>
                             </div>
                         </div>
-                    }
 
-                    @* Case history *@
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-case-history-heading">Case history</span>
-                            </h2>
-                        </div>
-                        <div id="accordion-case-history-content" class="govuk-accordion__section-content" aria-labelledby="accordion-case-history-heading">
-                            @if (Model.IsEditableCase)
-                            {
-                                <div><a id="accordion-case-history-heading-edit" data-testid="edit-case-history" class="govuk-link float__right" href="@Request.Path/casehistory" aria-label="Change case history">Change</a></div>
-                            }
+                        @* Case history *@
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-case-history-heading">Case history</span>
+                                </h2>
+                            </div>
+                            <div id="accordion-case-history-content" class="govuk-accordion__section-content" aria-labelledby="accordion-case-history-heading">
+                                @if (Model.IsEditableCase)
+                                {
+                                    <div><a id="accordion-case-history-heading-edit" data-testid="edit-case-history" class="govuk-link float__right" href="@Request.Path/casehistory" aria-label="Change case history">Change</a></div>
+                                }
 
-                            <div class="govuk-!-width-three-quarters">
-                                <span class="govuk-body dfe-text-area-display" data-testid="case-history">@Model.CaseModel.CaseHistory</span>
+                                <div class="govuk-!-width-three-quarters">
+                                    <span class="govuk-body dfe-text-area-display" data-testid="case-history">@Model.CaseModel.CaseHistory</span>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                }
 
                 <h3 class="govuk-heading-m">Case actions and decisions</h3>
                 @if (Model.IsEditableCase)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
@@ -111,7 +111,7 @@
                 </dl>
 
                 <!--Accordions-->
-                <h2 class="govuk-heading-m govuk-!-margin-top-6">Case details</h2>
+                <h2 class="govuk-heading-m govuk-!-margin-top-6">Case actions and decisions</h2>
 
                 if (Model.CaseModel.IsConcernsCase())
                 {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
@@ -12,9 +12,9 @@
 }
 
 @section BeforeMain {
-	<div class="govuk-width-container">
-		<back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
-	</div>
+    <div class="govuk-width-container">
+        <back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
+    </div>
 }
 
 <div class="govuk-width-container">
@@ -34,38 +34,41 @@
                     @Model.CaseModel.Urn
                 </h1>
 
-                <h2 class="govuk-heading-m">@Model.TrustDetailsModel.GiasData.GroupNameTitle</h2>
+                <h2 class="govuk-heading-m" data-testid="trust-name">@Model.TrustDetailsModel.GiasData.GroupNameTitle</h2>
                 <span class="govuk-tag ragtag ragtag__grey">Closed</span>
 
                 @if (Model.CaseModel.IsArchived)
                 {
                     <div class="govuk-warning-text govuk-!-margin-top-6">
                         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text">
-                        <span class="govuk-warning-text__assistive">Warning</span>
-                        This case may have further concerns, decisions and details not shown here. Check the <a href="@caseArchiveLink">SFSO case archive</a>  (spreadsheet).
-                        <br />
-                        <span>Password: @Model.CaseArchivePassword</span>
-                    </strong>
+                        <strong class="govuk-warning-text__text">
+                            <span class="govuk-warning-text__assistive">Warning</span>
+                            This case may have further concerns, decisions and details not shown here. Check the <a href="@caseArchiveLink">SFSO case archive</a>  (spreadsheet).
+                            <br />
+                            <span>Password: @Model.CaseArchivePassword</span>
+                        </strong>
                     </div>
                 }
 
                 <dl class="govuk-summary-list summary-list-margin-0 govuk-!-margin-top-3">
 
                     <!-- Concern -->
-                    <div class="govuk-summary-list__row">
-	                    <dt class="dfe-width-30percent govuk-summary-list__key">
-		                    Concerns
-	                    </dt>
-	                    <dd class="govuk-summary-list__value" data-testid="concerns_field">
-		                    @foreach (var recordModel in Model.CaseModel.RecordsModel)
-		                    {
-			                    <p class="govuk-body caseDetail_type">
-				                    @recordModel.TypeModel.TypeDisplay
-			                    </p>
-		                    }
-	                    </dd>
-                    </div>
+                    @if (Model.CaseModel.IsConcernsCase())
+                    {
+                        <div class="govuk-summary-list__row">
+                            <dt class="dfe-width-30percent govuk-summary-list__key">
+                                Concerns
+                            </dt>
+                            <dd class="govuk-summary-list__value" data-testid="concerns_field">
+                                @foreach (var recordModel in Model.CaseModel.RecordsModel)
+                                {
+                                    <p class="govuk-body caseDetail_type">
+                                        @recordModel.TypeModel.TypeDisplay
+                                    </p>
+                                }
+                            </dd>
+                        </div>
+                    }
                     <div class="govuk-summary-list__row">
                         <dt class="dfe-width-30percent govuk-summary-list__key">
                             SFSO territory
@@ -85,7 +88,7 @@
                         <dt class="dfe-width-30percent govuk-summary-list__key">
                             Case Worker
                         </dt>
-                        <dd class="govuk-summary-list__value">
+                        <dd class="govuk-summary-list__value" data-testid="case-owner-field">
                             @Model.CaseModel.CreatedBy.FromEmailToFullName()
                         </dd>
                     </div>
@@ -93,7 +96,7 @@
                         <dt class="dfe-width-30percent govuk-summary-list__key">
                             Date created
                         </dt>
-                        <dd class="govuk-summary-list__value">
+                        <dd class="govuk-summary-list__value" data-testid="date-created-field">
                             @DateTimeHelper.ParseToDisplayDate(Model.CaseModel.CreatedAt)
                         </dd>
                     </div>
@@ -101,107 +104,111 @@
                         <dt class="dfe-width-30percent govuk-summary-list__key">
                             Date closed
                         </dt>
-                        <dd class="govuk-summary-list__value">
+                        <dd class="govuk-summary-list__value" data-testid="date-closed-field">
                             @DateTimeHelper.ParseToDisplayDate(Model.CaseModel.ClosedAt!.Value)
                         </dd>
                     </div>
                 </dl>
 
                 <!--Accordions-->
-                <h2 class="govuk-heading-m govuk-!-margin-top-6">Concern details</h2>
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-	                <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-default-heading-1">Issue</span>
-                            </h2>
-                        </div>
-                        <div aria-labelledby="accordion-default-heading-1" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-1" data-testid="issue_field">
-                            <div class="govuk-body details govuk-body-accordion-limit">
-                                <span class="dfe-text-area-display">@Model.CaseModel.Issue</span>
+                <h2 class="govuk-heading-m govuk-!-margin-top-6">Case details</h2>
+
+                if (Model.CaseModel.IsConcernsCase())
+                {
+                    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-testid="case-narritive-fields-container">
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-default-heading-1">Issue</span>
+                                </h2>
+                            </div>
+                            <div aria-labelledby="accordion-default-heading-1" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-1" data-testid="issue_field">
+                                <div class="govuk-body details govuk-body-accordion-limit">
+                                    <span class="dfe-text-area-display">@Model.CaseModel.Issue</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-default-heading-2">Current status</span>
-                            </h2>
-                        </div>
-                        <div aria-labelledby="accordion-default-heading-2" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-2" data-testid="status_field">
-                            <div class="govuk-body details govuk-body-accordion-limit">
-                                <span class="dfe-text-area-display">@Model.CaseModel.CurrentStatus</span>
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-default-heading-2">Current status</span>
+                                </h2>
+                            </div>
+                            <div aria-labelledby="accordion-default-heading-2" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-2" data-testid="status_field">
+                                <div class="govuk-body details govuk-body-accordion-limit">
+                                    <span class="dfe-text-area-display">@Model.CaseModel.CurrentStatus</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-default-heading-3">Case aim</span>
-                            </h2>
-                        </div>
-                        <div aria-labelledby="accordion-default-heading-3" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-3" data-testid="case_aim_field">
-                            <div class="govuk-body details govuk-body-accordion-limit">
-                                <span class="dfe-text-area-display">@Model.CaseModel.CaseAim</span>
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-default-heading-3">Case aim</span>
+                                </h2>
+                            </div>
+                            <div aria-labelledby="accordion-default-heading-3" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-3" data-testid="case_aim_field">
+                                <div class="govuk-body details govuk-body-accordion-limit">
+                                    <span class="dfe-text-area-display">@Model.CaseModel.CaseAim</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-default-heading-4">De-escalation point</span>
-                            </h2>
-                        </div>
-                        <div aria-labelledby="accordion-default-heading-4" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-4" data-testid="deescalation_point_field">
-                            <div class="govuk-body details govuk-body-accordion-limit">
-                                <span class="dfe-text-area-display">@Model.CaseModel.DeEscalationPoint</span>
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-default-heading-4">De-escalation point</span>
+                                </h2>
+                            </div>
+                            <div aria-labelledby="accordion-default-heading-4" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-4" data-testid="deescalation_point_field">
+                                <div class="govuk-body details govuk-body-accordion-limit">
+                                    <span class="dfe-text-area-display">@Model.CaseModel.DeEscalationPoint</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-default-heading-5">Next steps</span>
-                            </h2>
-                        </div>
-                        <div aria-labelledby="accordion-default-heading-5" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-5" data-testid="next_step_field">
-                            <div class="govuk-body details govuk-body-accordion-limit">
-                                <span class="dfe-text-area-display">@Model.CaseModel.NextSteps</span>
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-default-heading-5">Next steps</span>
+                                </h2>
+                            </div>
+                            <div aria-labelledby="accordion-default-heading-5" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-5" data-testid="next_step_field">
+                                <div class="govuk-body details govuk-body-accordion-limit">
+                                    <span class="dfe-text-area-display">@Model.CaseModel.NextSteps</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-default-heading-5">Case History</span>
-                            </h2>
-                        </div>
-                        <div aria-labelledby="accordion-default-heading-5" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-5" data-testid="case_history_field">
-                            <div class="govuk-body details govuk-body-accordion-limit">
-                                <span class="dfe-text-area-display">@Model.CaseModel.CaseHistory</span>
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-default-heading-5">Case History</span>
+                                </h2>
+                            </div>
+                            <div aria-labelledby="accordion-default-heading-5" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-5" data-testid="case_history_field">
+                                <div class="govuk-body details govuk-body-accordion-limit">
+                                    <span class="dfe-text-area-display">@Model.CaseModel.CaseHistory</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button" id="accordion-default-heading-6">Rationale for closure</span>
-                            </h2>
-                        </div>
-                        <div aria-labelledby="accordion-default-heading-6" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-6" data-testid="rational_for_closure_field">
-                            <div class="govuk-body details govuk-body-accordion-limit">
-                                <span class="dfe-text-area-display">@Model.CaseModel.ReasonAtReview</span>
+                        <div class="govuk-accordion__section">
+                            <div class="govuk-accordion__section-header">
+                                <h2 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-default-heading-6">Rationale for closure</span>
+                                </h2>
+                            </div>
+                            <div aria-labelledby="accordion-default-heading-6" class="govuk-accordion__section-content govuk-!-margin-top-3 govuk-!-margin-bottom-6" id="accordion-default-content-6" data-testid="rational_for_closure_field">
+                                <div class="govuk-body details govuk-body-accordion-limit">
+                                    <span class="dfe-text-area-display">@Model.CaseModel.ReasonAtReview</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                </div>
+                    </div>
+                }
             }
         </div>
         <div>


### PR DESCRIPTION
**What is the change?**

updated automation to ensure narrative boxes do not exist on non concerns

**Why do we need the change?**

case history is not needed on non concerns now

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=129832

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=128027

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=129831
