### PR TITLE
125231: added submission decision id to the nti closed page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/nti.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/nti.cy.ts
@@ -232,6 +232,33 @@ describe("Testing case action NTI", () =>
             .cancel();
 
         assertClosedNti("Cancelled");
+
+        viewNtiPage
+            .hasDateCancelled(toDisplayDate(now));
+    });
+
+    it("Should cancel an nti with empty fields", () =>
+    {
+        Logger.Log("Saving an empty form");
+        editNtiPage.save();
+
+        Logger.Log("Validate the NTI on the view page");
+		actionSummaryTable
+			.getOpenAction("NTI")
+			.then(row =>
+			{
+				row.select();
+			});
+
+        viewNtiPage.cancel();
+
+        cancelNtiPage
+            .cancel();
+
+        assertEmptyClosedNti("Cancelled");
+
+        viewNtiPage
+            .hasDateCancelled(toDisplayDate(now));
     });
 
     it("Should be able to lift an NTI", () =>
@@ -277,6 +304,35 @@ describe("Testing case action NTI", () =>
             .lift();
 
         assertClosedNti("Lifted");
+
+        viewNtiPage
+            .hasDateLifted("12 July 2005")
+            .hasSubmissionDecisionId("123456");
+    });
+
+    it("Should lift an nti with empty fields", () =>
+    {
+        Logger.Log("Saving an empty form");
+        editNtiPage.save();
+
+        Logger.Log("Validate the NTI on the view page");
+		actionSummaryTable
+			.getOpenAction("NTI")
+			.then(row =>
+			{
+				row.select();
+			});
+
+        viewNtiPage.lift();
+
+        liftNtiPage
+            .lift();
+
+        assertEmptyClosedNti("Lifted");
+
+        viewNtiPage
+            .hasDateLifted("Empty")
+            .hasSubmissionDecisionId("Empty");
     });
 
     it("Should be able to close an NTI", () =>
@@ -320,6 +376,30 @@ describe("Testing case action NTI", () =>
 
         viewNtiPage
             .hasDateClosed("15 December 2020");
+    });
+
+    it("Should close an nti with empty fields", () =>
+    {
+        Logger.Log("Saving an empty form");
+        editNtiPage.save();
+
+        Logger.Log("Validate the NTI on the view page");
+		actionSummaryTable
+			.getOpenAction("NTI")
+			.then(row =>
+			{
+				row.select();
+			});
+
+        viewNtiPage.close();
+
+        closeNtiPage
+            .close();
+
+        assertEmptyClosedNti("Closed");
+
+        viewNtiPage
+            .hasDateClosed("Empty");
     });
 
     function addNtiToCase()
@@ -402,5 +482,29 @@ describe("Testing case action NTI", () =>
 
             Logger.Log("Checking accessibility on View Closed NTI");
             cy.excuteAccessibilityTests();
+    }
+
+    function assertEmptyClosedNti(expectedStatus: string)
+    {
+        Logger.Log("Viewing the closed empty NTI");
+		actionSummaryTable
+			.getClosedAction("NTI")
+			.then(row =>
+			{
+				row.hasName("NTI")
+				row.hasStatus(expectedStatus)
+				row.hasCreatedDate(toDisplayDate(now))
+                row.hasClosedDate(toDisplayDate(now))
+				row.select();
+			});
+
+        viewNtiPage
+            .hasDateOpened(toDisplayDate(now))
+            .hasDateCompleted(toDisplayDate(now))
+            .hasDateIssued("Empty")
+            .hasReasonIssued("Empty")
+            .hasStatus(expectedStatus)
+            .hasConditions("Empty")
+            .hasNotes("Empty");
     }
 });

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/noticeToImprove/viewNoticeToImprovePage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseActions/noticeToImprove/viewNoticeToImprovePage.ts
@@ -67,6 +67,33 @@ export class ViewNoticeToImprovePage {
         return this;
     }
 
