### PR TITLE
133923 Set CaseLastUpdatedDate on case when concern is updated

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsRecordIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsRecordIntegrationTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 namespace ConcernsCaseWork.API.Tests.Integration
 {
 	[Collection(ApiTestCollection.ApiTestCollectionName)]
-	public class ConcernsRecordIntegrationTests: IDisposable
+	public class ConcernsRecordIntegrationTests : IDisposable
 	{
 
 		private readonly Fixture _autoFixture;
@@ -203,6 +203,10 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 			response.StatusCode.Should().Be(HttpStatusCode.OK);
 			content.Data.Should().BeEquivalentTo(expectedContent);
+
+			await using ConcernsDbContext refreshedContext = _testFixture.GetContext();
+			currentConcernsCase = refreshedContext.ConcernsCase.FirstOrDefault(c => c.Id == content.Data.CaseUrn);
+			currentConcernsCase.CaseLastUpdatedAt.Should().Be(content.Data.UpdatedAt);
 		}
 
 		[Fact]
@@ -309,6 +313,10 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 			response.StatusCode.Should().Be(HttpStatusCode.OK);
 			content.Data.Should().BeEquivalentTo(expectedContent);
+
+			await using ConcernsDbContext refreshedContext = _testFixture.GetContext();
+			concernsCase = refreshedContext.ConcernsCase.FirstOrDefault(c => c.Id == content.Data.CaseUrn);
+			concernsCase.CaseLastUpdatedAt.Should().Be(content.Data.UpdatedAt);
 		}
 
 
@@ -529,6 +537,10 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			ApiResponseV2<ConcernsRecordResponse> content = await response.Content.ReadFromJsonAsync<ApiResponseV2<ConcernsRecordResponse>>();
 			content.Data.Count().Should().Be(2);
 			content.Data.Should().BeEquivalentTo(expected);
