### PR TITLE
130288: Api endpoint to soft delete a decision

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/ConcernsCaseDecisionControllerTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/ConcernsCaseDecisionControllerTests.cs
@@ -320,8 +320,10 @@ public class ConcernsCaseDecisionControllerTests
             internal readonly Mock<IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]>> GetDecisionsUseCase;
             internal readonly Mock<IUseCaseAsync<(int urn, int decisionId, UpdateDecisionRequest), UpdateDecisionResponse>> UpdateDecisionUseCase;
             internal readonly Mock<IUseCaseAsync<DecisionUseCaseRequestParams<CloseDecisionRequest>, CloseDecisionResponse>> CloseDecisionUseCase;
+			internal readonly Mock<IUseCaseAsync<DeleteDecisionRequest, DeleteDecisionResponse>> DeleteDecisionUseCase;
 
-            public TestBuilder()
+
+			public TestBuilder()
             {
                 Fixture = new Fixture();
                 Fixture.Customize(new AutoMoqCustomization());
@@ -332,16 +334,19 @@ public class ConcernsCaseDecisionControllerTests
                 GetDecisionsUseCase = Fixture.Freeze<Mock<IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]>>>();
                 UpdateDecisionUseCase = Fixture.Freeze<Mock<IUseCaseAsync<(int urn, int decisionId, UpdateDecisionRequest), UpdateDecisionResponse>>>();
                 CloseDecisionUseCase = Fixture.Freeze<Mock<IUseCaseAsync<DecisionUseCaseRequestParams<CloseDecisionRequest>, CloseDecisionResponse>>>();
-            }
+				DeleteDecisionUseCase = Fixture.Freeze<Mock<IUseCaseAsync<DeleteDecisionRequest, DeleteDecisionResponse>>>();
 
-            internal ConcernsCaseDecisionController BuildSut()
+			}
+
+			internal ConcernsCaseDecisionController BuildSut()
             {
                 return new ConcernsCaseDecisionController(MockLogger.Object, 
 	                CreateDecisionUseCase.Object, 
 	                GetDecisionUseCase.Object, 
 	                GetDecisionsUseCase.Object, 
 	                UpdateDecisionUseCase.Object,
-	                CloseDecisionUseCase.Object);
+	                CloseDecisionUseCase.Object,
+					DeleteDecisionUseCase.Object);
             }
 
             public UpdateDecisionRequest CreateValidUpdateDecisionRequest()

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/Concerns/Decisions/GetDecisionResponseFactoryTests.cs
@@ -46,6 +46,7 @@ namespace ConcernsCaseWork.API.Tests.Factories.Concerns.Decisions
 					.Excluding(x => x.Status)
 					.Excluding(x => x.ConcernsCaseId)
 					.Excluding(x => x.Outcome)
+					.Excluding(x => x.DeletedAt)
 				);
 
 			result.Outcome.Status.Should().Be(decision.Outcome.Status);

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseDecisionController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseDecisionController.cs
@@ -19,14 +19,17 @@ namespace ConcernsCaseWork.API.Controllers
 	    private readonly IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]> _getDecisionsUserCase;
 	    private readonly IUseCaseAsync<(int urn, int decisionId, UpdateDecisionRequest), UpdateDecisionResponse> _updateDecisionUseCase;
 	    private readonly IUseCaseAsync<DecisionUseCaseRequestParams<CloseDecisionRequest>, CloseDecisionResponse> _closeDecisionUseCase;
+		private readonly IUseCaseAsync<DeleteDecisionRequest, DeleteDecisionResponse> _deleteDecision;
 
-	    public ConcernsCaseDecisionController(
+
+		public ConcernsCaseDecisionController(
 		    ILogger<ConcernsCaseDecisionController> logger,
 		    IUseCaseAsync<CreateDecisionRequest, CreateDecisionResponse> createDecisionUseCase,
 		    IUseCaseAsync<GetDecisionRequest, GetDecisionResponse> getDecisionUseCase,
 		    IUseCaseAsync<GetDecisionsRequest, DecisionSummaryResponse[]> getDecisionsUseCase,
 		    IUseCaseAsync<(int urn, int decisionId, UpdateDecisionRequest), UpdateDecisionResponse> updateDecisionUseCase, 
-		    IUseCaseAsync<DecisionUseCaseRequestParams<CloseDecisionRequest>, CloseDecisionResponse> closeDecisionUseCase)
+		    IUseCaseAsync<DecisionUseCaseRequestParams<CloseDecisionRequest>, CloseDecisionResponse> closeDecisionUseCase,
+			IUseCaseAsync<DeleteDecisionRequest, DeleteDecisionResponse> deleteDecisionUsedCase)
 	    {
 		    _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 		    _createDecisionUseCase = createDecisionUseCase ?? throw new ArgumentNullException(nameof(createDecisionUseCase));
@@ -34,9 +37,10 @@ namespace ConcernsCaseWork.API.Controllers
 		    _getDecisionsUserCase = getDecisionsUseCase ?? throw new ArgumentNullException(nameof(getDecisionsUseCase));
 		    _updateDecisionUseCase = updateDecisionUseCase ?? throw new ArgumentNullException(nameof(updateDecisionUseCase));
 		    _closeDecisionUseCase = closeDecisionUseCase ?? throw new ArgumentNullException(nameof(closeDecisionUseCase));
-	    }
+			_deleteDecision = deleteDecisionUsedCase ?? throw new ArgumentNullException(nameof(deleteDecisionUsedCase));
+		}
 
