### PR TITLE
130273: Api endpoint to soft delete concerns

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/ConcernsRecordFactoryTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/ConcernsRecordFactoryTests.cs
@@ -39,14 +39,15 @@ namespace ConcernsCaseWork.API.Tests.Factories
                 UpdatedAt = recordRequest.UpdatedAt,
                 ReviewAt = recordRequest.ReviewAt,
                 ClosedAt = null,
-                Name = recordRequest.Name,
+				Name = recordRequest.Name,
                 Description = recordRequest.Description,
                 Reason = recordRequest.Reason,
                 ConcernsCase = concernsCase,
                 ConcernsType = concernsType,
                 ConcernsRating = concernsRating,
                 StatusId = recordRequest.StatusId,
-                ConcernsMeansOfReferral = concernsMeansOfReferral
+                ConcernsMeansOfReferral = concernsMeansOfReferral,
+				DeletedAt = null
             };
 
             var result = ConcernsRecordFactory.Create(recordRequest, concernsCase, concernsType, concernsRating, concernsMeansOfReferral);
@@ -56,13 +57,15 @@ namespace ConcernsCaseWork.API.Tests.Factories
         [Fact]
         public void Update_ReturnsConcernsRecord_WhenGivenAnConcernsRecordRequest()
         {
-	        var concernsCase = Builder<ConcernsCase>.CreateNew().Build();
+			BuilderSetup.DisablePropertyNamingFor<ConcernsRecord, DateTime?>(f => f.DeletedAt);
+
+			var concernsCase = Builder<ConcernsCase>.CreateNew().Build();
 	        var concernsType = Builder<ConcernsType>.CreateNew().Build();
 	        var concernsRating = Builder<ConcernsRating>.CreateNew().Build();
 	        var concernsMeansOfReferral = Builder<ConcernsMeansOfReferral>.CreateNew().Build();
-	        var originalConcernsRecord = Builder<ConcernsRecord>.CreateNew().Build();
-            
-	        var recordRequest = new ConcernsRecordRequest
+			var originalConcernsRecord = Builder<ConcernsRecord>.CreateNew().Build();
+
+			var recordRequest = new ConcernsRecordRequest
 	        {
 		        CreatedAt = new DateTime(2021, 05, 14),
 		        UpdatedAt = new DateTime(2021, 05, 14),

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -9,6 +9,7 @@ using ConcernsCaseWork.Data;
 using ConcernsCaseWork.Data.Models;
 using FizzWare.NBuilder;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -695,6 +696,20 @@ public class ConcernsIntegrationTests : IDisposable
 		return concernsCase;
 	}
 
+	[Fact]
+	public async Task DeleteMissingConcernsRecord_Returns_NotFound()
+	{
+		var currentRecordId = 987654321;
+
+		HttpRequestMessage httpRequestMessage = new()
+		{
+			Method = HttpMethod.Delete,
+			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
+		};
+		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+	}
 
 	[Fact]
 	public async Task DeleteConcernsRecord_Returns_NoConcernsRecordForCase()

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -665,6 +665,97 @@ public class ConcernsIntegrationTests : IDisposable
 		content.Data.Should().BeEquivalentTo(expectedContent);
 	}
 
