### PR TITLE
130434: Api endpoint to soft delete a Notice To Improve

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/NoticeToImproveControllerTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/NoticeToImproveControllerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using System.Threading.Tasks;
 using Xunit;
+using ConcernsCaseWork.API.UseCases.CaseActions.NTI.NoticeToImprove;
 
 namespace ConcernsCaseWork.API.Tests.Controllers
 {
@@ -25,6 +26,10 @@ namespace ConcernsCaseWork.API.Tests.Controllers
 		private readonly Mock<IUseCase<long, NoticeToImproveResponse>> _mockGetNoticeToImproveByIdUseCase;
 		private readonly Mock<IUseCase<int, List<NoticeToImproveResponse>>> _mockGetNoticeToImproveByCaseUrnUseCase;
 		private readonly Mock<IUseCase<PatchNoticeToImproveRequest, NoticeToImproveResponse>> _mockPatchNoticeToImproveUseCase;
+		private readonly Mock<IUseCase<long, DeleteNoticeToImproveResponse>> _mockDeleteNoticeToImproveByIdUseCase;
+
+
+
 		private readonly Mock<IUseCase<object, List<NoticeToImproveStatus>>> _mockGetAllStatuses;
 		private readonly Mock<IUseCase<object, List<NoticeToImproveReason>>> _mockGetAllReasons;
 		private readonly Mock<IUseCase<object, List<NoticeToImproveCondition>>> _mockGetAllCondition;
@@ -43,9 +48,10 @@ namespace ConcernsCaseWork.API.Tests.Controllers
 			_mockGetAllReasons = new Mock<IUseCase<object, List<NoticeToImproveReason>>>();
 			_mockGetAllCondition = new Mock<IUseCase<object, List<NoticeToImproveCondition>>>();
 			_mockGetAllConditionType = new Mock<IUseCase<object, List<NoticeToImproveConditionType>>>();
+			_mockDeleteNoticeToImproveByIdUseCase = new Mock<IUseCase<long, DeleteNoticeToImproveResponse>>();
 
 			controllerSUT = new NoticeToImproveController(_mockLogger.Object, _mockCreateNoticeToImproveUseCase.Object, _mockGetNoticeToImproveByIdUseCase.Object,
-				_mockGetNoticeToImproveByCaseUrnUseCase.Object, _mockPatchNoticeToImproveUseCase.Object, _mockGetAllStatuses.Object, _mockGetAllReasons.Object,
+				_mockGetNoticeToImproveByCaseUrnUseCase.Object, _mockPatchNoticeToImproveUseCase.Object, _mockDeleteNoticeToImproveByIdUseCase.Object, _mockGetAllStatuses.Object, _mockGetAllReasons.Object,
 				_mockGetAllCondition.Object, _mockGetAllConditionType.Object);
 		}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NoticeToImproveIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NoticeToImproveIntegrationTests.cs
@@ -1,10 +1,16 @@
 ﻿using AutoFixture;
+using ConcernsCaseWork.API.RequestModels;
 using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.NoticeToImprove;
+using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.WarningLetter;
+using ConcernsCaseWork.API.ResponseModels;
 using ConcernsCaseWork.API.Tests.Fixtures;
 using ConcernsCaseWork.API.Tests.Helpers;
+using FizzWare.NBuilder;
 using FluentAssertions;
