### PR TITLE
130435 Api endpoint to soft delete a NTI Warning Letter

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/NTIWarningLetterControllerTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/NTIWarningLetterControllerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using System.Threading.Tasks;
 using Xunit;
+using ConcernsCaseWork.API.UseCases.CaseActions.NTI.WarningLetter;
 
 namespace ConcernsCaseWork.API.Tests.Controllers
 {
@@ -25,7 +26,9 @@ namespace ConcernsCaseWork.API.Tests.Controllers
         private readonly Mock<IUseCase<long, NTIWarningLetterResponse>> _mockGetNtiWarningLetterByIdUseCase;
         private readonly Mock<IUseCase<int, List<NTIWarningLetterResponse>>> _mockGetNtiWarningLetterByCaseUrnUseCase;
         private readonly Mock<IUseCase<PatchNTIWarningLetterRequest, NTIWarningLetterResponse>> _mockPatchNTIWarningLetterUseCase;
-        private readonly Mock<IUseCase<object, List<NTIWarningLetterStatus>>> _mockGetAllStatuses;
+		private readonly Mock<IUseCase<long, DeleteNTIWarningLetterResponse>> _mockDeleteNTIWarningLetterUseCase;
+
+		private readonly Mock<IUseCase<object, List<NTIWarningLetterStatus>>> _mockGetAllStatuses;
         private readonly Mock<IUseCase<object, List<NTIWarningLetterReason>>> _mockGetAllReasons;
         private readonly Mock<IUseCase<object, List<NTIWarningLetterCondition>>> _mockGetAllCondition;
         private readonly Mock<IUseCase<object, List<NTIWarningLetterConditionType>>> _mockGetAllConditionType;
@@ -43,9 +46,11 @@ namespace ConcernsCaseWork.API.Tests.Controllers
             _mockGetAllReasons = new Mock<IUseCase<object, List<NTIWarningLetterReason>>>();
             _mockGetAllCondition = new Mock<IUseCase<object, List<NTIWarningLetterCondition>>>();
             _mockGetAllConditionType = new Mock<IUseCase<object, List<NTIWarningLetterConditionType>>>();
+			_mockDeleteNTIWarningLetterUseCase = new Mock<IUseCase<long, DeleteNTIWarningLetterResponse>>();
 
-            controllerSUT = new NTIWarningLetterController(_mockLogger.Object, _mockCreateNtiWarningLetterUseCase.Object, _mockGetNtiWarningLetterByIdUseCase.Object,
-                _mockGetNtiWarningLetterByCaseUrnUseCase.Object, _mockPatchNTIWarningLetterUseCase.Object, _mockGetAllStatuses.Object, _mockGetAllReasons.Object, _mockGetAllCondition.Object, _mockGetAllConditionType.Object);
+			controllerSUT = new NTIWarningLetterController(_mockLogger.Object, _mockCreateNtiWarningLetterUseCase.Object, _mockGetNtiWarningLetterByIdUseCase.Object,
+                _mockGetNtiWarningLetterByCaseUrnUseCase.Object, _mockPatchNTIWarningLetterUseCase.Object, _mockDeleteNTIWarningLetterUseCase.Object,
+				_mockGetAllStatuses.Object, _mockGetAllReasons.Object, _mockGetAllCondition.Object, _mockGetAllConditionType.Object);
         }
 
         [Fact]

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NtiWarningLetterIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NtiWarningLetterIntegrationTests.cs
@@ -1,10 +1,17 @@
 ﻿using AutoFixture;
+using ConcernsCaseWork.API.RequestModels;
 using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.WarningLetter;
+using ConcernsCaseWork.API.ResponseModels;
 using ConcernsCaseWork.API.Tests.Fixtures;
 using ConcernsCaseWork.API.Tests.Helpers;
+using ConcernsCaseWork.API.UseCases.CaseActions.Decisions;
+using ConcernsCaseWork.Data.Models;
+using FizzWare.NBuilder;
 using FluentAssertions;
