### PR TITLE
132650: fixed issue where radio button id's were duplicated

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_RadioList.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/Components/_RadioList.cshtml
@@ -35,18 +35,19 @@
                 var isChecked = Model.SelectedId == radioItem.Id ? "checked" : "";
                 var testId = !string.IsNullOrEmpty(radioItem.TestId) ? radioItem.TestId : radioItem.Label;
                 var radioItemSubContainerId = $"sub-item-container-{radioItem.Id}";
+                var radioItemElementId = $"{Model.ElementRootId}-{radioItem.Id}";
 				
 				<div class="govuk-radios__item">
-					<input class="govuk-radios__input" 
-					       id="@radioItem.Id" 
-					       name="@Model.Name.@nameof(Model.SelectedId)" 
-					       type="radio" 
+					<input class="govuk-radios__input"
+                           id="@radioItemElementId"
+                           name="@Model.Name.@nameof(Model.SelectedId)"
+					       type="radio"
 					       data-testid="@testId" 
 					       value="@radioItem.Id"
                            data-aria-controls="@radioItemSubContainerId"
 					       @isChecked />
 
-					<label class="govuk-label govuk-radios__label" for="@radioItem.Id">
+                    <label class="govuk-label govuk-radios__label" for="@radioItemElementId">
                         @if (@radioItem.IsHtmlLabel == true)
                         {
                             // Label contains HTML, so we can render it directly


### PR DESCRIPTION
**What is the change?**

if you have more than one radio item targeted by label for, it can control multiple buttons when clicking the text

we were using the value of the radio button as the id a lot of our selections are 1-n 
makes it highly likely for a duplicated id on the page 
label for will control the radio item with the specific id 

fixed by making sure that each radio item was unique across the page by prefixing with the element root id

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Concerns%20Casework/Stories/?workitem=132650