+    public hasDateCancelled(value: string): this
+    {
+        Logger.Log(`Has date NTI cancelled ${value}`);
+
+        cy.getByTestId("date-nti-cancelled").should("contains.text", value);
+
+        return this;
+    }
+
+    public hasDateLifted(value: string): this
+    {
+        Logger.Log(`Has date NTI lifted ${value}`);
+
+        cy.getByTestId("date-nti-lifted").should("contains.text", value);
+
+        return this;
+    }
+
+    public hasSubmissionDecisionId(value: string): this
+    {
+        Logger.Log(`Has submission decision ID ${value}`);
+
+        cy.getByTestId("submission-decision-id").should("contains.text", value);
+
+        return this;
+    }
+
     public edit(): this
     {
         Logger.Log("Editing Notice To Improve");

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiMappingTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Mappers/NtiMappingTests.cs
@@ -68,7 +68,7 @@ namespace ConcernsCaseWork.Tests.Mappers
 			Assert.That(serviceModel.Reasons.Count, Is.EqualTo(testData.Reasons.Length));
 			Assert.That(serviceModel.Reasons.ElementAt(0).Id, Is.EqualTo(testData.Reasons.ElementAt(0).Key));
 			Assert.That(serviceModel.Status, Is.Not.Null);
-			Assert.That(serviceModel.SumissionDecisionId, Is.EqualTo(testData.SumissionDecisionId));
+			Assert.That(serviceModel.SubmissionDecisionId, Is.EqualTo(testData.SumissionDecisionId));
 			Assert.That(serviceModel.DateNTILifted, Is.EqualTo(testData.DateNTILifted));
 			Assert.That(serviceModel.DateNTIClosed, Is.EqualTo(testData.DateNTIClosed));
 
@@ -123,7 +123,7 @@ namespace ConcernsCaseWork.Tests.Mappers
 				Status = new NtiStatusModel { Id = testData.Status.Key, Name = testData.Status.Value },
 				DateStarted = testData.DateStarted,
 				UpdatedAt = testData.UpdatedAt,
-				SumissionDecisionId = testData.SumissionDecisionId,
+				SubmissionDecisionId = testData.SumissionDecisionId,
 				DateNTIClosed = testData.DateNTIClosed,
 				DateNTILifted = testData.DateNTILifted
 			};
@@ -141,7 +141,7 @@ namespace ConcernsCaseWork.Tests.Mappers
 			Assert.That(dbModel.ReasonsMapping.First(), Is.EqualTo(testData.Reasons.First().Key));
 			Assert.That(dbModel.DateStarted, Is.EqualTo(testData.DateStarted));
 			Assert.That(dbModel.UpdatedAt, Is.EqualTo(testData.UpdatedAt));
-			Assert.That(serviceModel.SumissionDecisionId, Is.EqualTo(testData.SumissionDecisionId));
+			Assert.That(serviceModel.SubmissionDecisionId, Is.EqualTo(testData.SumissionDecisionId));
 			Assert.That(serviceModel.DateNTILifted, Is.EqualTo(testData.DateNTILifted));
 			Assert.That(serviceModel.DateNTIClosed, Is.EqualTo(testData.DateNTIClosed));
 		}

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiMappers.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/NtiMappers.cs
@@ -26,7 +26,7 @@ namespace ConcernsCaseWork.Mappers
 				DateStarted = ntiModel.DateStarted,
 				UpdatedAt = ntiModel.UpdatedAt,
 				ConditionsMapping = ntiModel.Conditions?.Select(c => c.Id).ToArray(),
-				SumissionDecisionId = ntiModel.SumissionDecisionId,
+				SumissionDecisionId = ntiModel.SubmissionDecisionId,
 				DateNTILifted = ntiModel.DateNTILifted,
 				DateNTIClosed = ntiModel.DateNTIClosed
 			};
@@ -56,7 +56,7 @@ namespace ConcernsCaseWork.Mappers
 				ClosedStatusId = ntiDto.ClosedStatusId,
 				ClosedStatus = ntiDto.ClosedStatusId.HasValue ? ToServiceModel(statuses.FirstOrDefault(s => s.Id == ntiDto.ClosedStatusId.Value)) : null,
 				ClosedAt = ntiDto.ClosedAt,
