### PR TITLE
Remove trailing comma from appsettings.json

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
@@ -58,7 +58,7 @@
 		"ConnectionString": "secret"
 	},
 	"FeatureManagement": {
-		"IsV3TrustSearchEnabled": true,
+		"IsV3TrustSearchEnabled": true
 	},
 	"FakeTrusts": {
 		"Trusts": [


### PR DESCRIPTION
**What is the change?**
Remove trailing comma from appsettings.json

**Why do we need the change?**
Invalid appsettings.json causing fail to load application in dev

**What is the impact?**
Application fails to load in dev

**Azure DevOps Ticket**
NA
