### PR TITLE
Feature/133923 concernlastupdateddate

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/ConcernsCaseFactoryTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Factories/ConcernsCaseFactoryTests.cs
@@ -17,7 +17,7 @@ namespace ConcernsCaseWork.API.Tests.Factories
             var request = Builder<ConcernCaseRequest>.CreateNew()
                 .With(c => c.CreatedAt = new DateTime(2022,10,13))
                 .With(c => c.UpdatedAt = new DateTime(2022,06,07))
-                .With(c => c.ReviewAt = new DateTime(2022,07,10))
+				.With(c => c.ReviewAt = new DateTime(2022,07,10))
                 .With(c => c.CreatedBy = "7654")
                 .With(c => c.Description = " Test Description for case")
                 .With(c => c.CrmEnquiry = "3456")
@@ -58,7 +58,8 @@ namespace ConcernsCaseWork.API.Tests.Factories
                 Territory = request.Territory,
                 StatusId = request.StatusId,
                 RatingId = request.RatingId,
-                TrustCompaniesHouseNumber = request.TrustCompaniesHouseNumber
+                TrustCompaniesHouseNumber = request.TrustCompaniesHouseNumber,
+				CaseLastUpdatedAt = request.CreatedAt
             };
 
             var result = ConcernsCaseFactory.Create(request);

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/CaseSummaryAssert.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Helpers/CaseSummaryAssert.cs
@@ -49,6 +49,7 @@ namespace ConcernsCaseWork.API.Tests.Helpers
 				actualCase.TrustUkPrn.Should().Be(expectedCase.TrustUkprn);
 				actualCase.CaseUrn.Should().Be(expectedCase.Id);
 				actualCase.CreatedBy.Should().Be(expectedCase.CreatedBy);
+				actualCase.CaseLastUpdatedAt.Should().Be(expectedCase.CaseLastUpdatedAt);
 			}
 		}
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsCaseIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsCaseIntegrationTests.cs
@@ -22,14 +22,14 @@ using Xunit;
 namespace ConcernsCaseWork.API.Tests.Integration;
 
 [Collection(ApiTestCollection.ApiTestCollectionName)]
