### PR TITLE
131989: added a red banner to the input of an autocomplete on error

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
@@ -9,6 +9,7 @@
     var errors = ViewData.ModelState.ToValidationResult();
 
     var errorBannerClass = errors.Any() ? " govuk-form-group--error" : string.Empty;
+    var inputErrorClass = errors.Any() ? "autocomplete__error" : string.Empty;
 }
 
 <div class="govuk-width-container">
@@ -37,7 +38,7 @@
 
                         <partial name="Components/_ValidationErrorDetail" model="@errors" />
 
-                        <div id="autocomplete-container"></div>
+                        <div id="autocomplete-container" class="@inputErrorClass"></div>
 
                         <div class="ccms-loader govuk-!-display-none"></div>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -18,6 +18,8 @@
     var errors = ViewData.ModelState.ToValidationResult();
 
     var errorBannerClass = errors.Any() ? " govuk-form-group--error" : string.Empty;
+
+    var inputErrorClass = errors.Any() ? "autocomplete__error" : string.Empty;
 }
 
 <div tabindex="-1" role="group" id="errorSummary" class="govuk-error-summary moj-hidden" aria-labelledby="error-summary-title" data-module="error-summary"></div>
@@ -42,7 +44,7 @@
 
     <partial name="Components/_ValidationErrorDetail" model="@errors" />
 
-    <div id="container-SelectedTrustUkprn" class="govuk-!-margin-top-3"></div>
+    <div id="container-SelectedTrustUkprn" class="govuk-!-margin-top-3 @inputErrorClass"></div>
     <div class="ccms-loader govuk-!-display-none"></div>
     <ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="trustsearch__listbox" role="listbox">
         <li class="autocomplete__option autocomplete__option--no-results">No results found.</li>

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_autocomplete.scss
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_autocomplete.scss
@@ -158,3 +158,9 @@
 	color: govuk-colour("white");
   }
 }
+
+.autocomplete__error {
+	.autocomplete__input {
+		border-color: #d4351c;
+	}
+}


### PR DESCRIPTION
**What is the change?**

added a style to change the autocomplete input to red when an error occurs

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=131989