### PR TITLE
131520: added sort order to components

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/decisions.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/decisions.cy.ts
@@ -9,6 +9,7 @@ import "cypress-axe";
 import actionSummaryTable from "cypress/pages/caseActions/summary/actionSummaryTable";
 import { toDisplayDate } from "cypress/support/formatDate";
 import { DateIncompleteError, DateInvalidError, NotesError } from "cypress/constants/validationErrorConstants";
+import validationComponent from "cypress/pages/validationComponent";
 
 describe("User can add decisions to an existing case", () => {
 	const viewDecisionPage = new ViewDecisionPage();
@@ -326,14 +327,8 @@ describe("User can add decisions to an existing case", () => {
 			.hasNoDecisionOutcome()
 			.createDecisionOutcome();
 
-		Logger.Log("Checking when no status is selected");
+		Logger.Log("Checking validation ");
 		decisionOutcomePage
-			.saveDecisionOutcome()
-			.hasValidationError("Select a decision outcome");
-
-		Logger.Log("Checking an invalid date");
-		decisionOutcomePage
-			.withDecisionOutcomeStatus("Withdrawn")
 			.withDateDecisionMadeDay("24")
 			.withDateDecisionMadeMonth("13")
 			.withDateDecisionMadeYear("2022")
@@ -341,14 +336,18 @@ describe("User can add decisions to an existing case", () => {
 			.withDecisionTakeEffectMonth("22")
 			.withDecisionTakeEffectYear("2023")
 			.saveDecisionOutcome()
-			.hasValidationError(DateInvalidError.replace("{0}", "Date decision was made"))
-			.hasValidationError(DateInvalidError.replace("{0}", "Date decision takes effect"))
+
+		validationComponent.hasValidationErrorsInOrder([
+			"Select a decision outcome",
+			DateInvalidError.replace("{0}", "Date decision was made"),
+			DateInvalidError.replace("{0}", "Date decision takes effect")
+		]);
 
 		Logger.Log("Checking accessibility on Add Decision Outcome");
 		cy.excuteAccessibilityTests();
 
-		Logger.Log("Checking an incomplete dates");
 		decisionOutcomePage
+			.withDecisionOutcomeStatus("Withdrawn")
 			.withDateDecisionMadeDay("24")
 			.withDateDecisionMadeMonth("12")
 			.withDateDecisionMadeYear("")
@@ -356,8 +355,11 @@ describe("User can add decisions to an existing case", () => {
 			.withDecisionTakeEffectMonth("06")
 			.withDecisionTakeEffectYear("")
 			.saveDecisionOutcome()
-			.hasValidationError(DateIncompleteError.replace("{0}", "Date decision was made"))
-			.hasValidationError(DateIncompleteError.replace("{0}", "Date decision takes effect"));
+
+		validationComponent.hasValidationErrorsInOrder([
+			DateIncompleteError.replace("{0}", "Date decision was made"),
+			DateIncompleteError.replace("{0}", "Date decision takes effect")
+		]);
 
 		Logger.Log("Create Decision Outcome");
 		decisionOutcomePage

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/srma.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/srma.cy.ts
@@ -6,6 +6,7 @@ import { ViewSrmaPage } from "../../../pages/caseActions/srma/viewSrmaPage";
 import actionSummaryTable from "cypress/pages/caseActions/summary/actionSummaryTable";
 import { toDisplayDate } from "cypress/support/formatDate";
 import { DateIncompleteError, DateInvalidError, NotesError } from "cypress/constants/validationErrorConstants";
+import validationComponent from "cypress/pages/validationComponent";
 
 describe("Testing the SRMA case action", () =>
 {
@@ -104,18 +105,24 @@ describe("Testing the SRMA case action", () =>
         editSrmaPage
             .withStartDayOfVisit("22")
             .withEndDayOfVisit("11")
-            .save()
-            .hasValidationError(DateIncompleteError.replace("{0}", "Start date"))
-            .hasValidationError(DateIncompleteError.replace("{0}", "End date"));
+            .save();
+
+        validationComponent.hasValidationErrorsInOrder([
+            DateIncompleteError.replace("{0}", "Start date"),
+            DateIncompleteError.replace("{0}", "End date")
+        ]);
 
         editSrmaPage
             .withStartMonthOfVisit("22")
             .withStartYearOfVisit("2022")
             .withEndMonthOfVisit("33")
             .withEndYearOfVisit("2021")
-            .save()
-            .hasValidationError(DateInvalidError.replace("{0}", "Start date"))
-            .hasValidationError(DateInvalidError.replace("{0}", "End date"));
+            .save();
+
+        validationComponent.hasValidationErrorsInOrder([
+            DateInvalidError.replace("{0}", "Start date"),
+            DateInvalidError.replace("{0}", "End date")
+        ]);
 
         Logger.Log("Checking accessibility on Add Dates of visit");
         cy.excuteAccessibilityTests();
@@ -126,9 +133,12 @@ describe("Testing the SRMA case action", () =>
             .withEndDayOfVisit("15")
             .withEndMonthOfVisit("01")
             .withEndYearOfVisit("2021")
-            .save()
-            .hasValidationError("Start date must be the same as or come before the end date")
-            .hasValidationError("End date must be the same as or come after the start date");
+            .save();
+
+        validationComponent.hasValidationErrorsInOrder([
+            "Start date must be the same as or come before the end date",
+            "End date must be the same as or come after the start date"
+        ]);
 
         editSrmaPage
             .withEndDayOfVisit("15")
@@ -402,10 +412,14 @@ describe("Testing the SRMA case action", () =>
 
             viewSrmaPage
                 .resolve()
-                .hasValidationError("Add reason for SRMA")
-                .hasValidationError("Enter date trust accepted SRMA")
-                .hasValidationError("Enter dates of visit")
-                .hasValidationError("Enter date report sent to trust");
+            
+            validationComponent.hasValidationErrorsInOrder([
+                    "Add reason for SRMA",
+                    "Enter date trust accepted SRMA",
+                    "Enter dates of visit",
+                    "Enter date report sent to trust"
+                ]
+            );
 
             completeSrmaConfiguration();
 
@@ -415,9 +429,12 @@ describe("Testing the SRMA case action", () =>
 
             editSrmaPage
                 .withNotesExceedingLimit()
-                .save()
-                .hasValidationError("Confirm SRMA action is complete")
-                .hasValidationError(NotesError);
+                .save();
+
+            validationComponent.hasValidationErrorsInOrder([
+                "Confirm SRMA action is complete",
+                NotesError
+            ]);
 
             Logger.Log("Checking accessibility on Resolve SRMA");
             cy.excuteAccessibilityTests();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/trust-financial-forecast.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/trust-financial-forecast.cy.ts
@@ -7,6 +7,7 @@ import AddToCasePage from "../../../pages/caseActions/addToCasePage";
 import actionSummaryTable from "cypress/pages/caseActions/summary/actionSummaryTable";
 import { toDisplayDate } from "cypress/support/formatDate";
 import { DateIncompleteError, DateInvalidError, NotesError } from "cypress/constants/validationErrorConstants";
+import validationComponent from "cypress/pages/validationComponent";
 
 describe("User can add trust financial forecast to an existing case", () => {
 
@@ -260,8 +261,12 @@ describe("User can add trust financial forecast to an existing case", () => {
 			.withDayReviewHappened("90")
 			.withDayTrustResponded("270")
 			.save()
-			.hasValidationError(DateIncompleteError.replace("{0}", "Date trust responded"))
-			.hasValidationError(DateIncompleteError.replace("{0}", "Date SFSO initial review happened"));
+
+		// Ensure errors appear in field order
+		validationComponent.hasValidationErrorsInOrder([
+			DateIncompleteError.replace("{0}", "Date SFSO initial review happened"),
+			DateIncompleteError.replace("{0}", "Date trust responded")
+		]);
 
 		editTFFPage
 			.withMonthReviewHappened("60")
@@ -270,9 +275,12 @@ describe("User can add trust financial forecast to an existing case", () => {
 			.withYearTrustResponded("2024")
 			.withNotesExceedingLimit()
 			.save()
-			.hasValidationError(NotesError)
-			.hasValidationError(DateInvalidError.replace("{0}", "Date trust responded"))
-			.hasValidationError(DateInvalidError.replace("{0}", "Date SFSO initial review happened"));
+
+		validationComponent.hasValidationErrorsInOrder([
+			DateInvalidError.replace("{0}", "Date SFSO initial review happened"),
+			DateInvalidError.replace("{0}", "Date trust responded"),
+			NotesError
+		]);
 
 		Logger.Log("Checking accessibility on Add/Edit TFF");
 		cy.excuteAccessibilityTests();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
@@ -8,6 +8,7 @@ import caseManagementPage from "cypress/pages/caseMangementPage";
 import concernsApi from "cypress/api/concernsApi";
 import caseApi from "cypress/api/caseApi";
 import createCaseSummary from "cypress/pages/createCase/createCaseSummary";
+import validationComponent from "cypress/pages/validationComponent";
 
 describe("Creating a case", () =>
 {
@@ -41,9 +42,12 @@ describe("Creating a case", () =>
         Logger.Log("Attempt to create an invalid concern");
         createConcernPage
             .addConcern()
-            .hasValidationError("Select concern type")
-            .hasValidationError("Select concern risk rating")
-            .hasValidationError("Select means of referral");
+
+        validationComponent
+            .hasValidationErrorsInOrder([
+                "Select concern type",
+                "Select concern risk rating",
+                "Select means of referral"]);
 
         Logger.Log("Checking accessibility on concern");
         cy.excuteAccessibilityTests();
@@ -126,13 +130,16 @@ describe("Creating a case", () =>
             .withDeEscalationPointExceedingLimit()
             .withNextStepsExceedingLimit()
             .withCaseHistoryExceedingLimit()
-            .createCase()
-            .hasValidationError("Issue must be 2000 characters or less")
-            .hasValidationError("Current status must be 4000 characters or less")
-            .hasValidationError("Case aim must be 1000 characters or less")
-            .hasValidationError("De-escalation point must be 1000 characters or less")
-            .hasValidationError("Next steps must be 4000 characters or less")
-            .hasValidationError("Case history must be 4300 characters or less");
+            .createCase();
+
+        validationComponent.hasValidationErrorsInOrder([
+            "Issue must be 2000 characters or less",
+            "Current status must be 4000 characters or less",
+            "Case aim must be 1000 characters or less",
+            "De-escalation point must be 1000 characters or less",
+            "Next steps must be 4000 characters or less",
+            "Case history must be 4300 characters or less"
+        ]);
 
         Logger.Log("Checking accessibility on concerns case confirmation");
         cy.excuteAccessibilityTests();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/validationComponent.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/validationComponent.ts
@@ -1,0 +1,30 @@
+class ValidationComponent
+{
+    public hasValidationError(message: string): this {
+		cy.task("log", `Has Validation error ${message}`);
+
+		cy.getById("errorSummary").should(
+			"contain.text",
+			message
+		);
+
+		return this;
+	}
+
+    public hasValidationErrorsInOrder(errors: string[])
+    {
+        cy.task("log", `Has validation errors in order ${errors.join(",")}`);
+
+        cy.getById("errorSummary")
+            .find(".govuk-error-message")
+            .should("have.length", errors.length)
+            .each(($elem, index) => {
+                expect($elem.text().trim()).to.equal(errors[index]);
+            });
+
+        return this;
+    }
+}
+
+const validationComponent = new ValidationComponent();
+export default validationComponent;

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/BaseUiComponent.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/BaseUiComponent.cs
@@ -26,4 +26,11 @@ public record BaseUiComponent
 	public string ErrorTextForRequiredField { get; set; }
 
 	public string? HintText { get; set; }
+
+	/// <summary>
+	/// For some reason the order of errors is not always the order the properties are added
+	/// Could not find any explanation for why this happens and have not been able to find a solution in the framework
+	/// Allows us to force a specific order when validation errors are displayed out of order
+	/// </summary>
+	public int? SortOrder { get; set; }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Base/AbstractPageModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Base/AbstractPageModel.cs
@@ -14,7 +14,6 @@ namespace ConcernsCaseWork.Pages.Base
 	{
 		public const string ErrorOnGetPage = ErrorConstants.ErrorOnGetPage;
 		public const string ErrorOnPostPage = ErrorConstants.ErrorOnPostPage;
-		public SortOrder? ErrorSortOrder { get; set; }
 		
 		// Configured in startup
 		public static IPageHistoryStorageHandler PageHistoryStorageHandler { get; set; }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml
@@ -46,11 +46,11 @@
 		<!-- FORM -->
 		<form role="form" method="post" id="case-concern-form" novalidate>
 
+
             <partial name="Components/_RadioList" model="Model.ConcernType" />
-
             <partial name="Components/_RadioList" model="Model.ConcernRiskRating" />
-
             <partial name="Components/_RadioList" model="Model.MeansOfReferral" />
+
 
 			<div class="govuk-button-group">
 				<button id="add-concern-button" data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button" data-testid="add-concern-button">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using JsonSerializer = System.Text.Json.JsonSerializer;
@@ -45,10 +46,10 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 		public RadioButtonsUiComponent ConcernType { get; set; }
 
 		[BindProperty]
-		public RadioButtonsUiComponent MeansOfReferral { get; set; }
+		public RadioButtonsUiComponent ConcernRiskRating { get; set; }
 
 		[BindProperty]
-		public RadioButtonsUiComponent ConcernRiskRating { get; set; }
+		public RadioButtonsUiComponent MeansOfReferral { get; set; }
 
 		[BindProperty(SupportsGet = true, Name = "Urn")]
 		public int? CaseUrn { get; set; }
@@ -212,9 +213,14 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 			CreateRecordsModel = new List<CreateRecordModel>();
 			var ratingsModel = await _ratingModelService.GetRatingsModel();
 
-			MeansOfReferral = CaseComponentBuilder.BuildMeansOfReferral(nameof(MeansOfReferral), MeansOfReferral?.SelectedId);
-			ConcernRiskRating = CaseComponentBuilder.BuildConcernRiskRating(nameof(ConcernRiskRating), ratingsModel, ConcernRiskRating?.SelectedId);
 			ConcernType = CaseComponentBuilder.BuildConcernType(nameof(ConcernType), ConcernType?.SelectedId, ConcernType?.SelectedSubId);
+			ConcernType.SortOrder = 1;
+
+			ConcernRiskRating = CaseComponentBuilder.BuildConcernRiskRating(nameof(ConcernRiskRating), ratingsModel, ConcernRiskRating?.SelectedId);
+			ConcernRiskRating.SortOrder = 2;
+
+			MeansOfReferral = CaseComponentBuilder.BuildMeansOfReferral(nameof(MeansOfReferral), MeansOfReferral?.SelectedId);
+			MeansOfReferral.SortOrder = 3;
 
 			AppInsightsHelper.LogEvent(_telemetryClient, new AppInsightsModel()
 			{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml.cs
@@ -150,11 +150,22 @@ namespace ConcernsCaseWork.Pages.Case
 			});
 
 			Issue = CaseComponentBuilder.BuildIssue(nameof(Issue), Issue?.Text.StringContents);
+			Issue.SortOrder = 1;
+
 			CurrentStatus = CaseComponentBuilder.BuildCurrentStatus(nameof(CurrentStatus), CurrentStatus?.Text.StringContents);
+			CurrentStatus.SortOrder = 2;
+
 			CaseAim = CaseComponentBuilder.BuildCaseAim(nameof(CaseAim), CaseAim?.Text.StringContents);
+			CaseAim.SortOrder = 3;
+
 			DeEscalationPoint = CaseComponentBuilder.BuildDeEscalationPoint(nameof(DeEscalationPoint), DeEscalationPoint?.Text.StringContents);
+			DeEscalationPoint.SortOrder = 4;
+
 			NextSteps = CaseComponentBuilder.BuildNextSteps(nameof(NextSteps), NextSteps?.Text.StringContents);
+			NextSteps.SortOrder = 5;
+
 			CaseHistory = CaseComponentBuilder.BuildCaseHistory(nameof(CaseHistory), CaseHistory?.Text.StringContents);
+			CaseHistory.SortOrder = 6;
 		}
 
 		private async Task<UserState> GetUserState()

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Outcome/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Outcome/Add.cshtml.cs
@@ -177,7 +177,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision.Outcome
 				SelectedId = selectedId,
 				Required = true,
 				DisplayName = "decision outcome",
-				ErrorTextForRequiredField = "Select a decision outcome"
+				ErrorTextForRequiredField = "Select a decision outcome",
+				SortOrder = 1
 			};
 		}
 
@@ -203,7 +204,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision.Outcome
 			return new OptionalDateTimeUiComponent("decision-made", nameof(DecisionMadeDate), "When was the decision made?")
 			{
 				Date = date,
-				DisplayName = "Date decision was made"
+				DisplayName = "Date decision was made",
+				SortOrder = 2
 			};
 		}
 
@@ -212,7 +214,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision.Outcome
 			return new OptionalDateTimeUiComponent("take-effect", nameof(DecisionEffectiveFromDate), "When did or does the decision take effect?")
 			{
 				Date = date,
-				DisplayName = "Date decision takes effect"
+				DisplayName = "Date decision takes effect",
+				SortOrder = 3
 			};
 		}
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Edit/DateOfVisit.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/SRMA/Edit/DateOfVisit.cshtml.cs
@@ -35,8 +35,6 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA.Edit
 		{
 			_srmaModelService = srmaModelService;
 			_logger = logger;
-			//Ensure start error comes before end errors
-			ErrorSortOrder = SortOrder.Descending;
 		}
 
 		public async Task<ActionResult> OnGetAsync()
@@ -132,7 +130,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA.Edit
 			return new OptionalDateTimeUiComponent("start", nameof(StartDate), "Start date")
 			{
 				Date = date,
-				DisplayName = "Start date"
+				DisplayName = "Start date",
+				SortOrder = 1
 			};
 		}
 
@@ -141,7 +140,8 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.SRMA.Edit
 			return new OptionalDateTimeUiComponent("end", nameof(EndDate), "End date")
 			{
 				Date = date,
-				DisplayName = "End date"
+				DisplayName = "End date",
+				SortOrder = 2
 			};
 		}
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/TrustFinancialForecast/EditableTrustFinancialForecastPageModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/TrustFinancialForecast/EditableTrustFinancialForecastPageModel.cs
@@ -70,6 +70,7 @@ public class EditableTrustFinancialForecastPageModel : AbstractPageModel
 	private static TextAreaUiComponent BuildNotesComponent(string contents = "")
 		=> new("notes", nameof(Notes), "Notes")
 		{
+			SortOrder = 3,
 			Text = new ValidateableString()
 			{
 				MaxLength = TrustFinancialForecastConstants.MaxNotesLength,
@@ -82,13 +83,15 @@ public class EditableTrustFinancialForecastPageModel : AbstractPageModel
 		=> new ("trust-responded-at", nameof(TrustRespondedAt), "When did the trust respond?")
 		{
 			Date = selectedDate,
-			DisplayName = "Date trust responded"
+			DisplayName = "Date trust responded",
+			SortOrder = 2
 		};
 		
 	private static OptionalDateTimeUiComponent BuildSFSOInitialReviewHappenedAtComponent([CanBeNull] OptionalDateModel selectedDate = default)
 		=> new("sfso-initial-review-happened-at", nameof(SFSOInitialReviewHappenedAt), "When did SFSO initial review happen?")
 		{
 			Date = selectedDate,
-			DisplayName = "Date SFSO initial review happened"
+			DisplayName = "Date SFSO initial review happened",
+			SortOrder = 1
 		};
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ValidationErrors.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_ValidationErrors.cshtml
@@ -9,38 +9,40 @@
 	var errors = Model.ModelState
 			.Where(s => s.Value?.ValidationState == ModelValidationState.Invalid)
 			.Select(e => new { e.Key, Msg = string.Join("<br />", e.Value.Errors.Select(errs => errs?.ErrorMessage)) });
-			
-	if (Model.ErrorSortOrder.HasValue)
-	{
-		errors = Model.ErrorSortOrder.Value.Equals(SortOrder.Ascending) ? errors .OrderBy(e => e.Key) : errors .OrderByDescending(e => e.Key);
-	}
+
+    var formattedErrors = errors.Select((error, index) =>
+    {
+        var propertyName = error.Key.Split(".").First();
+
+        object selectedProperty = Model.GetType().GetProperty(propertyName)?.GetValue(Model);
+
+        var containerId = "";
+        var sortOrder = index;
+
+        if (selectedProperty is BaseUiComponent)
+        {
+            var component = selectedProperty as BaseUiComponent;
+            containerId = $"container-{component.ElementRootId}";
+            sortOrder = component.SortOrder.HasValue ? component.SortOrder.Value : sortOrder;
+        }
+        else
+        {
+            containerId = $"container-{error.Key}";
+        }
+
+        return new { ContainerId = containerId, SortOrder = sortOrder, ErrorMessage = error.Msg };
+    }).OrderBy(error => error.SortOrder);
 
 
 	<div tabindex="-1" role="group" id="errorSummary" class="govuk-error-summary" data-module="error-summary" aria-labelledby="errorSummary-heading">
 		<h2 id="error-summary-title" class="govuk-error-summary__title">There is a problem</h2>
 		<div class="govuk-error-summary__body">
 			<ul class="govuk-list govuk-error-summary__list">
-				@foreach (var error in errors)
-				{
-                    var propertyName = error.Key.Split(".").First();
-
-                    object selectedProperty = Model.GetType().GetProperty(propertyName)?.GetValue(Model);
-
-                    var containerId = "";
-
-                    if (selectedProperty is BaseUiComponent)
-                    {
-                        var component = selectedProperty as BaseUiComponent;
-                        containerId = $"container-{component.ElementRootId}";
-                    }
-                    else
-                    {
-                        containerId = $"container-{error.Key}";
-                    }
-
-                    <li><a tabindex="0" aria-label="Error: @error.Msg" class="govuk govuk-error-message scrollable-error" data-scroll-to="@containerId">@error.Msg</a></li>
-				}
-			</ul>
+                @foreach (var error in formattedErrors)
+                {
+                    <li><a tabindex="0" aria-label="Error: @error.ErrorMessage" class="govuk govuk-error-message scrollable-error" data-scroll-to="@error.ContainerId">@error.ErrorMessage</a></li>
+                }
+            </ul>
 		</div>
 	</div>
 }


### PR DESCRIPTION
**What is the change?**

the order of properties can be wrong when displaying validation error messages

there is no real explanation for this, so there is a sort order property on components that can force a certain order

updated cypress to check the order of validation messages

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=131520