-public class ConcernsIntegrationTests : IDisposable
+public class ConcernsCaseIntegrationTests : IDisposable
 {
 	private readonly Fixture _autoFixture;
 	private readonly HttpClient _client;
 	private readonly RandomGenerator _randomGenerator;
 	private readonly ApiTestFixture _testFixture;
 
-	public ConcernsIntegrationTests(ApiTestFixture fixture)
+	public ConcernsCaseIntegrationTests(ApiTestFixture fixture)
 	{
 		_autoFixture = new Fixture();
 		_randomGenerator = new RandomGenerator();
@@ -38,18 +38,10 @@ public class ConcernsIntegrationTests : IDisposable
 	}
 
 	private List<ConcernsCase> CasesToBeDisposedAtEndOfTests { get; } = new();
-	private List<ConcernsRecord> RecordsToBeDisposedAtEndOfTests { get; } = new();
 
 	public void Dispose()
 	{
 		using ConcernsDbContext context = _testFixture.GetContext();
-
-		if (RecordsToBeDisposedAtEndOfTests.Any())
-		{
-			context.ConcernsRecord.RemoveRange(RecordsToBeDisposedAtEndOfTests);
-			context.SaveChanges();
-			RecordsToBeDisposedAtEndOfTests.Clear();
-		}
 
 		if (CasesToBeDisposedAtEndOfTests.Any())
 		{
@@ -84,7 +76,9 @@ public class ConcernsIntegrationTests : IDisposable
 
 		HttpRequestMessage httpRequestMessage = new()
 		{
-			Method = HttpMethod.Post, RequestUri = new Uri("https://notarealdomain.com/v2/concerns-cases"), Content = JsonContent.Create(createRequest)
+			Method = HttpMethod.Post,
+			RequestUri = new Uri("https://notarealdomain.com/v2/concerns-cases"),
+			Content = JsonContent.Create(createRequest)
 		};
 
 		ConcernsCase caseToBeCreated = ConcernsCaseFactory.Create(createRequest);
@@ -93,8 +87,8 @@ public class ConcernsIntegrationTests : IDisposable
 		ApiSingleResponseV2<ConcernsCaseResponse> expected = new(expectedConcernsCaseResponse);
 
 		// call API
-		var  response = await _client.SendAsync(httpRequestMessage);
-		
+		var response = await _client.SendAsync(httpRequestMessage);
+
 		response.StatusCode.Should().Be(HttpStatusCode.Created);
 		ApiSingleResponseV2<ConcernsCaseResponse> result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
 
@@ -134,7 +128,9 @@ public class ConcernsIntegrationTests : IDisposable
 
 		HttpRequestMessage httpRequestMessage = new()
 		{
-			Method = HttpMethod.Post, RequestUri = new Uri("https://notarealdomain.com/v2/concerns-cases"), Content = JsonContent.Create(createRequest)
+			Method = HttpMethod.Post,
+			RequestUri = new Uri("https://notarealdomain.com/v2/concerns-cases"),
+			Content = JsonContent.Create(createRequest)
 		};
 
 		ConcernsCase caseToBeCreated = ConcernsCaseFactory.Create(createRequest);
@@ -267,7 +263,8 @@ public class ConcernsIntegrationTests : IDisposable
 
 		HttpRequestMessage httpRequestMessage = new()
 		{
-			Method = HttpMethod.Get, RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/ukprn/{ukprn}/?count={count}")
+			Method = HttpMethod.Get,
+			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/ukprn/{ukprn}/?count={count}")
 		};
 		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
 		ApiResponseV2<ConcernsCaseResponse> content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
@@ -286,7 +283,8 @@ public class ConcernsIntegrationTests : IDisposable
 
 		HttpRequestMessage httpRequestMessage = new()
 		{
-			Method = HttpMethod.Get, RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/ukprn/{ukprn}/?count={count}")
+			Method = HttpMethod.Get,
+			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/ukprn/{ukprn}/?count={count}")
 		};
 		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
 		ApiResponseV2<ConcernsCaseResponse> content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsCaseResponse>>();
@@ -362,7 +360,9 @@ public class ConcernsIntegrationTests : IDisposable
 
 		HttpRequestMessage httpRequestMessage = new()
 		{
-			Method = HttpMethod.Patch, RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/{urn}"), Content = JsonContent.Create(updateRequest)
+			Method = HttpMethod.Patch,
+			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-cases/{urn}"),
+			Content = JsonContent.Create(updateRequest)
 		};
 		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
 		ApiSingleResponseV2<ConcernsCaseResponse> content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
@@ -404,480 +404,8 @@ public class ConcernsIntegrationTests : IDisposable
 		error.Should().Contain("The field TrustCompaniesHouseNumber must be a string with a maximum length of 8.");
 	}
 
-	[Fact]
-	public async Task CanCreateNewConcernRecord()
-	{
-		await using ConcernsDbContext context = _testFixture.GetContext();
 
-		ConcernsRating caseRating = context.ConcernsRatings.First();
 
-		ConcernsCase concernsCase = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			ClosedAt = _randomGenerator.DateTime(),
-			CreatedBy = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			CrmEnquiry = _randomGenerator.NextString(3, 10),
-			TrustUkprn = _randomGenerator.NextString(3, 10),
-			ReasonAtReview = _randomGenerator.NextString(3, 10),
-			DeEscalation = _randomGenerator.DateTime(),
-			Issue = _randomGenerator.NextString(3, 10),
-			CurrentStatus = _randomGenerator.NextString(3, 10),
-			CaseAim = _randomGenerator.NextString(3, 10),
-			DeEscalationPoint = _randomGenerator.NextString(3, 10),
-			NextSteps = _randomGenerator.NextString(3, 10),
-			CaseHistory = _randomGenerator.NextString(3, 10),
-			DirectionOfTravel = _randomGenerator.NextString(3, 10),
-			Territory = Territory.North_And_Utc__Yorkshire_And_Humber,
-			StatusId = 2,
-			RatingId = caseRating.Id
-		};
-
-		AddConcernsCaseToDatabase(concernsCase);
-
-		ConcernsCase linkedCase = context.ConcernsCase.First();
-		ConcernsType linkedType = context.ConcernsTypes.First();
-		ConcernsRating linkedRating = context.ConcernsRatings.First();
-		ConcernsMeansOfReferral meansOfReferral = context.ConcernsMeansOfReferrals.First();
-
-		ConcernsRecordRequest createRequest = Builder<ConcernsRecordRequest>.CreateNew()
-			.With(c => c.CaseUrn = linkedCase.Urn)
-			.With(c => c.TypeId = linkedType.Id)
-			.With(c => c.RatingId = linkedRating.Id)
-			.With(c => c.MeansOfReferralId = meansOfReferral.Id)
-			.Build();
-
-		HttpRequestMessage httpRequestMessage = new()
-		{
-			Method = HttpMethod.Post, RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records"), Content = JsonContent.Create(createRequest)
-		};
-
-		ConcernsRecord expectedRecordToBeCreated = ConcernsRecordFactory.Create(createRequest, linkedCase, linkedType, linkedRating, meansOfReferral);
-		ConcernsRecordResponse expectedConcernsRecordResponse = ConcernsRecordResponseFactory.Create(expectedRecordToBeCreated);
-		ApiSingleResponseV2<ConcernsRecordResponse> expected = new(expectedConcernsRecordResponse);
-
-		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-		response.StatusCode.Should().Be(HttpStatusCode.Created);
-		ApiSingleResponseV2<ConcernsRecordResponse> result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-
-		ConcernsRecord createdRecord = context.ConcernsRecord.FirstOrDefault(c => c.Id == result.Data.Id);
-		createdRecord.Should().NotBeNull();
-		expected.Data.Id = createdRecord!.Id;
-
-		result.Should().BeEquivalentTo(expected);
-	}
-
-	[Fact]
-	public async Task PostInvalidConcernsRecordRequest_Returns_ValidationErrors()
-	{
-		ConcernsRecordRequest request = _autoFixture.Create<ConcernsRecordRequest>();
-		request.Name = new string('a', 301);
-		request.Description = new string('a', 301);
-		request.Reason = new string('a', 301);
-
-		HttpResponseMessage result = await _client.PostAsync("/v2/concerns-records", request.ConvertToJson());
-		result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-		string error = await result.Content.ReadAsStringAsync();
-		error.Should().Contain("The field Name must be a string with a maximum length of 300.");
-		error.Should().Contain("The field Description must be a string with a maximum length of 300.");
-		error.Should().Contain("The field Reason must be a string with a maximum length of 300.");
-	}
-
-	[Fact]
-	public async Task UpdateConcernsRecord_ShouldReturnTheUpdatedConcernsRecord()
-	{
-		ConcernsCase currentConcernsCase = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			ClosedAt = _randomGenerator.DateTime(),
-			CreatedBy = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			CrmEnquiry = _randomGenerator.NextString(3, 10),
-			TrustUkprn = _randomGenerator.NextString(3, 10),
-			ReasonAtReview = _randomGenerator.NextString(3, 10),
-			DeEscalation = _randomGenerator.DateTime(),
-			Issue = _randomGenerator.NextString(3, 10),
-			CurrentStatus = _randomGenerator.NextString(3, 10),
-			CaseAim = _randomGenerator.NextString(3, 10),
-			DeEscalationPoint = _randomGenerator.NextString(3, 10),
-			NextSteps = _randomGenerator.NextString(3, 10),
-			CaseHistory = _randomGenerator.NextString(3, 10),
-			DirectionOfTravel = _randomGenerator.NextString(3, 10),
-			Territory = Territory.Midlands_And_West__West_Midlands,
-			StatusId = 2,
-			RatingId = 3
-		};
-
-		await using ConcernsDbContext context = _testFixture.GetContext();
-
-		ConcernsType concernsType = context.ConcernsTypes.First(t => t.Id == 3);
-		ConcernsRating concernsRating = context.ConcernsRatings.First(r => r.Id == 1);
-		ConcernsMeansOfReferral concernsMeansOfReferral = context.ConcernsMeansOfReferrals.First(r => r.Id == 1);
-
-		AddConcernsCaseToDatabase(currentConcernsCase);
-
-		ConcernsRecord currentConcernsRecord = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			ClosedAt = _randomGenerator.DateTime(),
-			Name = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			Reason = _randomGenerator.NextString(3, 10),
-			StatusId = 1,
-			CaseId = currentConcernsCase.Id,
-			TypeId = concernsType.Id,
-			RatingId = concernsRating.Id,
-			MeansOfReferralId = concernsMeansOfReferral.Id
-		};
-
-		AddConcernsRecord(currentConcernsRecord);
-		int currentRecordId = currentConcernsRecord.Id;
-
-		ConcernsRecordRequest updateRequest = Builder<ConcernsRecordRequest>.CreateNew()
-			.With(r => r.CaseUrn = currentConcernsCase.Urn)
-			.With(r => r.TypeId = concernsType.Id)
-			.With(r => r.RatingId = concernsRating.Id)
-			.With(r => r.MeansOfReferralId = concernsMeansOfReferral.Id).Build();
-
-		ConcernsRecord expectedConcernsRecord =
-			ConcernsRecordFactory.Update(currentConcernsRecord, updateRequest, currentConcernsCase, concernsType, concernsRating, concernsMeansOfReferral);
-		expectedConcernsRecord.Id = currentRecordId;
-		ConcernsRecordResponse expectedContent = ConcernsRecordResponseFactory.Create(expectedConcernsRecord);
-
-		HttpRequestMessage httpRequestMessage = new()
-		{
-			Method = HttpMethod.Patch, RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"), Content = JsonContent.Create(updateRequest)
-		};
-		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-		ApiSingleResponseV2<ConcernsRecordResponse> content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		content.Data.Should().BeEquivalentTo(expectedContent);
-	}
-
-	[Fact]
-	public async Task PatchInvalidConcernsRecordRequest_Returns_ValidationErrors()
-	{
-		ConcernsRecordRequest request = _autoFixture.Create<ConcernsRecordRequest>();
-		request.Name = new string('a', 301);
-		request.Description = new string('a', 301);
-		request.Reason = new string('a', 301);
-
-		HttpResponseMessage result = await _client.PatchAsync("/v2/concerns-records/1", request.ConvertToJson());
-		result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-		string error = await result.Content.ReadAsStringAsync();
-		error.Should().Contain("The field Name must be a string with a maximum length of 300.");
-		error.Should().Contain("The field Description must be a string with a maximum length of 300.");
-		error.Should().Contain("The field Reason must be a string with a maximum length of 300.");
-	}
-
-	[Theory]
-	[InlineData(true, true)]
-	[InlineData(false, false)]
-	[InlineData(true, false)]
-	[InlineData(false, true)]
-	public async Task UpdateConcernsRecord_MeansOfReferral_ShouldReturnTheUpdatedConcernsRecord(bool hasCurrentMeansOfReferral, bool isAddingMeansOfReferral)
-	{
-		ConcernsCase concernsCase = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			CreatedBy = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			CrmEnquiry = _randomGenerator.NextString(3, 10),
-			TrustUkprn = _randomGenerator.NextString(3, 10),
-			ReasonAtReview = _randomGenerator.NextString(3, 10),
-			DeEscalation = _randomGenerator.DateTime(),
-			Issue = _randomGenerator.NextString(3, 10),
-			CurrentStatus = _randomGenerator.NextString(3, 10),
-			CaseAim = _randomGenerator.NextString(3, 10),
-			DeEscalationPoint = _randomGenerator.NextString(3, 10),
-			NextSteps = _randomGenerator.NextString(3, 10),
-			CaseHistory = _randomGenerator.NextString(3, 10),
-			DirectionOfTravel = _randomGenerator.NextString(3, 10),
-			Territory = Territory.North_And_Utc__Yorkshire_And_Humber,
-			StatusId = 2,
-			RatingId = 3
-		};
-
-		AddConcernsCaseToDatabase(concernsCase);
-
-		await using ConcernsDbContext context = _testFixture.GetContext();
-
-		ConcernsType concernsType = context.ConcernsTypes.First(t => t.Id == 3);
-		ConcernsRating concernsRating = context.ConcernsRatings.First(r => r.Id == 1);
-
-		ConcernsMeansOfReferral currentMeansOfReferral = hasCurrentMeansOfReferral
-			? context.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 1)
-			: null;
-
-		ConcernsMeansOfReferral updateMeansOfReferral = isAddingMeansOfReferral
-			? context.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 2)
-			: null;
-
-		ConcernsRecord currentConcernsRecord = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			Name = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			Reason = _randomGenerator.NextString(3, 10),
-			StatusId = 1,
-			CaseId = concernsCase.Id,
-			TypeId = concernsType.Id,
-			RatingId = concernsRating.Id,
-			MeansOfReferralId = currentMeansOfReferral?.Id
-		};
-
-		AddConcernsRecord(currentConcernsRecord);
-		int currentRecordId = currentConcernsRecord.Id;
-
-		ConcernsRecordRequest updateRequest = Builder<ConcernsRecordRequest>.CreateNew()
-			.With(r => r.CaseUrn = concernsCase.Urn)
-			.With(r => r.ClosedAt = null)
-			.With(r => r.TypeId = concernsType.Id)
-			.With(r => r.RatingId = concernsRating.Id)
-			.With(r => r.MeansOfReferralId = updateMeansOfReferral?.Id)
-			.Build();
-
-		ConcernsRecord expectedConcernsRecord = ConcernsRecordFactory.Update(currentConcernsRecord, updateRequest, concernsCase, concernsType, concernsRating,
-			updateMeansOfReferral ?? currentMeansOfReferral);
-		expectedConcernsRecord.Id = currentRecordId;
-		ConcernsRecordResponse expectedContent = ConcernsRecordResponseFactory.Create(expectedConcernsRecord);
-
-		HttpRequestMessage httpRequestMessage = new()
-		{
-			Method = HttpMethod.Patch, RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"), Content = JsonContent.Create(updateRequest)
-		};
-		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-		ApiSingleResponseV2<ConcernsRecordResponse> content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		content.Data.Should().BeEquivalentTo(expectedContent);
-	}
-
-
-	public ConcernsCase BuildConcernsCase(Int32 caseRatingID)
-	{
-		ConcernsCase concernsCase = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			ClosedAt = _randomGenerator.DateTime(),
-			CreatedBy = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			CrmEnquiry = _randomGenerator.NextString(3, 10),
-			TrustUkprn = _randomGenerator.NextString(3, 10),
-			ReasonAtReview = _randomGenerator.NextString(3, 10),
-			DeEscalation = _randomGenerator.DateTime(),
-			Issue = _randomGenerator.NextString(3, 10),
-			CurrentStatus = _randomGenerator.NextString(3, 10),
-			CaseAim = _randomGenerator.NextString(3, 10),
-			DeEscalationPoint = _randomGenerator.NextString(3, 10),
-			NextSteps = _randomGenerator.NextString(3, 10),
-			CaseHistory = _randomGenerator.NextString(3, 10),
-			DirectionOfTravel = _randomGenerator.NextString(3, 10),
-			Territory = Territory.North_And_Utc__Yorkshire_And_Humber,
-			StatusId = 2,
-			RatingId = caseRatingID
-		};
-
-		return concernsCase;
-	}
-
-	[Fact]
-	public async Task DeleteMissingConcernsRecord_Returns_NotFound()
-	{
-		var currentRecordId = 987654321;
-
-		HttpRequestMessage httpRequestMessage = new()
-		{
-			Method = HttpMethod.Delete,
-			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
-		};
-		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-
-		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-	}
-
-	[Fact]
-	public async Task DeleteConcernsRecord_Returns_NoConcernsRecordForCase()
-	{
-		await using ConcernsDbContext context = _testFixture.GetContext();
-
-		ConcernsRating caseRating = context.ConcernsRatings.First();
-
-		ConcernsCase concernsCase = BuildConcernsCase(caseRating.Id);
-
-		AddConcernsCaseToDatabase(concernsCase);
-
-		ConcernsType linkedType = context.ConcernsTypes.First();
-		ConcernsRating linkedRating = context.ConcernsRatings.First();
-		ConcernsMeansOfReferral meansOfReferral = context.ConcernsMeansOfReferrals.First();
-
-		ConcernsRecordRequest createConcernsRecordContent = Builder<ConcernsRecordRequest>.CreateNew()
-			.With(c => c.CaseUrn = concernsCase.Urn)
-			.With(c => c.TypeId = linkedType.Id)
-			.With(c => c.RatingId = linkedRating.Id)
-			.With(c => c.MeansOfReferralId = meansOfReferral.Id)
-			.Build();
-
-		HttpRequestMessage createConcernsRecordHttpRequest = new()
-		{
-			Method = HttpMethod.Post,
-			RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records"),
-			Content = JsonContent.Create(createConcernsRecordContent)
-		};
-
-		HttpResponseMessage createdResponse = await _client.SendAsync(createConcernsRecordHttpRequest);
-		createdResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-
-		ApiSingleResponseV2<ConcernsRecordResponse> createdResult = await createdResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-		var currentRecordId = createdResult.Data.Id;
-		var urn = concernsCase.Urn;
-
-		HttpRequestMessage httpRequestMessage = new()
-		{
-			Method = HttpMethod.Delete,
-			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
-		};
-		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-
-		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
-
-	
-		HttpRequestMessage listConcernsforCaseResponse = new()
-		{
-			Method = HttpMethod.Get,
-			RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/case/urn/{urn}"),
-		};
-
-		HttpResponseMessage listResponse = await _client.SendAsync(listConcernsforCaseResponse);
-		ApiResponseV2<ConcernsRecordResponse> concernsforCaseList = await listResponse.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
-
-		listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-		concernsforCaseList.Data.Count().Should().Be(0);
-	}
-
-
-	[Fact]
-	public async Task GetConcernsRecordsByConcernsCaseUid()
-	{
-		ConcernsCase concernsCase = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			ClosedAt = _randomGenerator.DateTime(),
-			CreatedBy = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			CrmEnquiry = _randomGenerator.NextString(3, 10),
-			TrustUkprn = _randomGenerator.NextString(3, 10),
-			ReasonAtReview = _randomGenerator.NextString(3, 10),
-			DeEscalation = _randomGenerator.DateTime(),
-			Issue = _randomGenerator.NextString(3, 10),
-			CurrentStatus = _randomGenerator.NextString(3, 10),
-			CaseAim = _randomGenerator.NextString(3, 10),
-			DeEscalationPoint = _randomGenerator.NextString(3, 10),
-			NextSteps = _randomGenerator.NextString(3, 10),
-			CaseHistory = _randomGenerator.NextString(3, 10),
-			DirectionOfTravel = _randomGenerator.NextString(3, 10),
-			Territory = Territory.North_And_Utc__North_West,
-			StatusId = 2,
-			RatingId = 4
-		};
-
-		AddConcernsCaseToDatabase(concernsCase);
-
-		await using ConcernsDbContext context = _testFixture.GetContext();
-
-		ConcernsRating concernsRating = context.ConcernsRatings.FirstOrDefault();
-		ConcernsType concernsType = context.ConcernsTypes.FirstOrDefault();
-		ConcernsMeansOfReferral concernsMeansOfReferral = context.ConcernsMeansOfReferrals.FirstOrDefault();
-
-		ConcernsRecordRequest recordCreateRequest1 = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			ClosedAt = _randomGenerator.DateTime(),
-			Name = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			Reason = _randomGenerator.NextString(3, 10),
-			CaseUrn = concernsCase.Urn,
-			TypeId = concernsType!.Id,
-			RatingId = concernsRating!.Id,
-			StatusId = 1,
-			MeansOfReferralId = concernsMeansOfReferral!.Id
-		};
-
-		ConcernsRecordRequest recordCreateRequest2 = new()
-		{
-			CreatedAt = _randomGenerator.DateTime(),
-			UpdatedAt = _randomGenerator.DateTime(),
-			ReviewAt = _randomGenerator.DateTime(),
-			ClosedAt = _randomGenerator.DateTime(),
-			Name = _randomGenerator.NextString(3, 10),
-			Description = _randomGenerator.NextString(3, 10),
-			Reason = _randomGenerator.NextString(3, 10),
-			CaseUrn = concernsCase.Urn,
-			TypeId = concernsType.Id,
-			RatingId = concernsRating.Id,
-			StatusId = 1,
-			MeansOfReferralId = concernsMeansOfReferral.Id
-		};
-
-		HttpRequestMessage httpCreateRequestMessage1 = new()
-		{
-			Method = HttpMethod.Post, RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records/"), Content = JsonContent.Create(recordCreateRequest1)
-		};
-
-		HttpResponseMessage createResponse1 = await _client.SendAsync(httpCreateRequestMessage1);
-		ApiSingleResponseV2<ConcernsRecordResponse> content1 = await createResponse1.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-		createResponse1.StatusCode.Should().Be(HttpStatusCode.Created);
-
-		HttpRequestMessage httpCreateRequestMessage2 = new()
-		{
-			Method = HttpMethod.Post, RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records/"), Content = JsonContent.Create(recordCreateRequest2)
-		};
-
-		HttpResponseMessage createResponse2 = await _client.SendAsync(httpCreateRequestMessage2);
-		ApiSingleResponseV2<ConcernsRecordResponse> content2 = await createResponse2.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
-		createResponse2.StatusCode.Should().Be(HttpStatusCode.Created);
-
-		ConcernsRecord createdRecord1 = ConcernsRecordFactory
-			.Create(recordCreateRequest1, concernsCase, concernsType, concernsRating, concernsMeansOfReferral);
-		createdRecord1.Id = content1.Data.Id;
-		ConcernsRecord createdRecord2 = ConcernsRecordFactory
-			.Create(recordCreateRequest2, concernsCase, concernsType, concernsRating, concernsMeansOfReferral);
-		createdRecord2.Id = content2.Data.Id;
-		List<ConcernsRecord> createdRecords = new() { createdRecord1, createdRecord2 };
-		List<ConcernsRecordResponse> expected = createdRecords
-			.Select(ConcernsRecordResponseFactory.Create).ToList();
-
-		HttpRequestMessage httpRequestMessage = new()
-		{
-			Method = HttpMethod.Get, RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/case/urn/{concernsCase.Urn}")
-		};
-
-		HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-		ApiResponseV2<ConcernsRecordResponse> content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
-		content.Data.Count().Should().Be(2);
-		content.Data.Should().BeEquivalentTo(expected);
-	}
 
 	[Fact]
 	public async Task GetConcernsCaseByOwnerId()
