### PR TITLE
Bug/addiing multiple concerns to non concern

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
@@ -203,14 +203,14 @@ describe("Creating a case", () => {
             .addConcern();
 
 
-        // Logger.Log("Adding another concern during case creation");
+        Logger.Log("Adding another concern during case creation");
         createConcernPage
-        //     .addAnotherConcern()
-        //     .withConcernType("Governance and compliance")
-        //     .withSubConcernType("Governance and compliance: Compliance")
-        //     .withRating("Amber-Green")
-        //     .withMeansOfRefferal("Internal")
-        //     .addConcern()
+             .addAnotherConcern()
+            .withConcernType("Governance and compliance")
+            .withSubConcernType("Governance and compliance: Compliance")
+            .withConcernRating("Amber-Green")
+            .withMeansOfReferral("Internal")
+            .addConcern()
             .nextStep();
 
         Logger.Log("Check unpopulated risk to trust throws validation error");
@@ -258,7 +258,7 @@ describe("Creating a case", () => {
         caseManagementPage
             .hasTrust("Ashton West End Primary Academy")
             .hasRiskToTrust("Red Plus")
-          //  .hasConcerns("Governance and compliance: Compliance", ["Amber", "Green"])
+           .hasConcerns("Governance and compliance: Compliance", ["Amber", "Green"])
             .hasConcerns("Financial: Deficit", ["Red", "Amber"])
             .hasTerritory("North and UTC - North East")
             .hasIssue("This is an issue")
@@ -272,7 +272,7 @@ describe("Creating a case", () => {
             caseManagementPage.getCaseIDText().then((caseId) => {
                 concernsApi.get(parseInt(caseId))
                     .then(response => {
-                        expect(response[0].meansOfReferralId).to.eq(2);
+                        expect(response[0].meansOfReferralId).to.eq(1);
                     });
             });
     });

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Add.cshtml
@@ -53,11 +53,22 @@ else
                             </div>
                         </div>
                     }
-                    <span class="govuk-!-padding-right-1 govuk-grid-column-two-thirds">
-                        <a data-prevent-double-click="true" asp-page="index" class="govuk-link" data-module="govuk-button" role="button" data-testid="add-concern-button">
-                            Add concern
-                        </a>
-                    </span>
+                    @if (Model?.CaseModel?.Urn > 0)
+                    {
+	                    <span class="govuk-!-padding-right-1 govuk-grid-column-two-thirds">
+		                    <a data-prevent-double-click="true" asp-page="index" class="govuk-link" asp-route-urn="@Model.CaseModel.Urn" data-module="govuk-button" role="button" data-testid="add-concern-button">
+			                    Add concern
+		                    </a>
+	                    </span>
+                    }
+                    else
+                    {
+	                    <span class="govuk-!-padding-right-1 govuk-grid-column-two-thirds">
+		                    <a data-prevent-double-click="true" asp-page="index" class="govuk-link" data-module="govuk-button" role="button" data-testid="add-concern-button">
+			                    Add concern
+		                    </a>
+	                    </span>
+                    }
                 </div>
             </dd>
         </div>


### PR DESCRIPTION
**What is the change?**
Added Cypress tests for a bug on adding multiple concerns to a non-concern. (This PR includes the whole journey from start to finish and not only limited to this bug)

**Why do we need the change?**
In this PR I have introduced Cypress tests to address a bug related to adding multiple concerns to a non-concern scenario. The bug was causing issues with the correct passing of the Case ID when adding a new concern. By adding these tests, we ensure that the bug is fixed and the functionality works as expected.

**Reason for the Change:**
The implementation of Cypress tests for this bug was deemed necessary based on the project requirements. By adding these tests, we can verify that the issue with incorrect Case ID passing is resolved and prevent its recurrence in the future. This change aligns with the goal of ensuring a robust and error-free application.
**What is the impact?**
The impact of this code change is significant. By addressing the bug and fixing the Case ID passing issue, we ensure that the process of adding multiple concerns to a non-concern scenario works correctly. This improvement enhances the overall reliability and accuracy of the system, resulting in a better user experience.

**Azure DevOps Tickets:**
The following Azure DevOps tickets are associated with this change:

Important as this push fixes an issue we had where the Case ID was not passing correctly when adding a new concern. 
**Azure DevOps Ticket**
[User Story 129031](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/129031): Non-Conc To Conc Story 1 - Add 'Add concern' link
[User Story 129032](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/129032): Non-Conc to Conc Story 2 - Add type of concern to case
[User Story 129033](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/129033): Non-Conc to Conc Story 3 - Add other concern or go to Trust Risk
[User Story 129034](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/129034): Non-Conc to Conc Story 4 - Add Trust Risk
[User Story 129035](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/129035): Non-Conc to Conc Story 5 - Add narrative case details