### PR TITLE
130657: Enable autoselect on accessibleautocomplete

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
@@ -67,6 +67,7 @@
                 defaultValue:currentCaseOwner,
                 source: result,
                 confirmOnBlur: false,
+                autoselect: true,
                 showNoOptonsFound: true,
                 onConfirm: (selected) => {
 					document.getElementById('selected-owner').value = selected;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -125,6 +125,7 @@
             name: "trustSearch",
             source: searchForTrusts,
             confirmOnBlur: false,
+            autoselect: true,
             minLength: @trustSearchOptions.Value.MinCharsRequiredToSeach,
             showNoOptonsFound: true,
             onConfirm: (selected) => {


### PR DESCRIPTION
**What is the change?**
Enable auto select on control used to find trusts and select a case owner.

**Why do we need the change?**
To allow users to use the search functionality using the keyboard in order achieve WCAG 2.1

**What is the impact?**
Users can now use tab and enter buttons to interact with the system select a trust or case owner

**Azure DevOps Ticket**
[130657](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/130657)