-				SumissionDecisionId = ntiDto.SumissionDecisionId,
+				SubmissionDecisionId = ntiDto.SumissionDecisionId,
 				DateNTILifted = ntiDto.DateNTILifted,
 				DateNTIClosed = ntiDto.DateNTIClosed
 			};

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/NtiModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/CaseActions/NtiModel.cs
@@ -12,7 +12,7 @@ namespace ConcernsCaseWork.Models.CaseActions
 		public DateTime? DateStarted { get; set; }
 		public int? ClosedStatusId { get; set; }
 		public NtiStatusModel ClosedStatus { get; set; }
-		public string SumissionDecisionId { get; set; }
+		public string SubmissionDecisionId { get; set; }
 		public DateTime? DateNTILifted { get; set; }
 		public DateTime? DateNTIClosed { get; set; }
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Index.cshtml
@@ -12,9 +12,9 @@
 }
 
 @section BeforeMain {
-	<div class="govuk-width-container">
-		<back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
-	</div>
+    <div class="govuk-width-container">
+        <back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
+    </div>
 }
 
 <div class="govuk-width-container">
@@ -86,14 +86,7 @@
                         <th scope="row" class="govuk-table-case-details__header">Current status</th>
                         <td class="govuk-table__cell" data-testid="status-text">
                             @{
-                                if (Model.NtiModel.Status != null)
-                                {
-                                    RenderValue(Model.NtiModel.Status.Name);
-                                }
-                                else
-                                {
-                                    RenderEmptyLabel();
-                                }
+                                RenderValue(Model.NtiModel.Status?.Name);
                             }
                         </td>
                     }
@@ -102,35 +95,19 @@
                         <th scope="row" class="govuk-table-case-details__header">Status</th>
                         <td class="govuk-table__cell" data-testid="status-text">
                             @{
-                                if (Model.NtiModel.ClosedStatus != null)
-                                {
-                                    RenderValue(Model.NtiModel.ClosedStatus.Name);
-                                }
-                                else
-                                {
-                                    RenderEmptyLabel();
-                                }
+                                RenderValue(Model.NtiModel.ClosedStatus?.Name);
                             }
                         </td>
                     }
 
                 </tr>
 
-
-
                 @* Date NTI Issued *@
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table-case-details__header">Date NTI Issued</th>
                     <td class="govuk-table__cell" data-testid="date-issued-text">
                         @{
-                            if (Model.NtiModel.DateStarted.HasValue)
-                            {
-                                RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.DateStarted));
-                            }
-                            else
-                            {
-                                RenderEmptyLabel();
-                            }
+                            RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.DateStarted));
                         }
                     </td>
                 </tr>