@@ -1026,25 +554,6 @@ public class ConcernsIntegrationTests : IDisposable
 		catch (Exception)
 		{
 			context.ConcernsCase.Remove(concernsCase);
-			context.SaveChanges();
-			throw;
-		}
-	}
-
-	private void AddConcernsRecord(ConcernsRecord concernsRecord)
-	{
-		using ConcernsDbContext context = _testFixture.GetContext();
-
-		try
-		{
-			context.ConcernsRecord.Add(concernsRecord);
-			context.SaveChanges();
-
-			RecordsToBeDisposedAtEndOfTests.Add(concernsRecord);
-		}
-		catch (Exception)
-		{
-			context.ConcernsRecord.Remove(concernsRecord);
 			context.SaveChanges();
 			throw;
 		}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsCaseIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsCaseIntegrationTests.cs
@@ -101,6 +101,7 @@ public class ConcernsCaseIntegrationTests : IDisposable
 
 		result.Should().BeEquivalentTo(expected);
 		createdCase.Description.Should().BeEquivalentTo(createRequest.Description);
+		createdCase.CaseLastUpdatedAt.Should().Be(createRequest.CreatedAt);
 	}
 
 	[Fact]
@@ -150,6 +151,7 @@ public class ConcernsCaseIntegrationTests : IDisposable
 
 		result.Should().BeEquivalentTo(expected);
 		createdCase.Description.Should().BeEquivalentTo(createRequest.Description);