+using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -15,11 +21,13 @@ namespace ConcernsCaseWork.API.Tests.Integration
 	{
 		private readonly Fixture _fixture;
 		private readonly HttpClient _client;
+		private readonly RandomGenerator _randomGenerator;
 
 		public NoticeToImproveIntegrationTests(ApiTestFixture apiTestFixture)
 		{
 			_client = apiTestFixture.Client;
 			_fixture = new();
+			_randomGenerator = new RandomGenerator();
 		}
 
 		[Fact]
@@ -52,6 +60,78 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			var error = await result.Content.ReadAsStringAsync();
 			error.Should().Contain("The field CreatedBy must be a string with a maximum length of 300.");
 			error.Should().Contain("The field Notes must be a string with a maximum length of 2000.");
+		}
+
+		[Fact]
+		public async Task When_Delete_InvalidRequest_Returns_BadRequest()
+		{
+			var noticeToImproveId = 0;
+
+			var result = await _client.DeleteAsync($"/v2/case-actions/notice-to-improve/{noticeToImproveId}");
+			result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+		}
+
+		[Fact]
+		public async Task When_Delete_NotCreatedResourceRequest_Returns_NotFound()
+		{
+			var noticeToImproveId = 1;
+
+			var result = await _client.DeleteAsync($"/v2/case-actions/notice-to-improve/{noticeToImproveId}");
+			result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		}
+
+		[Fact]
+		public async Task When_Delete_ValidResourceRequest_Returns_NoContent()
+		{
+			//Create the case
+			ConcernCaseRequest createCaseRequest = Builder<ConcernCaseRequest>.CreateNew()
+				.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
+				.With(c => c.Description = "")
+				.With(c => c.CrmEnquiry = "")
+				.With(c => c.TrustUkprn = "100223")
+				.With(c => c.ReasonAtReview = "")
+				.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
+				.With(c => c.Issue = "Here is the issue")
+				.With(c => c.CurrentStatus = "Case status")
+				.With(c => c.CaseAim = "Here is the aim")
+				.With(c => c.DeEscalationPoint = "Point of de-escalation")
+				.With(c => c.CaseHistory = "Case history")
+				.With(c => c.NextSteps = "Here are the next steps")
+				.With(c => c.DirectionOfTravel = "Up")
+				.With(c => c.StatusId = 1)
+				.With(c => c.RatingId = 2)
+				.With(c => c.TrustCompaniesHouseNumber = "12345678")
+				.Build();
+
+			var createCaseResponse = await _client.PostAsync($"v2/concerns-cases", createCaseRequest.ConvertToJson());
+			var response = await createCaseResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
+
+			var CaseUrn = response.Data.Urn;
+			//create the nti
+			var request = _fixture.Create<CreateNoticeToImproveRequest>();
+			request.CaseUrn = CaseUrn;
+			request.ClosedStatusId = 1;
+			request.StatusId = 1;
+			request.NoticeToImproveConditionsMapping.Clear();
+			request.NoticeToImproveConditionsMapping.Add(1);
+			request.NoticeToImproveReasonsMapping.Clear();
+			request.NoticeToImproveReasonsMapping.Add(1);
+
+			var result = await _client.PostAsync($"/v2/case-actions/notice-to-improve", request.ConvertToJson());
+			result.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			var createdNoticeToImproveUri = result.Headers.Location;
+			//check for the warning letter
+			var getResponse = await _client.GetAsync(createdNoticeToImproveUri);
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			//delete the warning letter
+			var deleteResponse = await _client.DeleteAsync(createdNoticeToImproveUri);
+			deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+			//check it is not returned
+			var getResponseNotFound = await _client.GetAsync(createdNoticeToImproveUri);
+			getResponseNotFound.StatusCode.Should().Be(HttpStatusCode.NotFound);
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/DeleteNoticeToImprove.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/DeleteNoticeToImprove.cs
@@ -1,0 +1,25 @@
+﻿using ConcernsCaseWork.Data.Gateways;
+
+namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.NoticeToImprove
+{
+	public class DeleteNoticeToImprove : IUseCase<long, DeleteNoticeToImproveResponse>
+	{
+		private readonly INoticeToImproveGateway _gateway;
+
+
+		public DeleteNoticeToImprove(INoticeToImproveGateway gateway)
+		{
+			_gateway = gateway;
+		}
+
+		public DeleteNoticeToImproveResponse Execute(long warningLetterId)
+		{
+			_gateway.Delete(warningLetterId);
+			return new DeleteNoticeToImproveResponse();
+		}
+	}
+
+	public class DeleteNoticeToImproveResponse
+	{
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/GetNoticeToImproveById.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/GetNoticeToImproveById.cs
@@ -21,7 +21,11 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.NoticeToImprove
         public async Task<NoticeToImproveResponse> ExecuteAsync(long noticeToImproveId)
         {
             var noticeToImprove = await _gateway.GetNoticeToImproveById(noticeToImproveId);
-            return NoticeToImproveFactory.CreateResponse(noticeToImprove);
+			if (noticeToImprove == null)
+			{
+				return null;
+			}
+			return NoticeToImproveFactory.CreateResponse(noticeToImprove);
         }
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/NoticeToImprove/NoticeToImproveCaseConfiguration.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/NoticeToImprove/NoticeToImproveCaseConfiguration.cs
@@ -12,5 +12,6 @@ public class NoticeToImproveCaseConfiguration : IEntityTypeConfiguration<Models.
 		builder.HasKey(e => e.Id);
 		
 		builder.HasIndex(x => new {x.CaseUrn, x.CreatedAt}).IsUnique();
+		builder.HasQueryFilter(f => !f.DeletedAt.HasValue);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/INoticeToImproveGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/INoticeToImproveGateway.cs
@@ -12,5 +12,6 @@ namespace ConcernsCaseWork.Data.Gateways
         Task<List<NoticeToImproveConditionType>> GetAllConditionTypes();
         Task<List<NoticeToImproveCondition>> GetAllConditions();        
         Task<NoticeToImprove> PatchNoticeToImprove(NoticeToImprove patchNoticeToImprove);
-    }
+		void Delete(long warningLetterId);
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/NoticeToImproveGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/NoticeToImproveGateway.cs
@@ -94,5 +94,16 @@ namespace ConcernsCaseWork.Data.Gateways
                 throw;
             }
         }
-    }
+
+		public void Delete(long noticeToImproveId)
+		{
+			var result = _concernsDbContext.NoticesToImprove.SingleOrDefault(n => n.Id == noticeToImproveId);
+			if (result != null)
+			{
+				result.DeletedAt = System.DateTime.Now;
+			}
+
+			_concernsDbContext.SaveChanges();
+		}
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230601101808_AddDeletedAtToNti.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230601101808_AddDeletedAtToNti.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230601101808_AddDeletedAtToNti")]
+    partial class AddDeletedAtToNti
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230601101808_AddDeletedAtToNti.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230601101808_AddDeletedAtToNti.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletedAtToNti : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "NoticeToImproveCase",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "NoticeToImproveCase");
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/NoticeToImprove.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/NoticeToImprove.cs
@@ -28,5 +28,6 @@ namespace ConcernsCaseWork.Data.Models
 
         public virtual ICollection<NoticeToImproveReasonMapping> NoticeToImproveReasonsMapping { get; set; }
         public virtual ICollection<NoticeToImproveConditionMapping> NoticeToImproveConditionsMapping { get; set; }
-    }
+		public DateTime? DeletedAt { get; set; }
+	}
 }


### PR DESCRIPTION
What is the change?
Add Api endpoint to allow deleting of Notice to Improve relating to a case. Adds new field to the NoticeToImprove table called DeletedAt

Why do we need the change?
Provide automated means to flag data as being deleted so it can be removed from reports and as an enabling piece of work to allows user to delete via the frontend.

What is the impact?
New capability for the Api which introduces the concept of a soft delete for a Notice To Improve

Azure DevOps Ticket
[130434](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/130434)