### PR TITLE
130883: changed case worker to case owner on closed case page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/ViewClosed.cshtml
@@ -86,7 +86,7 @@
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="dfe-width-30percent govuk-summary-list__key">
-                            Case Worker
+                            Case owner
                         </dt>
                         <dd class="govuk-summary-list__value" data-testid="case-owner-field">
                             @Model.CaseModel.CreatedBy.FromEmailToFullName()


### PR DESCRIPTION
**What is the change?**

changed case worker to case owner on closed case page

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=130883