+		createdCase.CaseLastUpdatedAt.Should().Be(createRequest.CreatedAt);
 	}
 
 	[Fact]

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsRecordIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsRecordIntegrationTests.cs
@@ -104,6 +104,10 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			expected.Data.Id = createdRecord!.Id;
 
 			result.Should().BeEquivalentTo(expected);
+
+			await using ConcernsDbContext refreshedContext = _testFixture.GetContext();
+			concernsCase = refreshedContext.ConcernsCase.FirstOrDefault(c => c.Id == linkedCase.Id);
+			concernsCase.CaseLastUpdatedAt.Should().Be(createdRecord.CreatedAt);
 		}
 
 		[Fact]
@@ -310,9 +314,12 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 		public ConcernsCase BuildConcernsCase(Int32 caseRatingID)
 		{
+			var createdAt = _randomGenerator.DateTime();
+
 			ConcernsCase concernsCase = new()
 			{
-				CreatedAt = _randomGenerator.DateTime(),
+				CreatedAt = createdAt,
+				CaseLastUpdatedAt = createdAt,
 				UpdatedAt = _randomGenerator.DateTime(),
 				ReviewAt = _randomGenerator.DateTime(),
 				ClosedAt = _randomGenerator.DateTime(),
@@ -333,7 +340,6 @@ namespace ConcernsCaseWork.API.Tests.Integration
 				StatusId = 2,
 				RatingId = caseRatingID
 			};
-
 			return concernsCase;
 		}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsRecordIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsRecordIntegrationTests.cs