+using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -15,11 +22,13 @@ namespace ConcernsCaseWork.API.Tests.Integration
 	{
 		private readonly Fixture _fixture;
 		private readonly HttpClient _client;
+		private readonly RandomGenerator _randomGenerator;
 
 		public NtiWarningLetterIntegrationTests(ApiTestFixture apiTestFixture)
 		{
 			_client = apiTestFixture.Client;
 			_fixture = new();
+			_randomGenerator = new RandomGenerator();
 		}
 
 		[Fact]
@@ -51,6 +60,82 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			var error = await result.Content.ReadAsStringAsync();
 			error.Should().Contain("The field CreatedBy must be a string with a maximum length of 300.");
 			error.Should().Contain("The field Notes must be a string with a maximum length of 2000.");
+		}
+
+		[Fact]
+		public async Task When_Delete_InvalidRequest_Returns_BadRequest()
+		{
+			var warningLetterID = 0;
+
+			var result = await _client.DeleteAsync($"/v2/case-actions/nti-warning-letter/{warningLetterID}");
+			result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+		}
+
+		[Fact]
+		public async Task When_Delete_NotCreatedResourceRequest_Returns_NotFound()
+		{
+			var warningLetterID = 1;
+
+			var result = await _client.DeleteAsync($"/v2/case-actions/nti-warning-letter/{warningLetterID}");
+			result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		}
+
+		[Fact]
+		public async Task When_Delete_ValidResourceRequest_Returns_NoContent()
+		{
+			var warningLetterID = 1;
+
+			//Create the case
+			ConcernCaseRequest createCaseRequest = Builder<ConcernCaseRequest>.CreateNew()
+				.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
+				.With(c => c.Description = "")
+				.With(c => c.CrmEnquiry = "")
+				.With(c => c.TrustUkprn = "100223")
+				.With(c => c.ReasonAtReview = "")
+				.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
+				.With(c => c.Issue = "Here is the issue")
+				.With(c => c.CurrentStatus = "Case status")
+				.With(c => c.CaseAim = "Here is the aim")
+				.With(c => c.DeEscalationPoint = "Point of de-escalation")
+				.With(c => c.CaseHistory = "Case history")
+				.With(c => c.NextSteps = "Here are the next steps")
+				.With(c => c.DirectionOfTravel = "Up")
+				.With(c => c.StatusId = 1)
+				.With(c => c.RatingId = 2)
+				.With(c => c.TrustCompaniesHouseNumber = "12345678")
+				.Build();
+
+			var createCaseResponse = await _client.PostAsync($"v2/concerns-cases", createCaseRequest.ConvertToJson());
+			var response = await createCaseResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
+
+			var x = response.Data.Urn;
+			//create the warning letter
+
+			var request = _fixture.Create<CreateNTIWarningLetterRequest>();
+			request.CaseUrn = x;
+			request.ClosedStatusId = 1;
+			request.StatusId = 1;
+			request.WarningLetterConditionsMapping.Clear();
+			request.WarningLetterConditionsMapping.Add(1);
+			request.WarningLetterReasonsMapping.Clear();
+			request.WarningLetterReasonsMapping.Add(1);
+
+
+			var result = await _client.PostAsync($"/v2/case-actions/nti-warning-letter", request.ConvertToJson());
+			result.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			var createdWarningLetterUri = result.Headers.Location;
+			//check for the warning letter
+			//var getResponse = await _client.GetAsync(createdWarningLetterUri);
+			//getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			//delete the warning letter
+			var deleteResponse = await _client.DeleteAsync(createdWarningLetterUri);
+			deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+			//check it is not returned
+			var getResponseNotFound = await _client.GetAsync(createdWarningLetterUri);
+			getResponseNotFound.StatusCode.Should().Be(HttpStatusCode.NotFound);
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NtiWarningLetterIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NtiWarningLetterIntegrationTests.cs
@@ -108,11 +108,10 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			var createCaseResponse = await _client.PostAsync($"v2/concerns-cases", createCaseRequest.ConvertToJson());
 			var response = await createCaseResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
 
-			var x = response.Data.Urn;
+			var CaseUrn = response.Data.Urn;
 			//create the warning letter
-
 			var request = _fixture.Create<CreateNTIWarningLetterRequest>();
-			request.CaseUrn = x;
+			request.CaseUrn = CaseUrn;
 			request.ClosedStatusId = 1;
 			request.StatusId = 1;
 			request.WarningLetterConditionsMapping.Clear();
@@ -126,8 +125,8 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 			var createdWarningLetterUri = result.Headers.Location;
 			//check for the warning letter
-			//var getResponse = await _client.GetAsync(createdWarningLetterUri);
-			//getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+			var getResponse = await _client.GetAsync(createdWarningLetterUri);
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
 			//delete the warning letter
 			var deleteResponse = await _client.DeleteAsync(createdWarningLetterUri);

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsCaseController.cs
@@ -1,6 +1,7 @@
 using ConcernsCaseWork.API.RequestModels;
 using ConcernsCaseWork.API.ResponseModels;
 using ConcernsCaseWork.API.UseCases;
+using ConcernsCaseWork.API.UseCases.CaseActions.NTI.WarningLetter;
 using ConcernsCaseWork.API.Validators;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
@@ -60,7 +61,9 @@ namespace ConcernsCaseWork.API.Controllers
                 var createdConcernsCase = _createConcernsCase.Execute(request);
                 var response = new ApiSingleResponseV2<ConcernsCaseResponse>(createdConcernsCase);
 
-                return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
+				//return CreatedAtAction(nameof(GetByUrn), new { urn = response.Data.Urn }, response);
+
+				return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
             }
             _logger.LogInformation($"Failed to create Concerns Case due to bad request");
             return BadRequest();

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/WarningLetter/DeleteNTIWarningLetter.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/WarningLetter/DeleteNTIWarningLetter.cs
@@ -1,0 +1,24 @@
+﻿using ConcernsCaseWork.Data.Gateways;
+
+namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.WarningLetter
+{
+	public class DeleteNTIWarningLetter : IUseCase<long, DeleteNTIWarningLetterResponse>
+	{
+		private readonly INTIWarningLetterGateway _gateway;
+
+		public DeleteNTIWarningLetter(INTIWarningLetterGateway gateway)
+		{
+			_gateway = gateway;
+		}
+
+		public DeleteNTIWarningLetterResponse Execute(long warningLetterId)
+		{
+			_gateway.Delete(warningLetterId);
+			return new DeleteNTIWarningLetterResponse();
+		}
+	}
+
+	public class DeleteNTIWarningLetterResponse
+	{
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/WarningLetter/GetNTIWarningLetterById.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/WarningLetter/GetNTIWarningLetterById.cs
@@ -28,58 +28,8 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.WarningLetter
 			if (warningLetter ==null)
 			{
 				return null;
-				//return Task.FromResult<NTIWarningLetterResponse>(null).Result;
 			}
 			return NTIWarningLetterFactory.CreateResponse(warningLetter);
 		}
-
-		//public async NTIWarningLetterResponse Execute(long warningLetterId)
-		//{
-		//	var result = await _gateway.GetNTIWarningLetterById(warningLetterId);
-
-		//	return result == null ? null : NTIWarningLetterFactory.CreateResponse(result);
-
-
-		//}
-
-		//public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
-		//{
-		//	var result = await _gateway.GetNTIWarningLetterById(warningLetterId);
-
-		//	return result == null ? null : NTIWarningLetterFactory.CreateResponse(result);
-		//}
-
-		//     public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
-		//     {
-		//var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
-		//if (warningLetter == null)
-		//{
-		//	return Task.FromResult<NTIWarningLetterResponse>(null);
-		//}
-		//return NTIWarningLetterFactory.CreateResponse(warningLetter);
-
-
-		////async Task<NTIWarningLetterResponse> DoWork()
-		////{
-		////	var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
-
-		////	return warningLetter != null ? NTIWarningLetterFactory.CreateResponse(warningLetter): null;
-		////}
-
-		////return await DoWork();
-		//}
-
-
-
-		//public NTIWarningLetterResponse Execute(long warningLetterId)
-		//{
-		//	return ExecuteAsync(warningLetterId).Result;
-		//}
-
-		//public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
-		//{
-		//	var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
-		//	return NTIWarningLetterFactory.CreateResponse(warningLetter);
-		//}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/WarningLetter/GetNTIWarningLetterById.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/WarningLetter/GetNTIWarningLetterById.cs
@@ -1,27 +1,85 @@
-﻿using ConcernsCaseWork.API.Factories.CaseActionFactories;
+﻿using Azure.Core;
+using ConcernsCaseWork.API.Contracts.ResponseModels.Concerns.Decisions;
+using ConcernsCaseWork.API.Factories;
+using ConcernsCaseWork.API.Factories.CaseActionFactories;
 using ConcernsCaseWork.API.ResponseModels.CaseActions.NTI.WarningLetter;
 using ConcernsCaseWork.Data.Gateways;
+using System;
 
 namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.WarningLetter
 {
-    public class GetNTIWarningLetterById : IUseCase<long, NTIWarningLetterResponse>
-    {
-        private readonly INTIWarningLetterGateway _gateway;
+	public class GetNTIWarningLetterById : IUseCase<long, NTIWarningLetterResponse>
+	{
+		private readonly INTIWarningLetterGateway _gateway;
 
-        public GetNTIWarningLetterById(INTIWarningLetterGateway gateway)
-        {
-            _gateway = gateway;
-        }
+		public GetNTIWarningLetterById(INTIWarningLetterGateway gateway)
+		{
+			_gateway = gateway;
+		}
 
-        public NTIWarningLetterResponse Execute(long warningLetterId)
-        {
-            return ExecuteAsync(warningLetterId).Result;
-        }
+		public NTIWarningLetterResponse Execute(long warningLetterId)
+		{
+			return ExecuteAsync(warningLetterId).Result;
+		}
 
-        public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
-        {
-            var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
-            return NTIWarningLetterFactory.CreateResponse(warningLetter);
-        }
-    }
+		public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
+		{
+			var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
+			if (warningLetter ==null)
+			{
+				return null;
+				//return Task.FromResult<NTIWarningLetterResponse>(null).Result;
+			}
+			return NTIWarningLetterFactory.CreateResponse(warningLetter);
+		}
+
+		//public async NTIWarningLetterResponse Execute(long warningLetterId)
+		//{
+		//	var result = await _gateway.GetNTIWarningLetterById(warningLetterId);
+
+		//	return result == null ? null : NTIWarningLetterFactory.CreateResponse(result);
+
+
+		//}
+
+		//public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
+		//{
+		//	var result = await _gateway.GetNTIWarningLetterById(warningLetterId);
+
+		//	return result == null ? null : NTIWarningLetterFactory.CreateResponse(result);
+		//}
+
+		//     public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
+		//     {
+		//var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
+		//if (warningLetter == null)
+		//{
+		//	return Task.FromResult<NTIWarningLetterResponse>(null);
+		//}
+		//return NTIWarningLetterFactory.CreateResponse(warningLetter);
+
+
+		////async Task<NTIWarningLetterResponse> DoWork()
+		////{
+		////	var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
+
+		////	return warningLetter != null ? NTIWarningLetterFactory.CreateResponse(warningLetter): null;
+		////}
+
+		////return await DoWork();
+		//}
+
+
+
+		//public NTIWarningLetterResponse Execute(long warningLetterId)
+		//{
+		//	return ExecuteAsync(warningLetterId).Result;
+		//}
+
+		//public async Task<NTIWarningLetterResponse> ExecuteAsync(long warningLetterId)
+		//{
+		//	var warningLetter = await _gateway.GetNTIWarningLetterById(warningLetterId);
+		//	return NTIWarningLetterFactory.CreateResponse(warningLetter);
+		//}
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/NTIWarningLetters/NTIWarningLetterConditionMappingConfiguration.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/NTIWarningLetters/NTIWarningLetterConditionMappingConfiguration.cs
@@ -21,5 +21,7 @@ public class NTIWarningLetterConditionMappingConfiguration : IEntityTypeConfigur
 			.HasOne(n => n.NTIWarningLetterCondition)
 			.WithMany(n => n.WarningLetterConditionsMapping)
 			.HasForeignKey(n => n.NTIWarningLetterConditionId);
+
+		//builder.HasQueryFilter(t => !t.NTIWarningLetterCondition.IsDeleted);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/NTIWarningLetters/NTIWarningLetterConfiguration.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/NTIWarningLetters/NTIWarningLetterConfiguration.cs
@@ -13,5 +13,7 @@ public class NTIWarningLetterConfiguration : IEntityTypeConfiguration<NTIWarning
 		builder.HasKey(e => e.Id);
 		
 		builder.HasIndex(x => new {x.CaseUrn, x.CreatedAt}).IsUnique();
+		builder.HasQueryFilter(f => !f.DeletedAt.HasValue);
+
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/INTIWarningLetterGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/INTIWarningLetterGateway.cs
@@ -12,5 +12,6 @@ namespace ConcernsCaseWork.Data.Gateways
         Task<List<NTIWarningLetterConditionType>> GetAllConditionTypes();
         Task<ICollection<NTIWarningLetter>> GetNTIWarningLetterByCaseUrn(int caseUrn);
         Task<NTIWarningLetter> PatchNTIWarningLetter(NTIWarningLetter patchNTIWarningLetter);
-    }
+		void Delete(long warningLetterId);
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/NTIWarningLetterGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/NTIWarningLetterGateway.cs
@@ -94,5 +94,16 @@ namespace ConcernsCaseWork.Data.Gateways
                 throw;
             }
         }
