### PR TITLE
Add job to check appsettings before attempting a build

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -9,6 +9,19 @@ on:
     types: [ opened, synchronize, reopened ]
 
 jobs:
+  appsettings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check appsettings validity
+        run: |
+          DIRECTORY=./ConcernsCaseWork/ConcernsCaseWork
+          for i in "$DIRECTORY"/appsettings*.json; do
+            echo "$i" && jq . "$i"
+          done
+
   build-test:
     runs-on: ubuntu-latest
     environment: dev


### PR DESCRIPTION
**What is the change?**
A test to check that appsettings.*.json files have no syntax errors

**Why do we need the change?**
A recent commit did not have valid JSON which prevented the app from running

**What is the impact?**
N/A

**Azure DevOps Ticket**
N/A