@@ -1,0 +1,567 @@
+﻿using AutoFixture;
+using ConcernsCaseWork.API.Contracts.Enums;
+using ConcernsCaseWork.API.Factories;
+using ConcernsCaseWork.API.RequestModels;
+using ConcernsCaseWork.API.ResponseModels;
+using ConcernsCaseWork.API.Tests.Fixtures;
+using ConcernsCaseWork.API.Tests.Helpers;
+using ConcernsCaseWork.Data;
+using ConcernsCaseWork.Data.Models;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+namespace ConcernsCaseWork.API.Tests.Integration
+{
+	[Collection(ApiTestCollection.ApiTestCollectionName)]
+	public class ConcernsRecordIntegrationTests: IDisposable
+	{
+
+		private readonly Fixture _autoFixture;
+		private readonly HttpClient _client;
+		private readonly RandomGenerator _randomGenerator;
+		private readonly ApiTestFixture _testFixture;
+
+		public ConcernsRecordIntegrationTests(ApiTestFixture fixture)
+		{
+			_autoFixture = new Fixture();
+			_randomGenerator = new RandomGenerator();
+			_testFixture = fixture;
+			_client = fixture.Client;
+		}
+
+
+		private List<ConcernsCase> CasesToBeDisposedAtEndOfTests { get; } = new();
+		private List<ConcernsRecord> RecordsToBeDisposedAtEndOfTests { get; } = new();
+
+		public void Dispose()
+		{
+			using ConcernsDbContext context = _testFixture.GetContext();
+
+			if (RecordsToBeDisposedAtEndOfTests.Any())
+			{
+				context.ConcernsRecord.RemoveRange(RecordsToBeDisposedAtEndOfTests);
+				context.SaveChanges();
+				RecordsToBeDisposedAtEndOfTests.Clear();
+			}
+
+			if (CasesToBeDisposedAtEndOfTests.Any())
+			{
+				context.ConcernsCase.RemoveRange(CasesToBeDisposedAtEndOfTests);
+				context.SaveChanges();
+				CasesToBeDisposedAtEndOfTests.Clear();
+			}
+		}
+
+
+		[Fact]
+		public async Task CanCreateNewConcernRecord()
+		{
+			await using ConcernsDbContext context = _testFixture.GetContext();
+
+			ConcernsRating caseRating = context.ConcernsRatings.First();
+
+			ConcernsCase concernsCase = BuildConcernsCase(caseRating.Id);
+
+			AddConcernsCaseToDatabase(concernsCase);
+
+			ConcernsCase linkedCase = concernsCase;
+			ConcernsType linkedType = context.ConcernsTypes.First();
+			ConcernsRating linkedRating = context.ConcernsRatings.First();
+			ConcernsMeansOfReferral meansOfReferral = context.ConcernsMeansOfReferrals.First();
+
+			ConcernsRecordRequest createRequest = Builder<ConcernsRecordRequest>.CreateNew()
+				.With(c => c.CaseUrn = linkedCase.Urn)
+				.With(c => c.TypeId = linkedType.Id)
+				.With(c => c.RatingId = linkedRating.Id)
+				.With(c => c.MeansOfReferralId = meansOfReferral.Id)
+				.Build();
+
+			HttpRequestMessage httpRequestMessage = new()
+			{
+				Method = HttpMethod.Post,
+				RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records"),
+				Content = JsonContent.Create(createRequest)
+			};
+
+			ConcernsRecord expectedRecordToBeCreated = ConcernsRecordFactory.Create(createRequest, linkedCase, linkedType, linkedRating, meansOfReferral);
+			ConcernsRecordResponse expectedConcernsRecordResponse = ConcernsRecordResponseFactory.Create(expectedRecordToBeCreated);
+			ApiSingleResponseV2<ConcernsRecordResponse> expected = new(expectedConcernsRecordResponse);
+
+			HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+			response.StatusCode.Should().Be(HttpStatusCode.Created);
+			ApiSingleResponseV2<ConcernsRecordResponse> result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
+
+			ConcernsRecord createdRecord = context.ConcernsRecord.FirstOrDefault(c => c.Id == result.Data.Id);
+			createdRecord.Should().NotBeNull();
+			expected.Data.Id = createdRecord!.Id;
+
+			result.Should().BeEquivalentTo(expected);
+		}
+
+		[Fact]
+		public async Task PostInvalidConcernsRecordRequest_Returns_ValidationErrors()
+		{
+			ConcernsRecordRequest request = _autoFixture.Create<ConcernsRecordRequest>();
+			request.Name = new string('a', 301);
+			request.Description = new string('a', 301);
+			request.Reason = new string('a', 301);
+
+			HttpResponseMessage result = await _client.PostAsync("/v2/concerns-records", request.ConvertToJson());
+			result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+			string error = await result.Content.ReadAsStringAsync();
+			error.Should().Contain("The field Name must be a string with a maximum length of 300.");
+			error.Should().Contain("The field Description must be a string with a maximum length of 300.");
+			error.Should().Contain("The field Reason must be a string with a maximum length of 300.");
+		}
+
+		[Fact]
+		public async Task UpdateConcernsRecord_ShouldReturnTheUpdatedConcernsRecord()
+		{
+			ConcernsCase currentConcernsCase = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				ClosedAt = _randomGenerator.DateTime(),
+				CreatedBy = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				CrmEnquiry = _randomGenerator.NextString(3, 10),
+				TrustUkprn = _randomGenerator.NextString(3, 10),
+				ReasonAtReview = _randomGenerator.NextString(3, 10),
+				DeEscalation = _randomGenerator.DateTime(),
+				Issue = _randomGenerator.NextString(3, 10),
+				CurrentStatus = _randomGenerator.NextString(3, 10),
+				CaseAim = _randomGenerator.NextString(3, 10),
+				DeEscalationPoint = _randomGenerator.NextString(3, 10),
+				NextSteps = _randomGenerator.NextString(3, 10),
+				CaseHistory = _randomGenerator.NextString(3, 10),
+				DirectionOfTravel = _randomGenerator.NextString(3, 10),
+				Territory = Territory.Midlands_And_West__West_Midlands,
+				StatusId = 2,
+				RatingId = 3
+			};
+
+			await using ConcernsDbContext context = _testFixture.GetContext();
+
+			ConcernsType concernsType = context.ConcernsTypes.First(t => t.Id == 3);
+			ConcernsRating concernsRating = context.ConcernsRatings.First(r => r.Id == 1);
+			ConcernsMeansOfReferral concernsMeansOfReferral = context.ConcernsMeansOfReferrals.First(r => r.Id == 1);
+
+			AddConcernsCaseToDatabase(currentConcernsCase);
+
+			ConcernsRecord currentConcernsRecord = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				ClosedAt = _randomGenerator.DateTime(),
+				Name = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				Reason = _randomGenerator.NextString(3, 10),
+				StatusId = 1,
+				CaseId = currentConcernsCase.Id,
+				TypeId = concernsType.Id,
+				RatingId = concernsRating.Id,
+				MeansOfReferralId = concernsMeansOfReferral.Id
+			};
+
+			AddConcernsRecord(currentConcernsRecord);
+			int currentRecordId = currentConcernsRecord.Id;
+
+			ConcernsRecordRequest updateRequest = Builder<ConcernsRecordRequest>.CreateNew()
+				.With(r => r.CaseUrn = currentConcernsCase.Urn)
+				.With(r => r.TypeId = concernsType.Id)
+				.With(r => r.RatingId = concernsRating.Id)
+				.With(r => r.MeansOfReferralId = concernsMeansOfReferral.Id).Build();
+
+			ConcernsRecord expectedConcernsRecord =
+				ConcernsRecordFactory.Update(currentConcernsRecord, updateRequest, currentConcernsCase, concernsType, concernsRating, concernsMeansOfReferral);
+			expectedConcernsRecord.Id = currentRecordId;
+			ConcernsRecordResponse expectedContent = ConcernsRecordResponseFactory.Create(expectedConcernsRecord);
+
+			HttpRequestMessage httpRequestMessage = new()
+			{
+				Method = HttpMethod.Patch,
+				RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
+				Content = JsonContent.Create(updateRequest)
+			};
+			HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+			ApiSingleResponseV2<ConcernsRecordResponse> content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
+
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+			content.Data.Should().BeEquivalentTo(expectedContent);
+		}
+
+		[Fact]
+		public async Task PatchInvalidConcernsRecordRequest_Returns_ValidationErrors()
+		{
+			ConcernsRecordRequest request = _autoFixture.Create<ConcernsRecordRequest>();
+			request.Name = new string('a', 301);
+			request.Description = new string('a', 301);
+			request.Reason = new string('a', 301);
+
+			HttpResponseMessage result = await _client.PatchAsync("/v2/concerns-records/1", request.ConvertToJson());
+			result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+			string error = await result.Content.ReadAsStringAsync();
+			error.Should().Contain("The field Name must be a string with a maximum length of 300.");
+			error.Should().Contain("The field Description must be a string with a maximum length of 300.");
+			error.Should().Contain("The field Reason must be a string with a maximum length of 300.");
+		}
+
+		[Theory]
+		[InlineData(true, true)]
+		[InlineData(false, false)]
+		[InlineData(true, false)]
+		[InlineData(false, true)]
+		public async Task UpdateConcernsRecord_MeansOfReferral_ShouldReturnTheUpdatedConcernsRecord(bool hasCurrentMeansOfReferral, bool isAddingMeansOfReferral)
+		{
+			ConcernsCase concernsCase = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				CreatedBy = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				CrmEnquiry = _randomGenerator.NextString(3, 10),
+				TrustUkprn = _randomGenerator.NextString(3, 10),
+				ReasonAtReview = _randomGenerator.NextString(3, 10),
+				DeEscalation = _randomGenerator.DateTime(),
+				Issue = _randomGenerator.NextString(3, 10),
+				CurrentStatus = _randomGenerator.NextString(3, 10),
+				CaseAim = _randomGenerator.NextString(3, 10),
+				DeEscalationPoint = _randomGenerator.NextString(3, 10),
+				NextSteps = _randomGenerator.NextString(3, 10),
+				CaseHistory = _randomGenerator.NextString(3, 10),
+				DirectionOfTravel = _randomGenerator.NextString(3, 10),
+				Territory = Territory.North_And_Utc__Yorkshire_And_Humber,
+				StatusId = 2,
+				RatingId = 3
+			};
+
+			AddConcernsCaseToDatabase(concernsCase);
+
+			await using ConcernsDbContext context = _testFixture.GetContext();
+
+			ConcernsType concernsType = context.ConcernsTypes.First(t => t.Id == 3);
+			ConcernsRating concernsRating = context.ConcernsRatings.First(r => r.Id == 1);
+
+			ConcernsMeansOfReferral currentMeansOfReferral = hasCurrentMeansOfReferral
+				? context.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 1)
+				: null;
+
+			ConcernsMeansOfReferral updateMeansOfReferral = isAddingMeansOfReferral
+				? context.ConcernsMeansOfReferrals.FirstOrDefault(r => r.Id == 2)
+				: null;
+
+			ConcernsRecord currentConcernsRecord = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				Name = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				Reason = _randomGenerator.NextString(3, 10),
+				StatusId = 1,
+				CaseId = concernsCase.Id,
+				TypeId = concernsType.Id,
+				RatingId = concernsRating.Id,
+				MeansOfReferralId = currentMeansOfReferral?.Id
+			};
+
+			AddConcernsRecord(currentConcernsRecord);
+			int currentRecordId = currentConcernsRecord.Id;
+
+			ConcernsRecordRequest updateRequest = Builder<ConcernsRecordRequest>.CreateNew()
+				.With(r => r.CaseUrn = concernsCase.Urn)
+				.With(r => r.ClosedAt = null)
+				.With(r => r.TypeId = concernsType.Id)
+				.With(r => r.RatingId = concernsRating.Id)
+				.With(r => r.MeansOfReferralId = updateMeansOfReferral?.Id)
+				.Build();
+
+			ConcernsRecord expectedConcernsRecord = ConcernsRecordFactory.Update(currentConcernsRecord, updateRequest, concernsCase, concernsType, concernsRating,
+				updateMeansOfReferral ?? currentMeansOfReferral);
+			expectedConcernsRecord.Id = currentRecordId;
+			ConcernsRecordResponse expectedContent = ConcernsRecordResponseFactory.Create(expectedConcernsRecord);
+
+			HttpRequestMessage httpRequestMessage = new()
+			{
+				Method = HttpMethod.Patch,
+				RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
+				Content = JsonContent.Create(updateRequest)
+			};
+			HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+			ApiSingleResponseV2<ConcernsRecordResponse> content = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
+
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+			content.Data.Should().BeEquivalentTo(expectedContent);
+		}
+
+
+		public ConcernsCase BuildConcernsCase(Int32 caseRatingID)
+		{
+			ConcernsCase concernsCase = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				ClosedAt = _randomGenerator.DateTime(),
+				CreatedBy = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				CrmEnquiry = _randomGenerator.NextString(3, 10),
+				TrustUkprn = _randomGenerator.NextString(3, 10),
+				ReasonAtReview = _randomGenerator.NextString(3, 10),
+				DeEscalation = _randomGenerator.DateTime(),
+				Issue = _randomGenerator.NextString(3, 10),
+				CurrentStatus = _randomGenerator.NextString(3, 10),
+				CaseAim = _randomGenerator.NextString(3, 10),
+				DeEscalationPoint = _randomGenerator.NextString(3, 10),
+				NextSteps = _randomGenerator.NextString(3, 10),
+				CaseHistory = _randomGenerator.NextString(3, 10),
+				DirectionOfTravel = _randomGenerator.NextString(3, 10),
+				Territory = Territory.North_And_Utc__Yorkshire_And_Humber,
+				StatusId = 2,
+				RatingId = caseRatingID
+			};
+
+			return concernsCase;
+		}
+
+		[Fact]
+		public async Task DeleteMissingConcernsRecord_Returns_NotFound()
+		{
+			var currentRecordId = 987654321;
+
+			HttpRequestMessage httpRequestMessage = new()
+			{
+				Method = HttpMethod.Delete,
+				RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
+			};
+			HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+			response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		}
+
+		[Fact]
+		public async Task DeleteConcernsRecord_Returns_NoConcernsRecordForCase()
+		{
+			await using ConcernsDbContext context = _testFixture.GetContext();
+
+			ConcernsRating caseRating = context.ConcernsRatings.First();
+
+			ConcernsCase concernsCase = BuildConcernsCase(caseRating.Id);
+
+			AddConcernsCaseToDatabase(concernsCase);
+
+			ConcernsType linkedType = context.ConcernsTypes.First();
+			ConcernsRating linkedRating = context.ConcernsRatings.First();
+			ConcernsMeansOfReferral meansOfReferral = context.ConcernsMeansOfReferrals.First();
+
+			ConcernsRecordRequest createConcernsRecordContent = Builder<ConcernsRecordRequest>.CreateNew()
+				.With(c => c.CaseUrn = concernsCase.Urn)
+				.With(c => c.TypeId = linkedType.Id)
+				.With(c => c.RatingId = linkedRating.Id)
+				.With(c => c.MeansOfReferralId = meansOfReferral.Id)
+				.Build();
+
+			HttpRequestMessage createConcernsRecordHttpRequest = new()
+			{
+				Method = HttpMethod.Post,
+				RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records"),
+				Content = JsonContent.Create(createConcernsRecordContent)
+			};
+
+			HttpResponseMessage createdResponse = await _client.SendAsync(createConcernsRecordHttpRequest);
+			createdResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			ApiSingleResponseV2<ConcernsRecordResponse> createdResult = await createdResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
+			var currentRecordId = createdResult.Data.Id;
+			var urn = concernsCase.Urn;
+
+			HttpRequestMessage httpRequestMessage = new()
+			{
+				Method = HttpMethod.Delete,
+				RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/{currentRecordId}"),
+			};
+			HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+			response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+
+			HttpRequestMessage listConcernsforCaseResponse = new()
+			{
+				Method = HttpMethod.Get,
+				RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/case/urn/{urn}"),
+			};
+
+			HttpResponseMessage listResponse = await _client.SendAsync(listConcernsforCaseResponse);
+			ApiResponseV2<ConcernsRecordResponse> concernsforCaseList = await listResponse.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
+
+			listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+			concernsforCaseList.Data.Count().Should().Be(0);
+		}
+
+
+		[Fact]
+		public async Task GetConcernsRecordsByConcernsCaseUid()
+		{
+			ConcernsCase concernsCase = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				ClosedAt = _randomGenerator.DateTime(),
+				CreatedBy = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				CrmEnquiry = _randomGenerator.NextString(3, 10),
+				TrustUkprn = _randomGenerator.NextString(3, 10),
+				ReasonAtReview = _randomGenerator.NextString(3, 10),
+				DeEscalation = _randomGenerator.DateTime(),
+				Issue = _randomGenerator.NextString(3, 10),
+				CurrentStatus = _randomGenerator.NextString(3, 10),
+				CaseAim = _randomGenerator.NextString(3, 10),
+				DeEscalationPoint = _randomGenerator.NextString(3, 10),
+				NextSteps = _randomGenerator.NextString(3, 10),
+				CaseHistory = _randomGenerator.NextString(3, 10),
+				DirectionOfTravel = _randomGenerator.NextString(3, 10),
+				Territory = Territory.North_And_Utc__North_West,
+				StatusId = 2,
+				RatingId = 4
+			};
+
+			AddConcernsCaseToDatabase(concernsCase);
+
+			await using ConcernsDbContext context = _testFixture.GetContext();
+
+			ConcernsRating concernsRating = context.ConcernsRatings.FirstOrDefault();
+			ConcernsType concernsType = context.ConcernsTypes.FirstOrDefault();
+			ConcernsMeansOfReferral concernsMeansOfReferral = context.ConcernsMeansOfReferrals.FirstOrDefault();
+
+			ConcernsRecordRequest recordCreateRequest1 = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				ClosedAt = _randomGenerator.DateTime(),
+				Name = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				Reason = _randomGenerator.NextString(3, 10),
+				CaseUrn = concernsCase.Urn,
+				TypeId = concernsType!.Id,
+				RatingId = concernsRating!.Id,
+				StatusId = 1,
+				MeansOfReferralId = concernsMeansOfReferral!.Id
+			};
+
+			ConcernsRecordRequest recordCreateRequest2 = new()
+			{
+				CreatedAt = _randomGenerator.DateTime(),
+				UpdatedAt = _randomGenerator.DateTime(),
+				ReviewAt = _randomGenerator.DateTime(),
+				ClosedAt = _randomGenerator.DateTime(),
+				Name = _randomGenerator.NextString(3, 10),
+				Description = _randomGenerator.NextString(3, 10),
+				Reason = _randomGenerator.NextString(3, 10),
+				CaseUrn = concernsCase.Urn,
+				TypeId = concernsType.Id,
+				RatingId = concernsRating.Id,
+				StatusId = 1,
+				MeansOfReferralId = concernsMeansOfReferral.Id
+			};
+
+			HttpRequestMessage httpCreateRequestMessage1 = new()
+			{
+				Method = HttpMethod.Post,
+				RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records/"),
+				Content = JsonContent.Create(recordCreateRequest1)
+			};
+
+			HttpResponseMessage createResponse1 = await _client.SendAsync(httpCreateRequestMessage1);
+			ApiSingleResponseV2<ConcernsRecordResponse> content1 = await createResponse1.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
+			createResponse1.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			HttpRequestMessage httpCreateRequestMessage2 = new()
+			{
+				Method = HttpMethod.Post,
+				RequestUri = new Uri("https://notarealdomain.com/v2/concerns-records/"),
+				Content = JsonContent.Create(recordCreateRequest2)
+			};
+
+			HttpResponseMessage createResponse2 = await _client.SendAsync(httpCreateRequestMessage2);
+			ApiSingleResponseV2<ConcernsRecordResponse> content2 = await createResponse2.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsRecordResponse>>();
+			createResponse2.StatusCode.Should().Be(HttpStatusCode.Created);
+
+			ConcernsRecord createdRecord1 = ConcernsRecordFactory
+				.Create(recordCreateRequest1, concernsCase, concernsType, concernsRating, concernsMeansOfReferral);
+			createdRecord1.Id = content1.Data.Id;
+			ConcernsRecord createdRecord2 = ConcernsRecordFactory
+				.Create(recordCreateRequest2, concernsCase, concernsType, concernsRating, concernsMeansOfReferral);
+			createdRecord2.Id = content2.Data.Id;
+			List<ConcernsRecord> createdRecords = new() { createdRecord1, createdRecord2 };
+			List<ConcernsRecordResponse> expected = createdRecords
+				.Select(ConcernsRecordResponseFactory.Create).ToList();
+
+			HttpRequestMessage httpRequestMessage = new()
+			{
+				Method = HttpMethod.Get,
+				RequestUri = new Uri($"https://notarealdomain.com/v2/concerns-records/case/urn/{concernsCase.Urn}")
+			};
+
+			HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+			ApiResponseV2<ConcernsRecordResponse> content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
+			content.Data.Count().Should().Be(2);
+			content.Data.Should().BeEquivalentTo(expected);
+		}
+
+
+		private void AddConcernsCaseToDatabase(ConcernsCase concernsCase)
+		{
+			using ConcernsDbContext context = _testFixture.GetContext();
+
+			try
+			{
+				context.ConcernsCase.Add(concernsCase);
+				context.SaveChanges();
+
+				CasesToBeDisposedAtEndOfTests.Add(concernsCase);
+			}
+			catch (Exception)
+			{
+				context.ConcernsCase.Remove(concernsCase);
+				context.SaveChanges();
+				throw;
+			}
+		}
+
+		private void AddConcernsRecord(ConcernsRecord concernsRecord)
+		{
+			using ConcernsDbContext context = _testFixture.GetContext();
+
+			try
+			{
+				context.ConcernsRecord.Add(concernsRecord);
+				context.SaveChanges();
+
+				RecordsToBeDisposedAtEndOfTests.Add(concernsRecord);
+			}
+			catch (Exception)
+			{
+				context.ConcernsRecord.Remove(concernsRecord);
+				context.SaveChanges();
+				throw;
+			}
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/GetCasesByOwnerIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/GetCasesByOwnerIntegrationTests.cs
@@ -57,6 +57,8 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			actualCase.CaseUrn.Should().Be(expectedCase.Id);
 			actualCase.CreatedAt.Should().Be(expectedCase.CreatedAt);
 			actualCase.CreatedBy.Should().Be(expectedCase.CreatedBy);
+			actualCase.CaseLastUpdatedAt.Should().Be(expectedCase.CaseLastUpdatedAt);
+
 			actualCase.TrustUkPrn.Should().Be(expectedCase.TrustUkprn);
 			actualCase.StatusName.Should().Be(CaseStatus.Live.ToString());
 
@@ -226,6 +228,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			actualCase.CaseUrn.Should().Be(expectedCase.Id);
 			actualCase.CreatedAt.Should().Be(expectedCase.CreatedAt);
 			actualCase.CreatedBy.Should().Be(expectedCase.CreatedBy);
+			actualCase.CaseLastUpdatedAt.Should().Be(expectedCase.CaseLastUpdatedAt);
 			actualCase.TrustUkPrn.Should().Be(expectedCase.TrustUkprn);
 			actualCase.StatusName.Should().Be(CaseStatus.Close.ToString());
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsRecordController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsRecordController.cs
@@ -36,15 +36,15 @@ namespace ConcernsCaseWork.API.Controllers
 			_getConcernsRecord = getConcernsRecord;
 		}
         