@@ -138,57 +115,53 @@
                 @* Date Closed *@
                 @if (isClosed)
                 {
-                    <tr class="govuk-table__row">
-                        @{
-                            switch (Model.NtiModel.ClosedStatus.Id)
-                            {
-                                case (int)NTIStatus.Cancelled:
-                                    <th scope="row" class="govuk-table-case-details__header">Date NTI cancelled</th>
-                                    <td class="govuk-table__cell">
-                                        @{
-                                            RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.ClosedAt));
-                                        }
-                                    </td>
-                                    break;
-                                case (int)NTIStatus.Lifted:
-                                    <th scope="row" class="govuk-table-case-details__header">Date NTI Lifted</th>
-                                    <td class="govuk-table__cell">
-                                        @{
+                    switch (Model.NtiModel.ClosedStatus.Id)
+                    {
+                        case (int)NTIStatus.Cancelled:
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table-case-details__header">Date NTI cancelled</th>
+                                <td class="govuk-table__cell" data-testid="date-nti-cancelled">
+                                    @{
+                                        RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.ClosedAt));
+                                    }
+                                </td>
+                            </tr>
+                            break;
 
-                                            if (Model.NtiModel.DateNTILifted.HasValue)
-                                            {
-                                                RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.DateNTILifted));
-                                            }
-                                            else
-                                            {
-                                                RenderEmptyLabel();
-                                            }
-                                        }
-                                    </td>
-                                    break;
-                                case (int)NTIStatus.Closed:
-                                    <th scope="row" class="govuk-table-case-details__header">Date NTI Closed</th>
-                                    <td class="govuk-table__cell" data-testid="date-nti-closed">
-                                        @{
+                        case (int)NTIStatus.Lifted:
+                            <tr class="govuk-table__row">
 
-                                            if (Model.NtiModel.DateNTIClosed.HasValue)
-                                            {
-                                                RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.DateNTIClosed));
-                                            }
-                                            else
-                                            {
-                                                RenderEmptyLabel();
-                                            }
-                                        }
-                                    </td>
-                                    break;
-                                default:
-                                    throw new Exception($"{nameof(IndexPageModel)}::Uknown status found - {Model.NtiModel.ClosedStatus.Name}");
-                                    break;
-                            }
-                        }
+                                <th scope="row" class="govuk-table-case-details__header">Date NTI Lifted</th>
+                                <td class="govuk-table__cell" data-testid="date-nti-lifted">
+                                    @{
 
-                    </tr>
+                                        RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.DateNTILifted));
+                                    }
+                                </td>
+                            </tr>
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table-case-details__header">Submission Decision ID</th>
+                                <td class="govuk-table__cell" data-testid="submission-decision-id">
+                                    @{
+                                        RenderValue(Model.NtiModel.SubmissionDecisionId);
+                                    }
+                                </td>
+                            </tr>
+                            break;
+                        case (int)NTIStatus.Closed:
+                            <tr class="govuk-table__row">
+
+                                <th scope="row" class="govuk-table-case-details__header">Date NTI Closed</th>
+                                <td class="govuk-table__cell" data-testid="date-nti-closed">
+                                    @{
+                                        RenderValue(DateTimeHelper.ParseToDisplayDate(Model.NtiModel.DateNTIClosed));
+                                    }
+                                </td>
+                            </tr>
+                            break;
+                        default:
+                            throw new Exception($"{nameof(IndexPageModel)}::Uknown status found - {Model.NtiModel.ClosedStatus.Name}");
+                    }
                 }
 
                 @* Reasons *@
@@ -311,9 +284,9 @@
 </div>
 
 @functions {
-    private void RenderValue<T>(T value)
+    private void RenderValue(string value)
     {
-        if (IsEmpty(value))
+        if (string.IsNullOrWhiteSpace(value))
         {
             RenderEmptyLabel();
         }
@@ -321,16 +294,6 @@
         {
             @value
         }
-    }
-
-    private bool IsEmpty<T>(T value)
-    {
-        if (value is string)
-        {
-            return string.IsNullOrWhiteSpace(value as string);
-        }
-
-        return value == null || value.Equals(default(T));
     }
 
     private void RenderEmptyLabel()

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Lift.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Nti/Lift.cshtml.cs
@@ -68,7 +68,7 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Nti
 				var ntiModel = await _ntiModelService.GetNtiByIdAsync(NtiId);
 
 				ntiModel.Notes = Notes.Text.StringContents;
-				ntiModel.SumissionDecisionId = DecisionID.Text.StringContents;
+				ntiModel.SubmissionDecisionId = DecisionID.Text.StringContents;
 				ntiModel.DateNTILifted = !DateNTILifted.Date?.IsEmpty() ?? false ? DateNTILifted.Date?.ToDateTime() : null;
 				ntiModel.ClosedStatusId = (int)NTIStatus.Lifted;
 				ntiModel.ClosedAt = DateTime.Now;


### PR DESCRIPTION
**What is the change?**

automation for checking submission decision id
automation for closing nti actions with empty fields renamed submission decision id to be spelt correctly, only on the client model, the api is still wrong

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=125231
