### PR TITLE
129903: added the option to create non concerns on the create case journey

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/DatabaseModelBuilder.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/DatabaseModelBuilder.cs
@@ -60,5 +60,10 @@ namespace ConcernsCaseWork.API.Tests.Helpers
 				CreatedAt = _fixture.Create<DateTime>()
 			};
 		}
+
+		public static string CreateUkPrn()
+		{
+			return _fixture.Create<string>().Substring(0, 7);
+		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsIntegrationTests.cs
@@ -66,7 +66,7 @@ public class ConcernsIntegrationTests : IDisposable
 			.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
 			.With(c => c.Description = "")
 			.With(c => c.CrmEnquiry = "")
-			.With(c => c.TrustUkprn = "100223")
+			.With(c => c.TrustUkprn = DatabaseModelBuilder.CreateUkPrn())
 			.With(c => c.ReasonAtReview = "")
 			.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
 			.With(c => c.Issue = "Here is the issue")
@@ -78,7 +78,7 @@ public class ConcernsIntegrationTests : IDisposable
 			.With(c => c.DirectionOfTravel = "Up")
 			.With(c => c.StatusId = 1)
 			.With(c => c.RatingId = 2)
-			.With(c => c.TrustCompaniesHouseNumber = "12345678")
+			.With(c => c.TrustCompaniesHouseNumber = DatabaseModelBuilder.CreateUkPrn())
 			.Build();
 
 
@@ -116,7 +116,7 @@ public class ConcernsIntegrationTests : IDisposable
 			.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
 			.With(c => c.Description = "")
 			.With(c => c.CrmEnquiry = "")
-			.With(c => c.TrustUkprn = "100223")
+			.With(c => c.TrustUkprn = DatabaseModelBuilder.CreateUkPrn())
 			.With(c => c.ReasonAtReview = "")
 			.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
 			.With(c => c.Issue = "Here is the issue")

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NoticeToImproveIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NoticeToImproveIntegrationTests.cs
@@ -88,7 +88,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 				.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
 				.With(c => c.Description = "")
 				.With(c => c.CrmEnquiry = "")
-				.With(c => c.TrustUkprn = "100223")
+				.With(c => c.TrustUkprn = DatabaseModelBuilder.CreateUkPrn())
 				.With(c => c.ReasonAtReview = "")
 				.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
 				.With(c => c.Issue = "Here is the issue")

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NtiWarningLetterIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NtiWarningLetterIntegrationTests.cs
@@ -81,14 +81,12 @@ namespace ConcernsCaseWork.API.Tests.Integration
 		[Fact]
 		public async Task When_Delete_ValidResourceRequest_Returns_NoContent()
 		{
-			var warningLetterID = 1;
-
 			//Create the case
 			ConcernCaseRequest createCaseRequest = Builder<ConcernCaseRequest>.CreateNew()
 				.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
 				.With(c => c.Description = "")
 				.With(c => c.CrmEnquiry = "")
-				.With(c => c.TrustUkprn = "100223")
+				.With(c => c.TrustUkprn = DatabaseModelBuilder.CreateUkPrn())
 				.With(c => c.ReasonAtReview = "")
 				.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
 				.With(c => c.Issue = "Here is the issue")
@@ -100,7 +98,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 				.With(c => c.DirectionOfTravel = "Up")
 				.With(c => c.StatusId = 1)
 				.With(c => c.RatingId = 2)
-				.With(c => c.TrustCompaniesHouseNumber = "12345678")
+				.With(c => c.TrustCompaniesHouseNumber = DatabaseModelBuilder.CreateUkPrn())
 				.Build();
 
 			var createCaseResponse = await _client.PostAsync($"v2/concerns-cases", createCaseRequest.ConvertToJson());

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
@@ -9,6 +9,7 @@ import concernsApi from "cypress/api/concernsApi";
 import caseApi from "cypress/api/caseApi";
 import createCaseSummary from "cypress/pages/createCase/createCaseSummary";
 import validationComponent from "cypress/pages/validationComponent";
+import selectCaseTypePage from "cypress/pages/createCase/selectCaseTypePage";
 
 describe("Creating a case", () =>
 {
@@ -17,7 +18,7 @@ describe("Creating a case", () =>
     const addDetailsPage = new AddDetailsPage();
     const addTerritoryPage = new AddTerritoryPage();
     const addConcernDetailsPage = new AddConcernDetailsPage();
-    
+
 	beforeEach(() => {
 		cy.login();
 	});
@@ -39,9 +40,25 @@ describe("Creating a case", () =>
         createCaseSummary
             .hasTrustSummaryDetails("Ashton West End Primary Academy");
 
+        Logger.Log("You must select a case error");
+        selectCaseTypePage
+            .continue()
+            .hasValidationError("Select case type");
+
+        Logger.Log("Checking accessibility on select case type");
+        cy.excuteAccessibilityTests();
+
+        Logger.Log("Create a valid concerns case type");
+        selectCaseTypePage
+            .withCaseType("Concerns")
+            .continue();
+
+        createCaseSummary
+            .hasTrustSummaryDetails("Ashton West End Primary Academy");
+
         Logger.Log("Attempt to create an invalid concern");
         createConcernPage
-            .addConcern()
+            .addConcern();
 
         validationComponent
             .hasValidationErrorsInOrder([
@@ -197,6 +214,14 @@ describe("Creating a case", () =>
         createCaseSummary
             .hasTrustSummaryDetails("Ashton West End Primary Academy");
 
+        Logger.Log("Create a valid concerns case type");
+            selectCaseTypePage
+                .withCaseType("Concerns")
+                .continue();
+
+        createCaseSummary
+            .hasTrustSummaryDetails("Ashton West End Primary Academy");
+
         Logger.Log("Create a valid concern");
         createConcernPage
             .withConcernType("Force majeure")
@@ -257,10 +282,6 @@ describe("Creating a case", () =>
             .hasEmptyCaseHistory();
     });
 
-    const searchTerm =
-		"Accrington St Christopher's Church Of England High School";
-	const searchTermForSchool = "school";
-
     it('Should display an error if no trust is selected', () => {
 		createCasePage
             .createCase()
@@ -272,7 +293,7 @@ describe("Creating a case", () =>
 	it('Should display a warning if too many results', () => {
 		createCasePage
             .createCase()
-            .withTrustName(searchTermForSchool)
+            .withTrustName("school")
             .shouldNotHaveVisibleLoader()
             .hasTooManyResultsWarning("There are a large number of search results. Try a more specific search term.");
     });
@@ -285,6 +306,11 @@ describe("Creating a case", () =>
             .withTrustName("Ashton West End Primary Academy")
             .selectOption()
             .confirmOption();
+
+        Logger.Log("Create a valid concerns case type");
+        selectCaseTypePage
+            .withCaseType("Concerns")
+            .continue();
 
         Logger.Log("Create a valid concern");
         createConcernPage

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
@@ -2,7 +2,6 @@ import { Logger } from "cypress/common/logger";
 import AddTerritoryPage from "cypress/pages/createCase/addTerritoryPage";
 import AddConcernDetailsPage from "cypress/pages/createCase/addConcernDetailsPage";
 import caseManagementPage from "cypress/pages/caseMangementPage";
-import { SelectCaseTypePage } from "cypress/pages/createCase/selectCaseTypePage";
 import { EnvUsername } from "cypress/constants/cypressConstants";
 import { CreateCasePage } from "cypress/pages/createCase/createCasePage";
 import CreateConcernPage from "cypress/pages/createCase/createConcernPage";
@@ -18,11 +17,11 @@ import { toDisplayDate } from "cypress/support/formatDate";
 import { ViewClosedCasePage } from "cypress/pages/createCase/viewClosedCasePage";
 import actionTable from "cypress/pages/caseRows/caseActionTable";
 import concernsApi from "cypress/api/concernsApi";
+import selectCaseTypePage from "cypress/pages/createCase/selectCaseTypePage";
 
 describe("Creating a case", () => {
     let email: string;
     let name: string;
-    const selectCaseTypePage = new SelectCaseTypePage();
     const addTerritoryPage = new AddTerritoryPage();
     const addConcernDetailsPage = new AddConcernDetailsPage();
     const createCasePage = new CreateCasePage();
@@ -51,14 +50,6 @@ describe("Creating a case", () => {
             .withTrustName(trustName)
             .selectOption()
             .confirmOption();
-
-        Logger.Log("You must select a case error");
-        selectCaseTypePage
-            .continue()
-            .hasValidationError("Select case type");
-
-        Logger.Log("Checking accessibility on select case type");
-        cy.excuteAccessibilityTests();
 
         Logger.Log("Create a valid Non-concern case type");
         selectCaseTypePage

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
@@ -15,6 +15,7 @@ import EditNextStepsPage from "cypress/pages/createCase/editNextStepsPage";
 import EditCaseHistoryPage from "cypress/pages/createCase/editCaseHistoryPage";
 import CaseManagementPage from "../../pages/caseMangementPage";
 import AddToCasePage from "../../pages/caseActions/addToCasePage";
+import selectCaseTypePage from "cypress/pages/createCase/selectCaseTypePage";
 
 describe("Editing a case", () =>
 {
@@ -43,6 +44,11 @@ describe("Editing a case", () =>
             .withTrustName("Ashton West End Primary Academy")
             .selectOption()
             .confirmOption();
+
+        Logger.Log("Create a valid concerns case type");
+        selectCaseTypePage
+            .withCaseType("Concerns")
+            .continue();
 
         Logger.Log("Create a valid concern");
         createConcernPage

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/home-page.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/home-page.cy.ts
@@ -10,15 +10,15 @@ describe("Home page tests", () => {
 		Logger.Log("Create, Find and Closed Case buttons should be displayed");
 		cy.get('.govuk-button[href="/case/closed"]').should("be.visible");
 		cy.get('.govuk-button[href="/trust"]').should("be.visible");
-		cy.get('.govuk-button[href="/case"]').should("be.visible");
+		cy.get('.govuk-button[href="/case/create"]').should("be.visible");
 
 		Logger.Log("User clicks on Create Case and should see Search Trusts");
-		cy.get('[href="/case"]').click();
+		cy.get('[href="/case/create"]').click();
 		cy.get('#search').should('be.visible');
 
 		Logger.Log("User clicks Back and should be taken back to the Active Casework screen");
 		cy.getByTestId("cancel-trust-search").click();
-		cy.get('[href="/case"').should('be.visible');
+		cy.get('[href="/case/create"').should('be.visible');
 		cy.get('[href="/trust"').should('be.visible');
 		cy.get('[href="/case/closed"').should('be.visible');
 
@@ -28,7 +28,7 @@ describe("Home page tests", () => {
 
 		Logger.Log("User clicks Back and should be taken back to the Active Casework screen");
 		cy.getByTestId("cancel-trust-search").click();
-		cy.get('[href="/case"').should('be.visible');
+		cy.get('[href="/case/create"').should('be.visible');
 		cy.get('[href="/trust"').should('be.visible');
 		cy.get('[href="/case/closed"').should('be.visible');
 

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/smoke.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/smoke.cy.ts
@@ -36,6 +36,7 @@ import AddTerritoryPage from "cypress/pages/createCase/addTerritoryPage";
 import AddConcernDetailsPage from "cypress/pages/createCase/addConcernDetailsPage";
 import AddDetailsPage from "cypress/pages/createCase/addDetailsPage";
 import createCaseSummary from "cypress/pages/createCase/createCaseSummary";
+import selectCaseTypePage from "cypress/pages/createCase/selectCaseTypePage";
 
 describe("Testing closing of cases when there are case actions and concerns", () => {
     let caseId: string;
@@ -89,6 +90,11 @@ describe("Testing closing of cases when there are case actions and concerns", ()
             .withTrustName(trustName)
             .selectOption()
             .confirmOption();
+
+        Logger.Log("Create a valid concerns case type");
+        selectCaseTypePage
+            .withCaseType("Concerns")
+            .continue();
 
         Logger.Log("Create a valid concern");
         createConcernPage

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/selectCaseTypePage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/selectCaseTypePage.ts
@@ -1,6 +1,6 @@
 import { Logger } from "../../common/logger";
 
-export class SelectCaseTypePage {
+class SelectCaseTypePage {
 
     public withCaseType(value: string): this {
         Logger.Log(`With NonConcernType ${value}`);
@@ -27,8 +27,9 @@ export class SelectCaseTypePage {
 
         return this;
     }
-
-
-
 }
+
+var selectCaseTypePage = new SelectCaseTypePage();
+
+export default selectCaseTypePage;
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Create/SelectCaseTypePageModelTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Pages/Case/Create/SelectCaseTypePageModelTests.cs
@@ -297,7 +297,7 @@ namespace ConcernsCaseWork.Tests.Pages.Case.Create
 		}
 
 		[Test]
-		[TestCase(CaseType.Concerns, "/case/concern/index")]
+		[TestCase(CaseType.Concerns, "/case/concern")]
 		[TestCase(CaseType.NonConcerns, "/case/territory")]
 		public async Task WhenOnPost_WithConcernsType_RedirectsToConcernsCreatePage(CaseType selectedCaseType, string expectedUrl)
 		{

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/Details.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/NonConcernsCase/Details.cshtml
@@ -36,7 +36,8 @@
                         <button id="create-case-button" data-testid="create-case-button" data-prevent-double-click="true" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" role="button">
                             Create case
                         </button>
-                        <a data-prevent-double-click="true" class="govuk-link" asp-page="../home" data-module="govuk-button" role="button">
+
+                        <a data-prevent-double-click="true" class="govuk-link" href="/" data-module="govuk-button" role="button">
                             Cancel
                         </a>
                     </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain {
 	<div class="govuk-width-container">
-		<back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
+		<back-link url="/case/create"></back-link>
 	</div>
 }
 
@@ -28,7 +28,7 @@
 			<dl class="govuk-summary-list">
 				<div class="govuk-summary-list__row">
 					<dt class="govuk-summary-list__key">Trust</dt>
-					<dd class="govuk-summary-list__value">
+                    <dd class="govuk-summary-list__value" data-testid="trust-summary">
 						@Model.TrustAddress.TrustName @Model.TrustAddress.County
 						<br/>
 						@Model.TrustAddress.DisplayAddress

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml.cs
@@ -34,8 +34,6 @@ public class SelectCaseTypePageModel : AbstractPageModel
 	[BindProperty]
 	public RadioButtonsUiComponent CaseType { get; set; }
 
-	public Hyperlink BackLink => BuildBackLinkFromHistory(fallbackUrl: PageRoutes.YourCaseworkHomePage);
-
 	public SelectCaseTypePageModel(ITrustModelService trustModelService,
 		IUserStateCachedService cachedUserService,
 		ILogger<SelectCaseTypePageModel> logger,
@@ -86,7 +84,7 @@ public class SelectCaseTypePageModel : AbstractPageModel
 			switch (selectedCaseType)
 			{
 				case API.Contracts.Case.CaseType.Concerns:
-					return Redirect("/case/concern/index");
+					return Redirect("/case/concern");
 				case API.Contracts.Case.CaseType.NonConcerns:
 					return Redirect("/case/territory");
 				default:

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectTrust.cshtml
@@ -9,12 +9,6 @@
     Model.FindTrustModel.Nonce = nonce;
 }
 
-@section BeforeMain {
-	<div class="govuk-width-container">
-		<back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
-	</div>
-}
-
 <div class="govuk-width-container">
 
     <partial name="_BannerError" />
@@ -42,7 +36,7 @@
 		            value="continue">
 			    Continue
 		    </button>
-		    <a data-prevent-double-click="true" href="/" class="govuk-link" data-module="govuk-button" role="button">Cancel</a>
+            <a data-prevent-double-click="true" href="/" class="govuk-link" data-module="govuk-button" role="button" data-testid="cancel-trust-search">Cancel</a>
 	    </div>
     </form>
 </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Home.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Home.cshtml
@@ -1,6 +1,8 @@
 ﻿@page
+@using ConcernsCaseWork.API.Contracts.Configuration;
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model ConcernsCaseWork.Pages.HomePageModel
+@addTagHelper *, Microsoft.FeatureManagement.AspNetCore
 
 @{
     ViewData["Title"] = "Home";
@@ -31,9 +33,17 @@
 
                 <div class="govuk-tabs__panel" id="your-casework">
                     <div class="govuk-button-group concerns-align-buttons-right-in-govuk-button-group">
-                        <a class="govuk-button" asp-page="/case/index" role="button" data-testid="create-case-button">
-                            Create case
-                        </a>
+                        <feature name="@FeatureFlags.IsNonConcernsPageEnabled">
+                            <a class="govuk-button" asp-page="/case/createCase/selectTrust" role="button" data-testid="create-case-button">
+                                Create case
+                            </a>
+                        </feature>
+                        <feature name="@FeatureFlags.IsNonConcernsPageEnabled" negate="true">
+                            <a class="govuk-button" asp-page="/case/index" role="button" data-testid="create-case-button">
+                                Create case
+                            </a>
+                        </feature>
+
                         <a class="govuk-button govuk-button--secondary" asp-page="/trust/index" role="button">
                             Find trust
                         </a>


### PR DESCRIPTION
**What is the change?**

added the option to create non concerns on the create case journey

this option can be enabled or disabled by a feature flag

updated the automation to match, this will always be enabled in dev and staging

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=129903