+
+			await using ConcernsDbContext refreshedContext = _testFixture.GetContext();
+			concernsCase = refreshedContext.ConcernsCase.FirstOrDefault(c => c.Id == concernsCase.Id);
+			concernsCase.CaseLastUpdatedAt.Should().Be(createdRecord2.CreatedAt);
 		}
 
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsRecordController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/ConcernsRecordController.cs
@@ -7,76 +7,78 @@ using System.Text.Json;
 
 namespace ConcernsCaseWork.API.Controllers
 {
-    [ApiVersion("2.0")]
-    [ApiController]
-    [Route("v{version:apiVersion}/concerns-records")]
-    
-    public class ConcernsRecordController : ControllerBase
-    {
-        private readonly ILogger<ConcernsRecordController> _logger;
-        private readonly ICreateConcernsRecord _createConcernsRecord;
-        private readonly IUpdateConcernsRecord _updateConcernsRecord;
+	[ApiVersion("2.0")]
+	[ApiController]
+	[Route("v{version:apiVersion}/concerns-records")]
+
+	public class ConcernsRecordController : ControllerBase
+	{
+		private readonly ILogger<ConcernsRecordController> _logger;
+		private readonly ICreateConcernsRecord _createConcernsRecord;
+		private readonly IUpdateConcernsRecord _updateConcernsRecord;
 		private readonly IGetConcernsRecord _getConcernsRecord;
 		private readonly IDeleteConcernsRecord _deleteConcernsRecord;
-        private readonly IGetConcernsRecordsByCaseUrn _getConcernsRecordsByCaseUrn;
+		private readonly IGetConcernsRecordsByCaseUrn _getConcernsRecordsByCaseUrn;
 
-        public ConcernsRecordController(
-            ILogger<ConcernsRecordController> logger, 
-            ICreateConcernsRecord createConcernsRecord,
-            IUpdateConcernsRecord updateConcernsRecord,
+		public ConcernsRecordController(
+			ILogger<ConcernsRecordController> logger,
+			ICreateConcernsRecord createConcernsRecord,
+			IUpdateConcernsRecord updateConcernsRecord,
 			IDeleteConcernsRecord deleteConcernsRecord,
-            IGetConcernsRecordsByCaseUrn getConcernsRecordsByCaseUrn,
+			IGetConcernsRecordsByCaseUrn getConcernsRecordsByCaseUrn,
 			IGetConcernsRecord getConcernsRecord)
-        {
-            _logger = logger;
-            _createConcernsRecord = createConcernsRecord;
-            _updateConcernsRecord = updateConcernsRecord;
+		{
+			_logger = logger;
+			_createConcernsRecord = createConcernsRecord;
+			_updateConcernsRecord = updateConcernsRecord;
 			_deleteConcernsRecord = deleteConcernsRecord;
 			_getConcernsRecordsByCaseUrn = getConcernsRecordsByCaseUrn;
 			_getConcernsRecord = getConcernsRecord;
 		}
-        
-        //[HttpPost]
-        //[MapToApiVersion("2.0")]
-        //public async Task<ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>>> Create(ConcernsRecordRequest request, CancellationToken cancellationToken = default)
-        //{
-        //    var createdConcernsRecord = _createConcernsRecord.Execute(request);
-        //    var response = new ApiSingleResponseV2<ConcernsRecordResponse>(createdConcernsRecord);
-            
-        //    return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
-        //}
-        
-        [HttpPatch("{id}")]
-        [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>>> Update(int id, ConcernsRecordRequest request, CancellationToken cancellationToken = default)
-        {
-            _logger.LogInformation($"Attempting to update Concerns Record {id}");
-            var updatedAcademyConcernsRecord = _updateConcernsRecord.Execute(id, request);
-            if (updatedAcademyConcernsRecord == null)
-            {
-                _logger.LogInformation($"Updating Concerns Record failed: No Concerns Record matching Id {id} was found");
-                return NotFound();
-            }
 
-            _logger.LogInformation($"Successfully Updated Concerns Record {id}");
-            _logger.LogDebug(JsonSerializer.Serialize(updatedAcademyConcernsRecord));
-			
-            var response = new ApiSingleResponseV2<ConcernsRecordResponse>(updatedAcademyConcernsRecord);
-            return Ok(response);
-        }
-        
-        [HttpGet("case/urn/{urn}")]
-        [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiResponseV2<ConcernsRecordResponse>>> GetByCaseUrn(int urn, int page = 1, int count = 50, CancellationToken cancellationToken = default)
-        {
-            _logger.LogInformation($"Attempting to get Concerns Case {urn}");
-            var records = _getConcernsRecordsByCaseUrn.Execute(urn);
+		//Commenting out temporary before removing once Concerns Record Api controller is refactored
+		//[HttpPost]
+		//[MapToApiVersion("2.0")]
+		//public async Task<ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>>> Create(ConcernsRecordRequest request, CancellationToken cancellationToken = default)
+		//{
+		//    var createdConcernsRecord = _createConcernsRecord.Execute(request);
+		//    var response = new ApiSingleResponseV2<ConcernsRecordResponse>(createdConcernsRecord);
 
-            _logger.LogInformation($"Returning Records for Case urn: {urn}");
-            var pagingResponse = PagingResponseFactory.Create(page, count, records.Count, Request);
-            var response = new ApiResponseV2<ConcernsRecordResponse>(records, pagingResponse);
-            return Ok(response);
-        }
+		//    return new ObjectResult(response) {StatusCode = StatusCodes.Status201Created};
+		//}
+
+		//Commenting out temporary before removing once Concerns Record Api controller is refactored 
+		//[HttpPatch("{id}")]
+		//[MapToApiVersion("2.0")]
+		//public async Task<ActionResult<ApiSingleResponseV2<ConcernsRecordResponse>>> Update(int id, ConcernsRecordRequest request, CancellationToken cancellationToken = default)
+		//{
+		//	_logger.LogInformation($"Attempting to update Concerns Record {id}");
+		//	var updatedAcademyConcernsRecord = _updateConcernsRecord.Execute(id, request);
+		//	if (updatedAcademyConcernsRecord == null)
+		//	{
+		//		_logger.LogInformation($"Updating Concerns Record failed: No Concerns Record matching Id {id} was found");
+		//		return NotFound();
+		//	}
+
+		//	_logger.LogInformation($"Successfully Updated Concerns Record {id}");
+		//	_logger.LogDebug(JsonSerializer.Serialize(updatedAcademyConcernsRecord));
+
+		//	var response = new ApiSingleResponseV2<ConcernsRecordResponse>(updatedAcademyConcernsRecord);
+		//	return Ok(response);
+		//}
+
+		[HttpGet("case/urn/{urn}")]
+		[MapToApiVersion("2.0")]
+		public async Task<ActionResult<ApiResponseV2<ConcernsRecordResponse>>> GetByCaseUrn(int urn, int page = 1, int count = 50, CancellationToken cancellationToken = default)
+		{
+			_logger.LogInformation($"Attempting to get Concerns Case {urn}");
+			var records = _getConcernsRecordsByCaseUrn.Execute(urn);
+
+			_logger.LogInformation($"Returning Records for Case urn: {urn}");
+			var pagingResponse = PagingResponseFactory.Create(page, count, records.Count, Request);
+			var response = new ApiResponseV2<ConcernsRecordResponse>(records, pagingResponse);
+			return Ok(response);
+		}
 
 
 		[HttpDelete("{id}")]

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Factories/ConcernsCaseFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Factories/ConcernsCaseFactory.cs
@@ -4,70 +4,71 @@ using ConcernsCaseWork.Data.Models;
 
 namespace ConcernsCaseWork.API.Factories
 {
-    public class ConcernsCaseFactory
-    {
-        public static ConcernsCase Create(ConcernCaseRequest request)
-        {
-            var cc =  new ConcernsCase
-            {
-                CreatedAt = request.CreatedAt,
+	public class ConcernsCaseFactory
+	{
+		public static ConcernsCase Create(ConcernCaseRequest request)
+		{
+			var cc = new ConcernsCase
+			{
+				CreatedAt = request.CreatedAt,
 				CaseLastUpdatedAt = request.CreatedAt,
-                UpdatedAt = request.UpdatedAt,
-                ReviewAt = request.ReviewAt,
-                ClosedAt = request.ClosedAt,
-                CreatedBy = request.CreatedBy,
-                Description = request.Description,
-                CrmEnquiry = request.CrmEnquiry,
-                TrustUkprn = request.TrustUkprn,
-                ReasonAtReview = request.ReasonAtReview,
-                DeEscalation = request.DeEscalation,
-                Issue = request.Issue,
-                CurrentStatus = request.CurrentStatus,
-                CaseAim = request.CaseAim,
-                DeEscalationPoint = request.DeEscalationPoint,
-                NextSteps = request.NextSteps,
-                DirectionOfTravel = request.DirectionOfTravel,
-                CaseHistory = request.CaseHistory,
-                StatusId = request.StatusId,
-                RatingId = request.RatingId,
-                Territory = request.Territory,
-                TrustCompaniesHouseNumber = request.TrustCompaniesHouseNumber
-            };
+				UpdatedAt = request.UpdatedAt,
+				ReviewAt = request.ReviewAt,
+				ClosedAt = request.ClosedAt,
+				CreatedBy = request.CreatedBy,
+				Description = request.Description,
+				CrmEnquiry = request.CrmEnquiry,
+				TrustUkprn = request.TrustUkprn,
+				ReasonAtReview = request.ReasonAtReview,
+				DeEscalation = request.DeEscalation,
+				Issue = request.Issue,
+				CurrentStatus = request.CurrentStatus,
+				CaseAim = request.CaseAim,
+				DeEscalationPoint = request.DeEscalationPoint,
+				NextSteps = request.NextSteps,
+				DirectionOfTravel = request.DirectionOfTravel,
+				CaseHistory = request.CaseHistory,
+				StatusId = request.StatusId,
+				RatingId = request.RatingId,
+				Territory = request.Territory,
+				TrustCompaniesHouseNumber = request.TrustCompaniesHouseNumber
+			};
 
 			return cc;
-        }
-        
-        public static ConcernsCase Update(ConcernsCase original, ConcernCaseRequest updateRequest)
-        {
-            if (updateRequest == null)
-            {
-                return original;
-            }
-            
-            var toMerge = Create(updateRequest);
+		}
 
-            original.CreatedAt = toMerge.CreatedAt;
-            original.UpdatedAt = toMerge.UpdatedAt;
-            original.ReviewAt = toMerge.ReviewAt;
-            original.ClosedAt = toMerge.ClosedAt;
-            original.CreatedBy = toMerge.CreatedBy ?? original.CreatedBy;
-            original.Description = toMerge.Description ?? original.Description;
-            original.CrmEnquiry = toMerge.CrmEnquiry ?? original.CrmEnquiry;
-            original.TrustUkprn = toMerge.TrustUkprn ?? original.TrustUkprn;
-            original.ReasonAtReview = toMerge.ReasonAtReview ?? original.ReasonAtReview;
-            original.DeEscalation = toMerge.DeEscalation ?? original.DeEscalation;
-            original.Issue = toMerge.Issue ?? original.Issue;
-            original.CurrentStatus = toMerge.CurrentStatus ?? original.CurrentStatus;
-            original.CaseAim = toMerge.CaseAim ?? original.CaseAim;
-            original.DeEscalationPoint = toMerge.DeEscalationPoint ?? original.DeEscalationPoint;
-            original.NextSteps = toMerge.NextSteps ?? original.NextSteps;
-            original.CaseHistory = toMerge.CaseHistory ?? original.CaseHistory;
-            original.DirectionOfTravel = toMerge.DirectionOfTravel ?? original.DirectionOfTravel;
-            original.StatusId = toMerge.StatusId;
-            original.RatingId = toMerge.RatingId;
-            original.Territory = toMerge.Territory;
-            original.TrustCompaniesHouseNumber = toMerge.TrustCompaniesHouseNumber ?? original.TrustCompaniesHouseNumber; // doesn't for it to become null
-            return original;
-        }
-    }
+		public static ConcernsCase Update(ConcernsCase original, ConcernCaseRequest updateRequest)
+		{
+			if (updateRequest == null)
+			{
+				return original;
+			}
+
+			var toMerge = Create(updateRequest);
+
+			original.CreatedAt = toMerge.CreatedAt;
+			original.UpdatedAt = toMerge.UpdatedAt;
+			original.CaseLastUpdatedAt = toMerge.UpdatedAt;
+			original.ReviewAt = toMerge.ReviewAt;
+			original.ClosedAt = toMerge.ClosedAt;
+			original.CreatedBy = toMerge.CreatedBy ?? original.CreatedBy;
+			original.Description = toMerge.Description ?? original.Description;
+			original.CrmEnquiry = toMerge.CrmEnquiry ?? original.CrmEnquiry;
+			original.TrustUkprn = toMerge.TrustUkprn ?? original.TrustUkprn;
+			original.ReasonAtReview = toMerge.ReasonAtReview ?? original.ReasonAtReview;
+			original.DeEscalation = toMerge.DeEscalation ?? original.DeEscalation;
+			original.Issue = toMerge.Issue ?? original.Issue;
+			original.CurrentStatus = toMerge.CurrentStatus ?? original.CurrentStatus;
+			original.CaseAim = toMerge.CaseAim ?? original.CaseAim;
+			original.DeEscalationPoint = toMerge.DeEscalationPoint ?? original.DeEscalationPoint;
+			original.NextSteps = toMerge.NextSteps ?? original.NextSteps;
+			original.CaseHistory = toMerge.CaseHistory ?? original.CaseHistory;
+			original.DirectionOfTravel = toMerge.DirectionOfTravel ?? original.DirectionOfTravel;
+			original.StatusId = toMerge.StatusId;
+			original.RatingId = toMerge.RatingId;
+			original.Territory = toMerge.Territory;
+			original.TrustCompaniesHouseNumber = toMerge.TrustCompaniesHouseNumber ?? original.TrustCompaniesHouseNumber; // doesn't for it to become null
+			return original;
+		}
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/ConcernsRecordController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/ConcernsRecordController.cs
@@ -4,6 +4,7 @@ using ConcernsCaseWork.API.ResponseModels;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
 namespace ConcernsCaseWork.API.Features.ConcernsRecord
 {
@@ -42,6 +43,18 @@ namespace ConcernsCaseWork.API.Features.ConcernsRecord
 			}
 
 			return Ok(model);
+		}
+
+		[HttpPatch("{Id}", Name = nameof(Update))]
+		[MapToApiVersion("2.0")]
+		[ProducesResponseType((int)HttpStatusCode.Created)]
+		[ProducesResponseType((int)HttpStatusCode.BadRequest)]
+		public async Task<IActionResult> Update(int Id, [FromBody] Update.ConcernModel patchModel, CancellationToken cancellationToken = default)
+		{
+			var command = new Update.Command(Id, patchModel);
+			var commandResult = await _mediator.Send(command);
+			var model = await _mediator.Send(new GetByID.Query() { Id = commandResult });
+			return Ok(new ApiSingleResponseV2<GetByID.Result>(model));
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/Update.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/ConcernsRecord/Update.cs
@@ -1,0 +1,111 @@
+﻿using MediatR;
+using ConcernsCaseWork.Data;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcernsCaseWork.API.Features.ConcernsRecord
+{
+	using ConcernsCaseWork.Data.Models;
+	using Microsoft.EntityFrameworkCore;
+
+	public class Update
+	{
+		public class ConcernModel
+		{
+			public DateTime CreatedAt { get; set; }
+			public DateTime UpdatedAt { get; set; }
+			public DateTime ReviewAt { get; set; }
+			public DateTime? ClosedAt { get; set; }
+
+			[StringLength(300)]
+			public string Name { get; set; }
+
+			[StringLength(300)]
+			public string Description { get; set; }
+
+			[StringLength(300)]
+			public string Reason { get; set; }
+			public int CaseUrn { get; set; }
+			public int TypeId { get; set; }
+			public int RatingId { get; set; }
+			public int StatusId { get; set; }
+			public int? MeansOfReferralId { get; set; }
+		}
+		public class Command : IRequest<int>
+		{
+			public int Id { get; }
+
+			public ConcernModel Model { get; set; }
+
+			public Command(int id, ConcernModel model)
+			{
+				this.Id = id;
+				this.Model = model;
+			}
+		}
+
+		public class CommandHandler : IRequestHandler<Command, Int32>
+		{
+			private readonly ConcernsDbContext _context;
+			private readonly IMediator _mediator;
+
+			public CommandHandler(ConcernsDbContext context, IMediator mediator)
+			{
+				_context = context;
+				_mediator = mediator;
+			}
+
+			public async Task<int> Handle(Command request, CancellationToken cancellationToken)
+			{
+				ConcernsRecord cr = await _context.ConcernsRecord.SingleOrDefaultAsync(f => f.Id == request.Id);
+
+				cr.CreatedAt = request.Model.CreatedAt;
+				cr.UpdatedAt = request.Model.UpdatedAt;
+				cr.ReviewAt = request.Model.ReviewAt;
+				cr.ClosedAt = request.Model.ClosedAt;
+				//Taken Previous Logic from Factory (ConcernsCaseWork.API.Factories ConcernsCaseFactory)
+				cr.Name = request.Model.Name ?? cr.Name;
+				cr.Description = request.Model.Description ?? cr.Name;
+				cr.Reason = request.Model.Reason ?? cr.Name;
+
+				cr.StatusId = request.Model.StatusId;
+				cr.RatingId = request.Model.RatingId;
+				cr.TypeId = request.Model.TypeId;
+				if (request.Model.MeansOfReferralId.HasValue && request.Model.MeansOfReferralId > 0)
+				{
+					cr.MeansOfReferralId = request.Model.MeansOfReferralId;
+				}
+
+				await _context.SaveChangesAsync();
+
+				var ConcernCreatedNotification = new ConcernUpdatedNotification() { Id = cr.Id, CaseId = cr.CaseId, };
+				await _mediator.Publish(ConcernCreatedNotification);
+
+				return cr.Id;
+			}
+		}
+
+		//ToDo: BB 25/07/2023 Once we have more events decide on specific folder structure to organise events and handles
+		public class ConcernUpdatedNotification : INotification
+		{
+			public int Id { get; set; }
+			public int CaseId { get; set; }
+		}
+
+		public class ConcernUpdatedCaseUpdatedHandler : INotificationHandler<ConcernUpdatedNotification>
+		{
+			private readonly ConcernsDbContext _context;
+			public ConcernUpdatedCaseUpdatedHandler(ConcernsDbContext context)
+			{
+				_context = context;
+			}
+
+			public async Task Handle(ConcernUpdatedNotification notification, CancellationToken cancellationToken)
+			{
+				ConcernsCase cc = await _context.ConcernsCase.SingleOrDefaultAsync(f => f.Id == notification.CaseId, cancellationToken: cancellationToken);
+				ConcernsRecord cr = await _context.ConcernsRecord.SingleOrDefaultAsync(f => f.Id == notification.Id, cancellationToken: cancellationToken);
+				cc.CaseLastUpdatedAt = cr.UpdatedAt;
+				await _context.SaveChangesAsync();
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What is the change?**
Add ability to update new Case Last Updated field when updating a concern against a case and display in Your/Team Cases work. Include refactor of Concerns Update to adopt Mediator Pattern..

**Why do we need the change?**
Last Updated Date shown on Your/Team Case work should display changes to both the case information and updating a concern. 

**What is the impact?**
LastUpdatedDate field displayed in Your/Team Casework uses new CaseLastUpdatedField which using new logic.

**Azure DevOps Ticket**
[133923](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/133923)