-    }
+
+		public void Delete(long warningLetterId)
+		{
+			var result = _concernsDbContext.NTIWarningLetters.SingleOrDefault(n => n.Id == warningLetterId);
+			if (result != null)
+			{
+				result.DeletedAt = System.DateTime.Now;
+			}
+
+			_concernsDbContext.SaveChanges();
+		}
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230531154724_AddDeletedAtToNtiWarningLetter.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230531154724_AddDeletedAtToNtiWarningLetter.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230531154724_AddDeletedAtToNtiWarningLetter")]
+    partial class AddDeletedAtToNtiWarningLetter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230531154724_AddDeletedAtToNtiWarningLetter.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230531154724_AddDeletedAtToNtiWarningLetter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletedAtToNtiWarningLetter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "NTIWarningLetterCase",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "NTIWarningLetterCase");
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/NTIWarningLetter.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/NTIWarningLetter.cs
@@ -16,8 +16,10 @@ namespace ConcernsCaseWork.Data.Models
         public DateTime CreatedAt { get; set; }
         public DateTime? UpdatedAt { get; set; }
         public DateTime? ClosedAt { get; set; }
+		public DateTime? DeletedAt { get; set; }
 
-        [ForeignKey(nameof(StatusId))]
+
+		[ForeignKey(nameof(StatusId))]
         public virtual NTIWarningLetterStatus Status { get; set; }
 
         [ForeignKey(nameof(ClosedStatusId))]


### PR DESCRIPTION
**What is the change?**
Add Api endpoint to allow deleting of NTI Warning Letter relating to a case. Adds new field to the NTIWarningLetter table called DeletedAt

**Why do we need the change?**
Provide automated means to flag data as being deleted so it can be removed from reports and as an enabling piece of work to allows user to delete via the frontend.

**What is the impact?**
New capability for the Api which introduces the concept of a soft delete for an NTI Warning Letter

**Azure DevOps Ticket**
[130435](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/130435)