+
+	public ConcernsCase BuildConcernsCase(Int32 caseRatingID)
+	{
+		ConcernsCase concernsCase = new()
+		{
+			CreatedAt = _randomGenerator.DateTime(),
+			UpdatedAt = _randomGenerator.DateTime(),
+			ReviewAt = _randomGenerator.DateTime(),
+			ClosedAt = _randomGenerator.DateTime(),
+			CreatedBy = _randomGenerator.NextString(3, 10),
+			Description = _randomGenerator.NextString(3, 10),
+			CrmEnquiry = _randomGenerator.NextString(3, 10),
+			TrustUkprn = _randomGenerator.NextString(3, 10),
+			ReasonAtReview = _randomGenerator.NextString(3, 10),
+			DeEscalation = _randomGenerator.DateTime(),
+			Issue = _randomGenerator.NextString(3, 10),
+			CurrentStatus = _randomGenerator.NextString(3, 10),
+			CaseAim = _randomGenerator.NextString(3, 10),
+			DeEscalationPoint = _randomGenerator.NextString(3, 10),
+			NextSteps = _randomGenerator.NextString(3, 10),
+			CaseHistory = _randomGenerator.NextString(3, 10),
+			DirectionOfTravel = _randomGenerator.NextString(3, 10),
+			Territory = Territory.North_And_Utc__Yorkshire_And_Humber,
+			StatusId = 2,
+			RatingId = caseRatingID
+		};
+
+		return concernsCase;
+	}
+
+
+	[Fact]
+	public async Task DeleteConcernsRecord_Returns_NoConcernsRecordForCase()
+	{
+		await using ConcernsDbContext context = _testFixture.GetContext();
+
+		ConcernsRating caseRating = context.ConcernsRatings.First();
+
+		ConcernsCase concernsCase = BuildConcernsCase(caseRating.Id);
+
+		AddConcernsCaseToDatabase(concernsCase);
+
+		ConcernsType linkedType = context.ConcernsTypes.First();
+		ConcernsRating linkedRating = context.ConcernsRatings.First();
+		ConcernsMeansOfReferral meansOfReferral = context.ConcernsMeansOfReferrals.First();
+
+		ConcernsRecordRequest createConcernsRecordContent = Builder<ConcernsRecordRequest>.CreateNew()
+			.With(c => c.CaseUrn = concernsCase.Urn)
+			.With(c => c.TypeId = linkedType.Id)
+			.With(c => c.RatingId = linkedRating.Id)
+			.With(c => c.MeansOfReferralId = meansOfReferral.Id)
+			.Build();
+
+		HttpRequestMessage createConcernsRecordHttpRequest = new()
+		{
+			Method = HttpMethod.Post,
+			RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records"),
+			Content = JsonContent.Create(createConcernsRecordContent)
+		};
+
+		HttpResponseMessage createdResponse = await _client.SendAsync(createConcernsRecordHttpRequest);
+		createdResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+		ApiSingleResponseV2<ConcernsRecordResponse> createdResult = await createdResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
+		var currentRecordId = createdResult.Data.Id;
+		var urn = concernsCase.Urn;
+
+		HttpRequestMessage httpRequestMessage = new()
+		{
+			Method = HttpMethod.Delete,
+			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
+		};
+		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+	
+		HttpRequestMessage listConcernsforCaseResponse = new()
+		{
+			Method = HttpMethod.Get,
+			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/case/urn/{urn}"),
+		};
+
+		HttpResponseMessage listResponse = await _client.SendAsync(listConcernsforCaseResponse);
+		ApiResponseV2<ConcernsRecordResponse> concernsforCaseList = await listResponse.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
+
+		listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+		concernsforCaseList.Data.Count().Should().Be(0);
+	}
+
+
 	[Fact]
 	public async Task GetConcernsRecordsByConcernsCaseUid()
 	{

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
@@ -70,6 +70,8 @@ namespace ConcernsCaseWork.API.StartupConfiguration
 			services.AddScoped<IUpdateConcernsCase, UpdateConcernsCase>();
 			services.AddScoped<IIndexConcernsTypes, IndexConcernsTypes>();
 			services.AddScoped<IUpdateConcernsRecord, UpdateConcernsRecord>();
+			services.AddScoped<IDeleteConcernsRecord, DeleteConcernsRecord>();
+			services.AddScoped<IGetConcernsRecord, GetConcernsRecord>();
 
 			services.AddScoped<IIndexConcernsMeansOfReferrals, IndexConcernsMeansOfReferrals>();
 			services.AddScoped<IConcernsMeansOfReferralGateway, ConcernsMeansOfReferralGateway>();

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/DeleteConcernsRecord.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/DeleteConcernsRecord.cs
@@ -1,0 +1,19 @@
+﻿using ConcernsCaseWork.Data.Gateways;
+
+namespace ConcernsCaseWork.API.UseCases
+{
+	public class DeleteConcernsRecord : IDeleteConcernsRecord
+	{
+		private readonly IConcernsRecordGateway _concernsRecordGateway;
+
+		public DeleteConcernsRecord(IConcernsRecordGateway concernsRecordGateway)
+		{
+			_concernsRecordGateway = concernsRecordGateway;
+		}
+
+		public void Execute(int id)
+		{
+			_concernsRecordGateway.Delete(id);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/GetConcernsRecord.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/GetConcernsRecord.cs
@@ -1,0 +1,30 @@
+﻿using ConcernsCaseWork.API.Factories;
+using ConcernsCaseWork.API.ResponseModels;
+using ConcernsCaseWork.Data.Gateways;
+using ConcernsCaseWork.Data.Models;
+
+namespace ConcernsCaseWork.API.UseCases
+{
+	public class GetConcernsRecord : IGetConcernsRecord
+	{
+		private readonly IConcernsRecordGateway _concernsRecordGateway;
+
+		public GetConcernsRecord(IConcernsRecordGateway concernsRecordGateway)
+		{
+			_concernsRecordGateway = concernsRecordGateway;
+		}
+
+		public ConcernsRecordResponse Execute(int id)
+		{
+			ConcernsRecordResponse result = null;
+			var record = _concernsRecordGateway.GetConcernsRecordByUrn(id);
+
+			if (record != null)
+			{
+				result = ConcernsRecordResponseFactory.Create(record);
+			}
+
+			return result;
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/IDeleteConcernsRecord.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/IDeleteConcernsRecord.cs
@@ -1,0 +1,9 @@
+﻿namespace ConcernsCaseWork.API.UseCases
+{
+
+	public interface IDeleteConcernsRecord
+	{
+		void Execute(int id);
+
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/IGetConcernsRecord.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/IGetConcernsRecord.cs
@@ -1,0 +1,9 @@
+﻿using ConcernsCaseWork.API.ResponseModels;
+
+namespace ConcernsCaseWork.API.UseCases
+{
+	public interface IGetConcernsRecord
+	{
+		ConcernsRecordResponse Execute(int id);
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/IUpdateConcernsRecord.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/IUpdateConcernsRecord.cs
@@ -7,4 +7,7 @@ namespace ConcernsCaseWork.API.UseCases
     {
         ConcernsRecordResponse Execute(int urn, ConcernsRecordRequest request);
     }
+
+
+
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/ConcernsRecordConfiguration.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/ConcernsRecordConfiguration.cs
@@ -34,5 +34,7 @@ public class ConcernsRecordConfiguration : IEntityTypeConfiguration<ConcernsReco
 			.HasConstraintName("FK__ConcernsRecord_ConcernsMeansOfReferral");
 		
 		builder.HasIndex(x => new {x.CaseId, x.CreatedAt}).IsUnique();
+
+		builder.HasQueryFilter(f => !f.DeletedAt.HasValue);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ConcernsRecordGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ConcernsRecordGateway.cs
@@ -29,7 +29,7 @@ namespace ConcernsCaseWork.Data.Gateways
 
         public ConcernsRecord GetConcernsRecordByUrn(int id)
         {
-            return _concernsDbContext.ConcernsRecord
+            return _concernsDbContext.ConcernsRecord.AsNoTracking()
 				.Include(f=> f.ConcernsType)
 				.Include(f => f.ConcernsCase)
 				.Include(f => f.ConcernsRating)

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ConcernsRecordGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ConcernsRecordGateway.cs
@@ -1,4 +1,5 @@
 using ConcernsCaseWork.Data.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace ConcernsCaseWork.Data.Gateways
 {
@@ -28,7 +29,19 @@ namespace ConcernsCaseWork.Data.Gateways
 
         public ConcernsRecord GetConcernsRecordByUrn(int id)
         {
-            return _concernsDbContext.ConcernsRecord.FirstOrDefault(r => r.Id == id);
+            return _concernsDbContext.ConcernsRecord
+				.Include(f=> f.ConcernsType)
+				.Include(f => f.ConcernsCase)
+				.Include(f => f.ConcernsRating)
+				.Include(f => f.ConcernsMeansOfReferral)
+				.SingleOrDefault(r => r.Id == id);
         }
-    }
+
+		public void Delete(int id)
+		{
+			var c = _concernsDbContext.ConcernsRecord.SingleOrDefault(f=> f.Id == id);
+			c.DeletedAt = DateTime.Now;
+			_concernsDbContext.SaveChanges();
+		}
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/IConcernsRecordGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/IConcernsRecordGateway.cs
@@ -7,5 +7,6 @@ namespace ConcernsCaseWork.Data.Gateways
         ConcernsRecord SaveConcernsCase(ConcernsRecord concernsRecord);
         ConcernsRecord Update(ConcernsRecord concernsRecord);
         ConcernsRecord GetConcernsRecordByUrn(int urn);
-    }
+		void Delete(int id);
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230525140904_AddDeletedAtToConcern.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230525140904_AddDeletedAtToConcern.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230525140904_AddDeletedAtToConcern")]
+    partial class AddDeletedAtToConcern
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230525140904_AddDeletedAtToConcern.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230525140904_AddDeletedAtToConcern.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletedAtToConcern : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "ConcernsRecord",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "ConcernsRecord");
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsRecord.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsRecord.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace ConcernsCaseWork.Data.Models
 {
     public class ConcernsRecord: IAuditable
@@ -20,5 +22,7 @@ namespace ConcernsCaseWork.Data.Models
         public virtual ConcernsRating ConcernsRating { get; set; }
         public virtual ConcernsMeansOfReferral ConcernsMeansOfReferral { get; set; }
         public virtual ConcernsStatus Status { get; set; }
-    }
+
+		public DateTime? DeletedAt { get; set; }
+	}
 }


### PR DESCRIPTION
**What is the change?**
Add Api endpoint to allow deleting of concerns relating to a case. Adds new field to the ConcernsRecord table called DeletedAt

**Why do we need the change?**
Provide automated means to flag data as being deleted so it can be removed from reports and as an enabling piece of work to allows user to delete via the frontend.

**What is the impact?**
New capability for the Api which introduces the concept of a soft delete for concerns.

**Azure DevOps Ticket**
[130273](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/130273)