-	    [HttpPost]
+		[HttpPost]
 	    [MapToApiVersion("2.0")]
 	    public async Task<ActionResult<ApiSingleResponseV2<CreateDecisionResponse>>> Create(int urn, CreateDecisionRequest request, CancellationToken cancellationToken = default)
 	    {
@@ -151,7 +155,36 @@ namespace ConcernsCaseWork.API.Controllers
 		    return Ok(new ApiSingleResponseV2<DecisionSummaryResponse[]>(results));
 	    }
 
-	    private bool ValidateUrn(int urn, string methodName)
+		[HttpDelete("{decisionId:int}")]
+		[MapToApiVersion("2.0")]
+		public async Task<IActionResult> Delete(int urn, int decisionId, CancellationToken cancellationToken = default)
+		{
+			LogInfo($"Attempting to delete Concerns Decision by Urn {urn}, DecisionId {decisionId}");
+
+			if (!ValidateUrn(urn, nameof(Delete)) || !ValidateDecisionId(decisionId, nameof(Delete)))
+			{
+				return BadRequest();
+			}
+
+			var decisionResponse = await _getDecisionUserCase.Execute(new GetDecisionRequest(urn, decisionId), cancellationToken);
+			if (decisionResponse == null)
+			{
+				LogInfo($"Deleting Concern Decision failed: No Decision matching Urn {urn}, DecisionId {decisionId} was found");
+
+				return NotFound();
+			}
+			else
+			{
+
+				await _deleteDecision.Execute(new DeleteDecisionRequest(urn, decisionId), cancellationToken);
+				LogInfo($"Successfully Deleted Concern Decision By Urn {urn}, DecisionId {decisionId}");
+
+				return NoContent();
+			}
+		}
+
+
+		private bool ValidateUrn(int urn, string methodName)
 	    {
 		    if (urn <= 0)
 		    {

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseDecisionController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseDecisionController.cs
@@ -173,14 +173,11 @@ namespace ConcernsCaseWork.API.Controllers
 
 				return NotFound();
 			}
-			else
-			{
 
-				await _deleteDecision.Execute(new DeleteDecisionRequest(urn, decisionId), cancellationToken);
-				LogInfo($"Successfully Deleted Concern Decision By Urn {urn}, DecisionId {decisionId}");
+			await _deleteDecision.Execute(new DeleteDecisionRequest(urn, decisionId), cancellationToken);
+			LogInfo($"Successfully Deleted Concern Decision By Urn {urn}, DecisionId {decisionId}");
 
-				return NoContent();
-			}
+			return NoContent();
 		}
 
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
@@ -115,7 +115,9 @@ namespace ConcernsCaseWork.API.StartupConfiguration
 			services.AddScoped<IUseCaseAsync<(int urn, int decisionId, UpdateDecisionRequest details), UpdateDecisionResponse>, UpdateDecision>();
 			services.AddScoped<IUpdateDecisionResponseFactory, UpdateDecisionResponseFactory>();
 			services.AddScoped<ICloseDecisionResponseFactory, CloseDecisionResponseFactory>();
