### PR TITLE
133580: New endpoint to Delete TFF with tests

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/RequestModels/TrustFinancialForecasts/DeleteTrustFinancialForecastRequest.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/RequestModels/TrustFinancialForecasts/DeleteTrustFinancialForecastRequest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConcernsCaseWork.API.Contracts.RequestModels.TrustFinancialForecasts
+{
+	public record DeleteTrustFinancialForecastRequest : GetTrustFinancialForecastsForCaseRequest
+	{
+		public int TrustFinancialForecastId { get; init; }
+
+		public override bool IsValid() => base.IsValid()
+										  && TrustFinancialForecastId > 0;
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/TrustFinancialForecastControllerTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/TrustFinancialForecastControllerTests.cs
@@ -366,6 +366,7 @@ public class TrustFinancialForecastControllerTests
 		internal readonly Mock<IUseCaseAsync<GetTrustFinancialForecastsForCaseRequest, IEnumerable<TrustFinancialForecastResponse>>> _getTrustFinancialForecastsUseCase;
 		internal readonly Mock<IUseCaseAsync<UpdateTrustFinancialForecastRequest, int>> _updateTrustFinancialForecastUseCase;
 		internal readonly Mock<IUseCaseAsync<CloseTrustFinancialForecastRequest, int>> _closeTrustFinancialForecastUseCase;
+		internal readonly Mock<IUseCaseAsync<DeleteTrustFinancialForecastRequest, int>> _deleteTrustFinancialForecastUseCase;
 
 		public TestBuilder()
 		{
@@ -378,6 +379,7 @@ public class TrustFinancialForecastControllerTests
 			_getTrustFinancialForecastsUseCase = _fixture.Freeze<Mock<IUseCaseAsync<GetTrustFinancialForecastsForCaseRequest, IEnumerable<TrustFinancialForecastResponse>>>>();
 			_updateTrustFinancialForecastUseCase = _fixture.Freeze<Mock<IUseCaseAsync<UpdateTrustFinancialForecastRequest, int>>>();
 			_closeTrustFinancialForecastUseCase = _fixture.Freeze<Mock<IUseCaseAsync<CloseTrustFinancialForecastRequest, int>>>();
+			_deleteTrustFinancialForecastUseCase = _fixture.Freeze<Mock<IUseCaseAsync<DeleteTrustFinancialForecastRequest, int>>>();
 		}
 
 		internal TrustFinancialForecastController BuildSut()
@@ -387,7 +389,8 @@ public class TrustFinancialForecastControllerTests
 				_getTrustFinancialForecastUseCase.Object, 
 				_updateTrustFinancialForecastUseCase.Object,
 				_closeTrustFinancialForecastUseCase.Object,
-				_getTrustFinancialForecastsUseCase.Object );
+				_getTrustFinancialForecastsUseCase.Object,
+				_deleteTrustFinancialForecastUseCase.Object);
 		}
 
 		public UpdateTrustFinancialForecastRequest CreateValidUpdateTrustFinancialForecastRequest()

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/TrustFinancialForecastFactoryTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/TrustFinancialForecastFactoryTests.cs
@@ -20,7 +20,7 @@ public class TrustFinancialForecastFactoryTests
 		var result = trustFinancialForecast.ToResponseModel();
 
 		// assert
-		result.Should().BeEquivalentTo(trustFinancialForecast, options => options.Excluding(x => x.Id));
+		result.Should().BeEquivalentTo(trustFinancialForecast, options => options.Excluding(x => x.Id).Excluding(f=> f.DeletedAt));
 		result.TrustFinancialForecastId.Should().Be(trustFinancialForecast.Id);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/TrustFinancialForecastIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/TrustFinancialForecastIntegrationTests.cs
