### PR TITLE
Release Note and Version increment for Version 26

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -5,7 +5,7 @@
 		<CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
 		<UserSecretsId>ac20b61d-9280-4be5-bbad-ad27aaff2f24</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-		<Version>24.0.0</Version>
+		<Version>26.0.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Label="custom">

--- a/ConcernsCaseWork/release-notes.md
+++ b/ConcernsCaseWork/release-notes.md
@@ -1,3 +1,17 @@
+## 26.0.0
+* Ability to add Cases to CTCs
+* Remove redundant code replace by components
+* Enabling work on Api for adding Sub questions to Decision work
+* Fix incorrect character count display in UI
+* Ability to Soft Delete TFF for a Case via Api
+* Amend subnav on trust page to better reflect the design
+
+## 25.0.0
+* Add pagination to get active cases by owner and get closed cases by owner APIs
+* Your active casework redesign - Add pagination
+* Trust Overview Redesign - Add Open/Closed sub-navs
+* Trust Overview Design - Add pagination to sub-navs
+
 ## 24.0.0
 * Increase SRMA notes field limit
 * Iterate hint text on Create Case page based on user feedback


### PR DESCRIPTION
**What is the change?**
Add release notes and app version for release 26. Retrospective adding of notes from version 25.

**Why do we need the change?**
Maintain versioning of app and release nodes. Tr

**What is the impact?**

**Azure DevOps Ticket**