-			
+			services.AddScoped<IUseCaseAsync<DeleteDecisionRequest, DeleteDecisionResponse>, DeleteDecision>();
+
+
 			services.AddScoped<IUseCaseAsync<CreateTrustFinancialForecastRequest, int>, CreateTrustFinancialForecast>();
 			services.AddScoped<IUseCaseAsync<UpdateTrustFinancialForecastRequest, int>, UpdateTrustFinancialForecast>();
 			services.AddScoped<IUseCaseAsync<GetTrustFinancialForecastByIdRequest, TrustFinancialForecastResponse>, GetTrustFinancialForecastById>();

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/DeleteDecision.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/Decisions/DeleteDecision.cs
@@ -1,0 +1,69 @@
+﻿using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
+using ConcernsCaseWork.API.Factories.Concerns.Decisions;
+using ConcernsCaseWork.Data.Gateways;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcernsCaseWork.API.UseCases.CaseActions.Decisions
+{
+	public class DeleteDecision : IUseCaseAsync<DeleteDecisionRequest, DeleteDecisionResponse>
+	{
+		private readonly IConcernsCaseGateway _concernsCaseGateway;
+		private readonly IDecisionFactory _decisionFactory;
+		private readonly ICreateDecisionResponseFactory _createDecisionResponseFactory;
+
+		public DeleteDecision(IConcernsCaseGateway concernsCaseGateway, IDecisionFactory decisionFactory, ICreateDecisionResponseFactory createDecisionResponseFactory)
+		{
+			_concernsCaseGateway = concernsCaseGateway ?? throw new ArgumentNullException(nameof(concernsCaseGateway));
+			_decisionFactory = decisionFactory ?? throw new ArgumentNullException(nameof(decisionFactory));
+			_createDecisionResponseFactory = createDecisionResponseFactory ?? throw new ArgumentNullException(nameof(createDecisionResponseFactory));
+		}
+
+		public Task<DeleteDecisionResponse> Execute(DeleteDecisionRequest request, CancellationToken cancellationToken)
+		{
+			_ = request ?? throw new ArgumentNullException(nameof(request));
+
+			async Task<DeleteDecisionResponse> DoWork()
+			{
+				var concernsCase = _concernsCaseGateway.GetConcernsCaseByUrn(request.ConcernsCaseUrn) ??
+								   throw new InvalidOperationException(
+									   $"The concerns case for urn {request.ConcernsCaseUrn}, was not found");
+
+
+				concernsCase.DeleteDecision(request.DecisionId, DateTimeOffset.Now);
+
+
+				cancellationToken.ThrowIfCancellationRequested();
+
+				_concernsCaseGateway.SaveConcernsCase(concernsCase);
+
+				return null;
+			}
+
+			return DoWork();
+		}
+	}
+
+	public class DeleteDecisionRequest
+	{
+
+		[Range(1, int.MaxValue, ErrorMessage = "The ConcernsCaseUrn must be greater than zero")]
+		public int ConcernsCaseUrn { get; set; }
+
+		[Range(1, int.MaxValue, ErrorMessage = "The DecisionId must be greater than zero")]
+		public int DecisionId { get; set; }
+
+		public DeleteDecisionRequest(int concernsCaseUrn, int decisionId)
+		{
+			_ = concernsCaseUrn <= 0 ? throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn)) : concernsCaseUrn;
+			_ = decisionId <= 0 ? throw new ArgumentOutOfRangeException(nameof(concernsCaseUrn)) : decisionId;
+
+			ConcernsCaseUrn = concernsCaseUrn;
+			DecisionId = decisionId;
+		}
+	}
+
+	public class DeleteDecisionResponse
+	{
+
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/Decisions/DecisionConfiguration.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/Decisions/DecisionConfiguration.cs
@@ -14,5 +14,6 @@ public class DecisionConfiguration : IEntityTypeConfiguration<Decision>
 		builder.HasMany(x => x.DecisionTypes).WithOne();
 		builder.HasOne(x => x.Outcome);
 		builder.HasIndex(x => new {x.ConcernsCaseId, x.CreatedAt}).IsUnique();
+		builder.HasQueryFilter(f => !f.DeletedAt.HasValue);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230530111343_AddDeletedAtToDecision.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230530111343_AddDeletedAtToDecision.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230530111343_AddDeletedAtToDecision")]
+    partial class AddDeletedAtToDecision
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230530111343_AddDeletedAtToDecision.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230530111343_AddDeletedAtToDecision.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletedAtToDecision : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "ConcernsDecision",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "ConcernsDecision");
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Concerns/Case/Management/Actions/Decisions/Decision.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Concerns/Case/Management/Actions/Decisions/Decision.cs
@@ -116,7 +116,9 @@ namespace ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decision
 
 		public DecisionOutcome? Outcome { get; set; }
 
-        public string GetTitle()
+		public DateTime? DeletedAt { get; set; }
+
+		public string GetTitle()
         {
             switch (DecisionTypes?.Count ?? 0)
             {
@@ -167,5 +169,10 @@ namespace ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decision
 	        SupportingNotes = notes;
 	        UpdatedAt = updatedAt;
         }
+
+		public void Delete(DateTime now)
+		{
+			this.DeletedAt = now;
+		}
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
@@ -65,7 +65,21 @@ namespace ConcernsCaseWork.Data.Models
 	        currentDecision.Update(updatedDecision, now);
         }
 
-        public void CloseDecision(int decisionId, string notes, DateTimeOffset now)
+		public void DeleteDecision(int decisionId, DateTimeOffset now)
+		{
+			_ = decisionId > 0 ? decisionId : throw new ArgumentOutOfRangeException(nameof(decisionId));
+
+			var currentDecision = Decisions.FirstOrDefault(x => x.DecisionId == decisionId);
+			if (currentDecision == null)
+			{
+				throw new ArgumentOutOfRangeException(nameof(decisionId),
+					$"Decision id {decisionId} not found in this concerns case. Concerns case urn {Urn}");
+			}
+
+			currentDecision.Delete(now.DateTime);
+		}
+
+		public void CloseDecision(int decisionId, string notes, DateTimeOffset now)
         {
 	        _ = decisionId > 0 ? decisionId : throw new ArgumentOutOfRangeException(nameof(decisionId));
 


### PR DESCRIPTION
**What is the change?**
Add Api endpoint to allow deleting of Decision relating to a case. Adds new field to the Decision table called DeletedAt

**Why do we need the change?**
Provide automated means to flag data as being deleted so it can be removed from reports and as an enabling piece of work to allows user to delete via the frontend.

**What is the impact?**
New capability for the Api which introduces the concept of a soft delete for a decision

**Azure DevOps Ticket**
[130288](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/130288)