@@ -1,0 +1,111 @@
+﻿using AutoFixture;
+using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.NoticeToImprove;
+using ConcernsCaseWork.API.RequestModels;
+using ConcernsCaseWork.API.ResponseModels;
+using ConcernsCaseWork.API.Tests.Fixtures;
+using ConcernsCaseWork.API.Tests.Helpers;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using System.Net.Http.Json;
+using ConcernsCaseWork.API.Contracts.RequestModels.TrustFinancialForecasts;
+using ConcernsCaseWork.API.Contracts.Enums.TrustFinancialForecast;
+
+namespace ConcernsCaseWork.API.Tests.Integration
+{
+	[Collection(ApiTestCollection.ApiTestCollectionName)]
+	public class TrustFinancialForecastIntegrationTests
+	{
+		private readonly Fixture _fixture;
+		private readonly HttpClient _client;
+		private readonly RandomGenerator _randomGenerator;
+
+		public TrustFinancialForecastIntegrationTests(ApiTestFixture apiTestFixture)
+		{
+			_client = apiTestFixture.Client;
+			_fixture = new();
+			_randomGenerator = new RandomGenerator();
+		}
+
+		[Fact]
+		public async Task When_Delete_InvalidRequest_Returns_BadRequest()
+		{
+			var urn = "1";
+			var noticeToImproveId = 0;
+			var result = await _client.DeleteAsync($"/v2/concerns-cases/{urn}/trustfinancialforecast/{noticeToImproveId}");
+			result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+		}
+
+		[Fact]
+		public async Task When_Delete_NotCreatedResourceRequest_Returns_NotFound()
+		{
+			var urn = "1";
+			var noticeToImproveId = 1000000;
+			var result = await _client.DeleteAsync($"/v2/concerns-cases/{urn}/trustfinancialforecast/{noticeToImproveId}");
+			result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		}
+
+		[Fact]
+		public async Task When_Delete_ValidResourceRequest_Returns_NoContent()
+		{
+			//Create the case
+			ConcernCaseRequest createCaseRequest = Builder<ConcernCaseRequest>.CreateNew()
+				.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
+				.With(c => c.Description = "")
+				.With(c => c.CrmEnquiry = "")
+				.With(c => c.TrustUkprn = DatabaseModelBuilder.CreateUkPrn())
+				.With(c => c.ReasonAtReview = "")
+				.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
+				.With(c => c.Issue = "Here is the issue")
+				.With(c => c.CurrentStatus = "Case status")
+				.With(c => c.CaseAim = "Here is the aim")
+				.With(c => c.DeEscalationPoint = "Point of de-escalation")
+				.With(c => c.CaseHistory = "Case history")
+				.With(c => c.NextSteps = "Here are the next steps")
+				.With(c => c.DirectionOfTravel = "Up")
+				.With(c => c.StatusId = 1)
+				.With(c => c.RatingId = 2)
+				.With(c => c.TrustCompaniesHouseNumber = "12345678")
+				.Build();
+
+			var createCaseResponse = await _client.PostAsync($"v2/concerns-cases", createCaseRequest.ConvertToJson());
+			var response = await createCaseResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
+
+			var CaseUrn = response.Data.Urn;
+			//create the tff
+			var request = Builder<CreateTrustFinancialForecastRequest>.CreateNew()
+				.With(c => c.CaseUrn = CaseUrn)
+				.With(c => c.SRMAOfferedAfterTFF = SRMAOfferedAfterTFF.Yes)
+				.With(c => c.ForecastingToolRanAt = ForecastingToolRanAt.CurrentYearSpring)
+				.With(c => c.WasTrustResponseSatisfactory = WasTrustResponseSatisfactory.Satisfactory)
+				.With(c => c.Notes = "Here are the notes")
+				.With(c => c.SFSOInitialReviewHappenedAt = System.DateTime.UtcNow)
+				.With(c => c.TrustRespondedAt = System.DateTime.UtcNow)
+				.Build();
+
+			var result = await _client.PostAsync($"/v2/concerns-cases/{CaseUrn}/trustfinancialforecast", request.ConvertToJson());
+			result.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			var createdTFF = result.Headers.Location;
+			//check for the tff
+			var getResponse = await _client.GetAsync(createdTFF);
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			//delete the tff
+			var deleteResponse = await _client.DeleteAsync(createdTFF);
+			deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+			//check it is not returned
+			var getResponseNotFound = await _client.GetAsync(createdTFF);
+			getResponseNotFound.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		}
+
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DependencyConfigurationExtensions.cs
@@ -125,6 +125,7 @@ namespace ConcernsCaseWork.API.StartupConfiguration
 			services.AddScoped<IUseCaseAsync<GetTrustFinancialForecastByIdRequest, TrustFinancialForecastResponse>, GetTrustFinancialForecastById>();
 			services.AddScoped<IUseCaseAsync<GetTrustFinancialForecastsForCaseRequest, IEnumerable<TrustFinancialForecastResponse>>, GetTrustFinancialForecastsForCase>();
 			services.AddScoped<IUseCaseAsync<CloseTrustFinancialForecastRequest, int>, CloseTrustFinancialForecast>();
+			services.AddScoped<IUseCaseAsync<DeleteTrustFinancialForecastRequest, int>, DeleteTrustFinancialForecast>();
 			services.AddScoped<ITrustFinancialForecastGateway, TrustFinancialForecastGateway>();
 
 			// case action permission strategies

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/TrustFinancialForecast/DeleteTrustFinancialForecast.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/TrustFinancialForecast/DeleteTrustFinancialForecast.cs
@@ -1,0 +1,21 @@
+﻿using ConcernsCaseWork.API.Contracts.RequestModels.TrustFinancialForecasts;
+using ConcernsCaseWork.Data.Gateways;
+
+namespace ConcernsCaseWork.API.UseCases.CaseActions.TrustFinancialForecast
+{
+	public class DeleteTrustFinancialForecast : IUseCaseAsync<DeleteTrustFinancialForecastRequest, int>
+	{
+		private readonly ITrustFinancialForecastGateway _trustFinancialForecastGateway;
+
+		public DeleteTrustFinancialForecast(ITrustFinancialForecastGateway financialForecastGateway)
+		{
+			_trustFinancialForecastGateway = financialForecastGateway;
+		}
+
+		public Task<int> Execute(DeleteTrustFinancialForecastRequest request, CancellationToken cancellationToken)
+		{
+			_trustFinancialForecastGateway.Delete(request.TrustFinancialForecastId);
+			return Task.FromResult(request.TrustFinancialForecastId);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/TrustFinancialForecast/GetTrustFinancialForecastById.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/TrustFinancialForecast/GetTrustFinancialForecastById.cs
@@ -3,6 +3,7 @@ using ConcernsCaseWork.API.Contracts.ResponseModels.TrustFinancialForecasts;
 using ConcernsCaseWork.API.Exceptions;
 using ConcernsCaseWork.API.Factories.CaseActionFactories;
 using ConcernsCaseWork.Data.Gateways;
+using ConcernsCaseWork.Data.Models;
 
 namespace ConcernsCaseWork.API.UseCases.CaseActions.TrustFinancialForecast;
 
@@ -24,7 +25,10 @@ public class GetTrustFinancialForecastById : IUseCaseAsync<GetTrustFinancialFore
 		await EnsureCaseExists(request.CaseUrn, cancellationToken);
             
 		var response = await _trustFinancialForecastGateway.GetById(request.TrustFinancialForecastId, cancellationToken);
-		
+		if (response == null)
+		{
+			return null;
+		}
 		return response.ToResponseModel();
 	}
 	

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/TrustFinancialForecastConfiguration.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Configurations/TrustFinancialForecastConfiguration.cs
@@ -23,5 +23,6 @@ public class TrustFinancialForecastConfiguration : IEntityTypeConfiguration<Trus
 			.HasConversion<string>();
 
 		builder.HasIndex(x => new {x.CaseUrn, x.CreatedAt}).IsUnique();
+		builder.HasQueryFilter(f => !f.DeletedAt.HasValue);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ITrustFinancialForecastGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/ITrustFinancialForecastGateway.cs
@@ -7,4 +7,5 @@ public interface ITrustFinancialForecastGateway
 	Task<TrustFinancialForecast> GetById(int trustFinancialForecastId, CancellationToken cancellationToken = default);
 	Task<ICollection<TrustFinancialForecast>> GetAllForCase(int caseUrn, CancellationToken cancellationToken = default);
 	Task<int> Update(TrustFinancialForecast trustFinancialForecast, CancellationToken cancellationToken = default);
+	void Delete(int trustFinancialForecastId);
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/TrustFinancialForecastGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/TrustFinancialForecastGateway.cs
@@ -15,7 +15,7 @@ public class TrustFinancialForecastGateway : ITrustFinancialForecastGateway
 	public async Task<TrustFinancialForecast> GetById(int trustFinancialForecastId, CancellationToken cancellationToken = default)
 		=> await _concernsDbContext
 			.TrustFinancialForecasts
-			.SingleAsync(f => f.Id == trustFinancialForecastId, cancellationToken);
+			.SingleOrDefaultAsync(f => f.Id == trustFinancialForecastId, cancellationToken);
 
 
 	public async Task<ICollection<TrustFinancialForecast>> GetAllForCase(int caseUrn, CancellationToken cancellationToken = default)
@@ -34,5 +34,17 @@ public class TrustFinancialForecastGateway : ITrustFinancialForecastGateway
 		await _concernsDbContext.SaveChangesAsync(cancellationToken);
 		
 		return trustFinancialForecast.Id;
+	}
+
+	public void Delete(int trustFinancialForecastId)
+	{
+		var result = this._concernsDbContext.TrustFinancialForecasts.SingleOrDefault(f => f.Id == trustFinancialForecastId);
+		if (result != null)
+		{
+			result.DeletedAt = System.DateTime.Now;
+		}
+
+		_concernsDbContext.SaveChanges();
+
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/TrustFinancialForecastGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/TrustFinancialForecastGateway.cs
@@ -39,10 +39,7 @@ public class TrustFinancialForecastGateway : ITrustFinancialForecastGateway
 	public void Delete(int trustFinancialForecastId)
 	{
 		var result = this._concernsDbContext.TrustFinancialForecasts.SingleOrDefault(f => f.Id == trustFinancialForecastId);
-		if (result != null)
-		{
-			result.DeletedAt = System.DateTime.Now;
-		}
+		result.DeletedAt = System.DateTime.Now;
 
 		_concernsDbContext.SaveChanges();
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230717140646_AddDeletedAtToTFF.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230717140646_AddDeletedAtToTFF.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230717140646_AddDeletedAtToTFF")]
+    partial class AddDeletedAtToTFF
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230717140646_AddDeletedAtToTFF.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230717140646_AddDeletedAtToTFF.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletedAtToTFF : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "TrustFinancialForecast",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                schema: "concerns",
+                table: "TrustFinancialForecast");
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/TrustFinancialForecast.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/TrustFinancialForecast.cs
@@ -15,4 +15,5 @@ public class TrustFinancialForecast: IAuditable
 	public DateTimeOffset UpdatedAt { get; set; }
 	public DateTimeOffset? ClosedAt { get; set; }
 	public string Notes { get; set; }
+	public DateTime? DeletedAt { get; set; }
 }


### PR DESCRIPTION
**What is the change?**
Add ability to soft delete Trust Financial Forecast (TFF) via Api

**Why do we need the change?**
Be able to filter TFFs from national and regional reports

**What is the impact?**
Ability to flag records as deleted

**Azure DevOps Ticket**
[133580](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/133580)