-        [HttpPost]
-        [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>>> Create(ConcernsRecordRequest request, CancellationToken cancellationToken = default)
-        {
-            var createdConcernsRecord = _createConcernsRecord.Execute(request);
-            var response = new ApiSingleResponseV2<ConcernsRecordResponse>(createdConcernsRecord);
+        //[HttpPost]
+        //[MapToApiVersion("2.0")]
+        //public async Task<ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>>> Create(ConcernsRecordRequest request, CancellationToken cancellationToken = default)
+        //{
+        //    var createdConcernsRecord = _createConcernsRecord.Execute(request);
+        //    var response = new ApiSingleResponseV2<ConcernsRecordResponse>(createdConcernsRecord);
             
-            return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
-        }
+        //    return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
+        //}
         
         [HttpPatch("{id}")]
         [MapToApiVersion("2.0")]

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Factories/CaseSummaryResponseFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Factories/CaseSummaryResponseFactory.cs
@@ -24,7 +24,8 @@ public static class CaseSummaryResponseFactory
 			TrustFinancialForecasts = Create(caseSummary.TrustFinancialForecasts),
 			StatusName = caseSummary.StatusName,
 			TrustUkPrn = caseSummary.TrustUkPrn,
-			UpdatedAt = caseSummary.UpdatedAt
+			UpdatedAt = caseSummary.UpdatedAt,
+			CaseLastUpdatedAt = caseSummary.CaseLastUpdatedAt
 		};
 	}
 	

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Factories/ConcernsCaseFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Factories/ConcernsCaseFactory.cs
@@ -8,9 +8,10 @@ namespace ConcernsCaseWork.API.Factories
     {
         public static ConcernsCase Create(ConcernCaseRequest request)
         {
-            return new ConcernsCase
+            var cc =  new ConcernsCase
             {
                 CreatedAt = request.CreatedAt,
+				CaseLastUpdatedAt = request.CreatedAt,
                 UpdatedAt = request.UpdatedAt,
                 ReviewAt = request.ReviewAt,
                 ClosedAt = request.ClosedAt,
@@ -32,6 +33,8 @@ namespace ConcernsCaseWork.API.Factories
                 Territory = request.Territory,
                 TrustCompaniesHouseNumber = request.TrustCompaniesHouseNumber
             };
+
+			return cc;
         }
         
         public static ConcernsCase Update(ConcernsCase original, ConcernCaseRequest updateRequest)

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/ConcernsRecordController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/ConcernsRecordController.cs
@@ -1,0 +1,47 @@
+﻿using ConcernsCaseWork.API.Features.CityTechnicalCollege;
+using ConcernsCaseWork.API.RequestModels;
+using ConcernsCaseWork.API.ResponseModels;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace ConcernsCaseWork.API.Features.ConcernsRecord
+{
+	[ApiVersion("2.0")]
+	[ApiController]
+	[Route("v{version:apiVersion}/concerns-records")]
+	public class ConcernsRecordController : ControllerBase
+	{
+		private readonly IMediator _mediator;
+
+		public ConcernsRecordController(IMediator mediator)
+		{
+			_mediator = mediator;
+		}
+
+		[HttpPost()]
+		[MapToApiVersion("2.0")]
+		[ProducesResponseType((int)HttpStatusCode.Created)]
+		[ProducesResponseType((int)HttpStatusCode.BadRequest)]
+		public async Task<IActionResult> Create([FromBody] Create.Command command, CancellationToken cancellationToken = default)
+		{
+			var commandResult = await _mediator.Send(command);
+			var model = await _mediator.Send(new GetByID.Query() { Id = commandResult });
+			return CreatedAtAction(nameof(GetByID), new { Id = model.Id }, new ApiSingleResponseV2<GetByID.Result>(model));
+		}
+
+		[HttpGet("{Id}:int", Name = nameof(GetByID))]
+		[ProducesResponseType((int)HttpStatusCode.OK)]
+		[ProducesResponseType((int)HttpStatusCode.NotFound)]
+		public async Task<IActionResult> GetByID([FromRoute] GetByID.Query query)
+		{
+			var model = await _mediator.Send(query);
+			if (model == null)
+			{
+				return NotFound();
+			}
+
+			return Ok(model);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/Create.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/Create.cs
@@ -1,0 +1,62 @@
+﻿using ConcernsCaseWork.Data;
+using MediatR;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcernsCaseWork.API.Features.ConcernsRecord
+{
+	using ConcernsCaseWork.Data.Models;
+	using Microsoft.EntityFrameworkCore;
+
+	public class Create
+	{
+		public class Command : IRequest<int>
+		{
+			public DateTime CreatedAt { get; set; }
+			public DateTime UpdatedAt { get; set; }
+			public DateTime ReviewAt { get; set; }
+			public DateTime? ClosedAt { get; set; }
+
+			[StringLength(300)]
+			public string Name { get; set; }
+
+			[StringLength(300)]
+			public string Description { get; set; }
+
+			[StringLength(300)]
+			public string Reason { get; set; }
+			public int CaseUrn { get; set; }
+			public int TypeId { get; set; }
+			public int RatingId { get; set; }
+			public int StatusId { get; set; }
+			public int MeansOfReferralId { get; set; }
+		}
+
+		public class CommandHandler : IRequestHandler<Command, Int32>
+		{
+			private readonly ConcernsDbContext _context;
+			private readonly IMediator _mediator;
+
+			public CommandHandler(ConcernsDbContext context, IMediator mediator)
+			{
+				_context = context;
+				_mediator = mediator;
+			}
+
+			public async Task<int> Handle(Command request, CancellationToken cancellationToken)
+			{
+				ConcernsRecord cr = ConcernsRecord.Create(request.CaseUrn, request.TypeId, request.RatingId, request.MeansOfReferralId, request.StatusId);
+
+				cr.ChangeNameDescriptionAndReason(request.Name, request.Description, request.Reason);
+				cr.SetAuditInformation(request.CreatedAt, request.UpdatedAt, request.ReviewAt);
+
+				_context.ConcernsRecord.Add(cr);
+							
+				await _context.SaveChangesAsync();
+
+
+				return cr.Id;
+			}
+		}
+
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/GetByID.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/GetByID.cs
@@ -1,0 +1,52 @@
+﻿using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using ConcernsCaseWork.Data;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcernsCaseWork.API.Features.ConcernsRecord
+{
+	public class GetByID
+	{
+		public class Query : IRequest<Result>
+		{
+			public int Id { get; set; }
+		}
+
+		public class Result
+		{
+			public DateTime CreatedAt { get; set; }
+			public DateTime UpdatedAt { get; set; }
+			public DateTime ReviewAt { get; set; }
+			public DateTime? ClosedAt { get; set; }
+			public string Name { get; set; }
+			public string Description { get; set; }
+			public string Reason { get; set; }
+			public int RatingId { get; set; }
+			public int Id { get; set; }
+			public int StatusId { get; set; }
+			public int TypeId { get; set; }
+			public int CaseUrn { get; set; }
+			public int? MeansOfReferralId { get; set; }
+
+		}
+
+		public class Handler : IRequestHandler<Query, Result>
+		{
+			private readonly ConcernsDbContext _context;
+			private readonly MapperConfiguration _mapperConfiguration;
+
+			public Handler(ConcernsDbContext context, MapperConfiguration mapperConfiguration)
+			{
+				_context = context;
+				_mapperConfiguration = mapperConfiguration;
+			}
+
+			public async Task<Result> Handle(Query request, CancellationToken cancellationToken)
+			{
+				Result result = await _context.ConcernsRecord.Include(f=> f.ConcernsCase).Where(f => f.Id == request.Id).ProjectTo<Result>(_mapperConfiguration).SingleOrDefaultAsync(f => f.Id == request.Id);
+				return result;
+			}
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/MappingProfile.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/MappingProfile.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+
+namespace ConcernsCaseWork.API.Features.ConcernsRecord
+{
+	using ConcernsCaseWork.Data.Models;
+
+	public class MappingProfile : Profile
+	{
+		public MappingProfile()
+		{
+			CreateMap<ConcernsRecord, GetByID.Result>()
+				.ForMember(dest => dest.CaseUrn, opt => opt.MapFrom(src => src.ConcernsCase.Urn));
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/ResponseModels/ActiveCaseSummaryResponse.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/ResponseModels/ActiveCaseSummaryResponse.cs
@@ -6,6 +6,7 @@ public abstract record CaseSummaryResponse
 	public string CreatedBy { get; set; }
 	public DateTime CreatedAt { get; set; }
 	public DateTime UpdatedAt { get; set; }
+	public DateTime? CaseLastUpdatedAt { get; set; }
 	public string StatusName { get; set; }
 	public string TrustUkPrn { get; set; }
 	public IEnumerable<ActionOrDecision> Decisions { get; set; }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
@@ -30,7 +30,7 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 				StatusName = cases.Status.Name,
 				TrustUkPrn = cases.TrustUkprn,
 				UpdatedAt = cases.UpdatedAt,
-
+				CaseLastUpdatedAt = cases.CaseLastUpdatedAt,
 				ActiveConcerns = from concerns
 					in cases.ConcernsRecords
 								 where concerns.StatusId == 1
@@ -167,7 +167,7 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 			StatusName = cases.Status.Name,
 			TrustUkPrn = cases.TrustUkprn,
 			UpdatedAt = cases.UpdatedAt,
-
+			CaseLastUpdatedAt = cases.CaseLastUpdatedAt,
 			ActiveConcerns = from concerns
 				in cases.ConcernsRecords
 							 where concerns.StatusId == 1

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryVm.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryVm.cs
@@ -27,6 +27,7 @@ public record ActiveCaseSummaryVm : CaseSummaryVm
 {
 	public IEnumerable<Concern> ActiveConcerns { get; set; }
 	public ConcernsRating Rating { get; set; }
+	public DateTime? CaseLastUpdatedAt { get; set; }
 }
 
 public record ClosedCaseSummaryVm : CaseSummaryVm

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230725115835_AddCaseLastUpdatedDate.Designer.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230725115835_AddCaseLastUpdatedDate.Designer.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConcernsCaseWork.Data.Migrations
 {
     [DbContext(typeof(ConcernsDbContext))]
-    partial class ConcernsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230725115835_AddCaseLastUpdatedDate")]
+    partial class AddCaseLastUpdatedDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230725115835_AddCaseLastUpdatedDate.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Migrations/20230725115835_AddCaseLastUpdatedDate.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcernsCaseWork.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCaseLastUpdatedDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CaseLastUpdatedAt",
+                schema: "concerns",
+                table: "ConcernsCase",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CaseLastUpdatedAt",
+                schema: "concerns",
+                table: "ConcernsCase");
+        }
+    }
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsCase.cs
@@ -1,3 +1,5 @@
+using ConcernsCaseWork.API.Contracts.Case;
+using ConcernsCaseWork.API.Contracts.Concerns;
 using ConcernsCaseWork.API.Contracts.Enums;
 using ConcernsCaseWork.Data.Exceptions;
 using ConcernsCaseWork.Data.Models.Concerns.Case.Management.Actions.Decisions;
@@ -9,7 +11,10 @@ namespace ConcernsCaseWork.Data.Models
     {
         public int Id { get; set; }
         public DateTime CreatedAt { get; set; }
-        public DateTime UpdatedAt { get; set; }
+		/// <summary>
+		/// Stores datetime when the case object was last updated
+		/// </summary>
+		public DateTime UpdatedAt { get; set; }
         public DateTime ReviewAt { get; set; }
         public DateTime? ClosedAt { get; set; }
         public string CreatedBy { get; set; }
@@ -32,8 +37,14 @@ namespace ConcernsCaseWork.Data.Models
         public Territory? Territory { get; set; }
 
         public string? TrustCompaniesHouseNumber { get; set; }
-        
-        public virtual ConcernsStatus Status { get; set; }
+
+		/// <summary>
+		/// Stores date when the entire case was last updated e.g. Changes such as adding concern or case action.
+		/// </summary>
+		public DateTime? CaseLastUpdatedAt { get; set; }
+
+
+		public virtual ConcernsStatus Status { get; set; }
         public virtual ConcernsRating Rating { get; set; }
         public virtual ICollection<ConcernsRecord> ConcernsRecords { get; set; }
 
@@ -101,5 +112,41 @@ namespace ConcernsCaseWork.Data.Models
 
 	        currentDecision.Close(notes, now);
         }
-    }
+
+		//public void SetCreatedDate(DateTime createdAt)
+		//{
+		//	this.CreatedAt = createdAt;
+		//	SetCaseUpdatedDate(createdAt);
+		//}
+
+		//public void SetCaseUpdatedDate(DateTime caseUpdatedAt)
+		//{
+		//	this.CaseLastUpdatedAt = caseUpdatedAt;
+		//}
+
+		//public ConcernsCase()
+		//{
+
+		//}
+
+		//private ConcernsCase(int statusID, int ratingID, string trustUKPRN, string createdBy, DateTime createdAt)
+		//{
+		//	this.ConcernsRecords = new List<ConcernsRecord>();
+		//	this.StatusId = statusID;
+		//	this.RatingId = ratingID;
+		//	this.TrustUkprn = trustUKPRN;
+		//	this.CreatedBy = createdBy;
+		//	this.CreatedAt = CreatedAt;
+		//}
+
+		//public static ConcernsCase Create(CaseStatus status, ConcernRating rating, string trustUKPRN, string createdBy, DateTime createdAt)
+		//{
+		//	return new ConcernsCase((int)status, (int)rating, trustUKPRN, createdBy, createdAt);
+		//}
+
+		//public void SetAuditInformation(DateTime caseUpdatedAt)
+		//{
+		//	this.CaseLastUpdatedAt = caseUpdatedAt;
+		//}
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsRecord.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/ConcernsRecord.cs
@@ -4,7 +4,7 @@ namespace ConcernsCaseWork.Data.Models
 {
     public class ConcernsRecord: IAuditable
     {
-        public int Id { get; set; }
+		public int Id { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public DateTime ReviewAt { get; set; }
@@ -24,5 +24,39 @@ namespace ConcernsCaseWork.Data.Models
         public virtual ConcernsStatus Status { get; set; }
 
 		public DateTime? DeletedAt { get; set; }
+
+		//Todo: BB 25/07/2023 Make constructor private once concernsrecord refactor is complete
+		public ConcernsRecord()
+		{
+			
+		}
+
+		protected ConcernsRecord(int caseUrn, int typeId, int ratingId, int meansOfReferralId, int statusId)
+		{
+			this.CaseId = caseUrn;
+			this.TypeId = typeId;
+			this.RatingId = ratingId;
+			this.MeansOfReferralId = meansOfReferralId; 
+			this.StatusId = statusId;
+		}
+
+		public static ConcernsRecord Create(int caseUrn, int typeId, int ratingId, int meansOfReferralId, int statusId)
+		{
+			return new ConcernsRecord(caseUrn,typeId, ratingId, meansOfReferralId, statusId);
+		}
+
+		public void ChangeNameDescriptionAndReason(string name, string description, string reason)
+		{
+			this.Name = name;
+			this.Description = description;
+			this.Reason = reason;
+		}
+
+		public void SetAuditInformation(DateTime createdAt, DateTime updatedAt, DateTime reviewAt)
+		{
+			this.CreatedAt = createdAt;
+			this.UpdatedAt = updatedAt;
+			this.ReviewAt = reviewAt;
+		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Cases/ActiveCaseSummaryDto.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Cases/ActiveCaseSummaryDto.cs
@@ -8,6 +8,7 @@ public record CaseSummaryDto
 	public string CreatedBy { get; set; }
 	public DateTime CreatedAt { get; set; }
 	public DateTime UpdatedAt { get; set; }
+	public DateTime? CaseLastUpdatedAt { get; set; }
 	public string StatusName { get; set; }
 	public RatingDto Rating { get; set; }
 	public string TrustUkPrn { get; set; }

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/ActiveCaseSummaryModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/ActiveCaseSummaryModel.cs
@@ -18,6 +18,7 @@ public record ActiveCaseSummaryModel : CaseSummaryModel
 	public string[] ActiveActionsAndDecisions { get; set; }
 	public IEnumerable<string> ActiveConcerns { get; set; }
 	public RatingModel Rating { get; set; }
+	public string CaseLastUpdatedAt { get; internal set; }
 }
 
 public record ClosedCaseSummaryModel : CaseSummaryModel

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
@@ -41,7 +41,7 @@
 					<a class="govuk-link" href="case/@activeCase.CaseUrn/management">@activeCase.CaseUrn</a>
 				</td>
 				<td class="govuk-table__cell" data-testid="updated-at">
-					@activeCase.UpdatedAt
+					@activeCase.CaseLastUpdatedAt
 				</td>
 				<td class="govuk-table__cell" data-testid="created-at">
 					@activeCase.CreatedAt

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesTeamActive.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesTeamActive.cshtml
@@ -43,7 +43,7 @@
 					<a class="govuk-link" href="case/@activeCase.CaseUrn/management">@activeCase.CaseUrn</a>
 				</td>
 				<td class="govuk-table__cell">
-					@activeCase.UpdatedAt
+                     @activeCase.CaseLastUpdatedAt
 				</td>
 				<td class="govuk-table__cell">
 					@activeCase.CreatedAt

--- a/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/CaseSummaryService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Services/Cases/CaseSummaryService.cs
@@ -115,7 +115,8 @@ public class CaseSummaryService : CachedService, ICaseSummaryService
 					Rating = RatingMapping.MapDtoToModel(caseSummary.Rating),
 					StatusName = caseSummary.StatusName,
 					TrustName = trusts.Single(x => x.Key == caseSummary.TrustUkPrn).Value,
-					UpdatedAt = DateTimeHelper.ParseToDisplayDate(caseSummary.UpdatedAt)
+					UpdatedAt = DateTimeHelper.ParseToDisplayDate(caseSummary.UpdatedAt),
+					CaseLastUpdatedAt = DateTimeHelper.ParseToDisplayDate(caseSummary.CaseLastUpdatedAt),
 				};
 			
 			sortedCaseSummaries.Add(summary);


### PR DESCRIPTION
**What is the change?**
Add ability to update new Case Last Updated field when creating a concern against a case and display in Your/Team Cases work. Include refactor of Concerns Creation to adopt Mediator Pattern..

**Why do we need the change?**
Last Updated Date shown on Your/Team Case work should display changes to both the case information and adding a concern. Further scenarios to be added in other tickets.

**What is the impact?**
New database field and LastUpdatedDate field displayed in Your/Team Casework instead of UpdatedAt field from concernscase table

**Azure DevOps Ticket**
[133923](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/133923)