### PR TITLE
136089: Change CaseLastUpdatedAt when financial plans are created or updated

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/FinancialPlanControllerTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/FinancialPlanControllerTests.cs
@@ -42,29 +42,29 @@ namespace ConcernsCaseWork.API.Tests.Controllers
 				_mockGetFinancialPlansByCaseUseCase.Object, _mockPatchFinancialPlanUseCase.Object, _mockGetAllStatuses.Object);
 		}
 
-		[Fact]
-		public async Task Create_ReturnsApiSingleResponseWithNewFinancialPlan()
-		{
-			var status = 2;
-			var createdAt = DateTime.Now.AddDays(-5);
-			var caseUrn = 223;
+		//[Fact]
+		//public async Task Create_ReturnsApiSingleResponseWithNewFinancialPlan()
+		//{
+		//	var status = 2;
+		//	var createdAt = DateTime.Now.AddDays(-5);
+		//	var caseUrn = 223;
 
-			var response = Builder<FinancialPlanResponse>
-				.CreateNew()
-				.With(r => r.StatusId = status)
-				.With(r => r.CreatedAt = createdAt)
-				.Build();
+		//	var response = Builder<FinancialPlanResponse>
+		//		.CreateNew()
+		//		.With(r => r.StatusId = status)
+		//		.With(r => r.CreatedAt = createdAt)
+		//		.Build();
 
-			var expectedResponse = new ApiSingleResponseV2<FinancialPlanResponse>(response);
+		//	var expectedResponse = new ApiSingleResponseV2<FinancialPlanResponse>(response);
 
-			_mockCreateFinancialPlanUseCase
-				.Setup(x => x.Execute(It.IsAny<CreateFinancialPlanRequest>()))
-				.Returns(response);
+		//	_mockCreateFinancialPlanUseCase
+		//		.Setup(x => x.Execute(It.IsAny<CreateFinancialPlanRequest>()))
+		//		.Returns(response);
 
-			var result = await _controllerSut.Create(new CreateFinancialPlanRequest { StatusId = status, CaseUrn = caseUrn, CreatedAt = createdAt, });
+		//	var result = await _controllerSut.Create(new CreateFinancialPlanRequest { StatusId = status, CaseUrn = caseUrn, CreatedAt = createdAt, });
 
-			result.Result.Should().BeEquivalentTo(new ObjectResult(expectedResponse) { StatusCode = StatusCodes.Status201Created });
-		}
+		//	result.Result.Should().BeEquivalentTo(new ObjectResult(expectedResponse) { StatusCode = StatusCodes.Status201Created });
+		//}
 
 		[Fact]
 		public async Task GetFinancialPlansByCaseId_ReturnsMatchingFinancialPlan_WhenGivenCaseId()
@@ -94,30 +94,30 @@ namespace ConcernsCaseWork.API.Tests.Controllers
 			actualResult?.Data.First().CaseUrn.Should().Be(caseUrn);
 		}
 
-		[Fact]
-		public async Task GetFinancialPlansById_ReturnsMatchingFinancialPlan_WhenGivenId()
-		{
-			var fpId = 444;
+		//[Fact]
+		//public async Task GetFinancialPlansById_ReturnsMatchingFinancialPlan_WhenGivenId()
+		//{
+		//	var fpId = 444;
 
-			var matchingFinancialPlan = new FinancialPlanCase { Id = fpId, Notes = "match" };
+		//	var matchingFinancialPlan = new FinancialPlanCase { Id = fpId, Notes = "match" };
 
-			var fpResponse = Builder<FinancialPlanResponse>
-				.CreateNew()
-				.With(r => r.Id = matchingFinancialPlan.Id)
-				.With(r => r.Notes = matchingFinancialPlan.Notes)
-				.Build();
+		//	var fpResponse = Builder<FinancialPlanResponse>
+		//		.CreateNew()
+		//		.With(r => r.Id = matchingFinancialPlan.Id)
+		//		.With(r => r.Notes = matchingFinancialPlan.Notes)
+		//		.Build();
 
-			_mockGetFinancialPlanByIdUseCase
-				.Setup(x => x.Execute(fpId))
-				.Returns(fpResponse);
+		//	_mockGetFinancialPlanByIdUseCase
+		//		.Setup(x => x.Execute(fpId))
+		//		.Returns(fpResponse);
 
-			var controllerResponse = await _controllerSut.GetFinancialPlanById(fpId); //.Result as OkObjectResult;
+		//	var controllerResponse = await _controllerSut.GetFinancialPlanById(fpId); //.Result as OkObjectResult;
 
-			var actualResult = controllerResponse?.Value as ApiSingleResponseV2<FinancialPlanResponse>;
+		//	var actualResult = controllerResponse?.Value as ApiSingleResponseV2<FinancialPlanResponse>;
 
-			actualResult?.Data.Should().NotBeNull();
-			actualResult?.Data.Id.Should().Be(fpId);
-		}
+		//	actualResult?.Data.Should().NotBeNull();
+		//	actualResult?.Data.Id.Should().Be(fpId);
+		//}
 
 		[Fact]
 		public async Task PatchFinancialPlan_ReturnsUpdatedFinancialPlan()

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/FinancialPlanControllerTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Controllers/FinancialPlanControllerTests.cs
@@ -119,40 +119,40 @@ namespace ConcernsCaseWork.API.Tests.Controllers
 		//	actualResult?.Data.Id.Should().Be(fpId);
 		//}
 
-		[Fact]
-		public async Task PatchFinancialPlan_ReturnsUpdatedFinancialPlan()
-		{
-			var fpId = 444;
-			var newNotes = "new notes xyz";
-			var newStatusId = 3;
+		//[Fact]
+		//public async Task PatchFinancialPlan_ReturnsUpdatedFinancialPlan()
+		//{
+		//	var fpId = 444;
+		//	var newNotes = "new notes xyz";
+		//	var newStatusId = 3;
 
-			var fp = new FinancialPlanCase { Id = fpId, Notes = "Original notes", StatusId = 1 };
+		//	var fp = new FinancialPlanCase { Id = fpId, Notes = "Original notes", StatusId = 1 };
 
-			var request = Builder<PatchFinancialPlanRequest>
-				.CreateNew()
-				.With(r => r.Id = fp.Id)
-				.With(r => r.StatusId = newStatusId)
-				.With(r => r.Notes = newNotes)
-				.Build();
+		//	var request = Builder<PatchFinancialPlanRequest>
+		//		.CreateNew()
+		//		.With(r => r.Id = fp.Id)
+		//		.With(r => r.StatusId = newStatusId)
+		//		.With(r => r.Notes = newNotes)
+		//		.Build();
 
-			var fpResponse = Builder<FinancialPlanResponse>
-				.CreateNew()
-				.With(r => r.Id = request.Id)
-				.With(r => r.Notes = request.Notes)
-				.With(r => r.StatusId = request.StatusId)
-				.Build();
+		//	var fpResponse = Builder<FinancialPlanResponse>
+		//		.CreateNew()
+		//		.With(r => r.Id = request.Id)
+		//		.With(r => r.Notes = request.Notes)
+		//		.With(r => r.StatusId = request.StatusId)
+		//		.Build();
 
-			_mockPatchFinancialPlanUseCase
-				.Setup(x => x.Execute(request))
-				.Returns(fpResponse);
+		//	_mockPatchFinancialPlanUseCase
+		//		.Setup(x => x.Execute(request))
+		//		.Returns(fpResponse);
 
-			var controllerResponse = await _controllerSut.Patch(request); //.Result as OkObjectResult;
+		//	var controllerResponse = await _controllerSut.Patch(request); //.Result as OkObjectResult;
 
-			var actualResult = controllerResponse?.Value as ApiSingleResponseV2<FinancialPlanResponse>;
+		//	var actualResult = controllerResponse?.Value as ApiSingleResponseV2<FinancialPlanResponse>;
 
-			actualResult?.Data.Should().NotBeNull();
-			actualResult?.Data.Id.Should().Be(fpId);
-		}
+		//	actualResult?.Data.Should().NotBeNull();
+		//	actualResult?.Data.Id.Should().Be(fpId);
+		//}
 
 		[Fact]
 		public async Task GetAllStatuses_ReturnsAllStatuses()

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/FinancialPlanIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/FinancialPlanIntegrationTests.cs
@@ -83,8 +83,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			//Assert
 			createdFinancialPlan.Should().BeEquivalentTo(request, options => options.ExcludingMissingMembers());
 			createdFinancialPlan.Status.Id.Should().Be(request.StatusId.Value);
-			updatedCase.CaseLastUpdatedAt = createdFinancialPlan.CreatedAt;
-
+			updatedCase.CaseLastUpdatedAt.Should().Be(createdFinancialPlan.CreatedAt);
 		}
 
 		[Fact]
@@ -94,7 +93,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			var createdConcern = await CreateCase();
 			var createdFinancialPlan = await CreateFinancialPlan(createdConcern.Urn);
 
-			var request = _fixture.Build<PatchFinancialPlanModel>()
+			var request = _fixture.Build<PatchFinancialPlanRequest>()
 							.With(x => x.Id, createdFinancialPlan.Id)
 							.With(x => x.CaseUrn, createdConcern.Urn)
 							.With(x => x.StatusId, 2)
@@ -102,13 +101,15 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 			//Act
 			var result = await _client.PatchAsync($"/v2/case-actions/financial-plan", request.ConvertToJson());
-			result.StatusCode.Should().Be(HttpStatusCode.OK);
+			var updatedCase = await GetCase(request.CaseUrn);
 
 			//Assert
+			result.StatusCode.Should().Be(HttpStatusCode.OK);
+
 			var updatedFinancialPlan = await GetFinancialPlanByID(request.Id);
 			updatedFinancialPlan.Should().BeEquivalentTo(request, options => options.ExcludingMissingMembers());
+			updatedCase.CaseLastUpdatedAt.Should().Be(updatedFinancialPlan.UpdatedAt);
 		}
-
 
 		private async Task<ConcernsCaseResponse> CreateCase()
 		{

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/FinancialPlanController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/FinancialPlanController.cs
@@ -99,14 +99,14 @@ namespace ConcernsCaseWork.API.Controllers
             return Ok(response);
         }
 
-        [HttpPatch]
-        [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiSingleResponseV2<FinancialPlanResponse>>> Patch(PatchFinancialPlanRequest request, CancellationToken cancellationToken = default)
-        {
-            var createdFP = _patchFinancialPlanUseCase.Execute(request);
-            var response = new ApiSingleResponseV2<FinancialPlanResponse>(createdFP);
+        //[HttpPatch]
+        //[MapToApiVersion("2.0")]
+        //public async Task<ActionResult<ApiSingleResponseV2<FinancialPlanResponse>>> Patch(PatchFinancialPlanRequest request, CancellationToken cancellationToken = default)
+        //{
+        //    var createdFP = _patchFinancialPlanUseCase.Execute(request);
+        //    var response = new ApiSingleResponseV2<FinancialPlanResponse>(createdFP);
 
-            return Ok(response);
-        }
+        //    return Ok(response);
+        //}
     }
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/FinancialPlanController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Controllers/FinancialPlanController.cs
@@ -34,26 +34,26 @@ namespace ConcernsCaseWork.API.Controllers
             _getAllStatuses = getAllStatuses;
         }
 
-        [HttpPost]
-        [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiSingleResponseV2<FinancialPlanResponse>>> Create(CreateFinancialPlanRequest request, CancellationToken cancellationToken = default)
-        {
-            var createdFP = _createFinancialPlanUseCase.Execute(request);
-            var response = new ApiSingleResponseV2<FinancialPlanResponse>(createdFP);
+        //[HttpPost]
+        //[MapToApiVersion("2.0")]
+        //public async Task<ActionResult<ApiSingleResponseV2<FinancialPlanResponse>>> Create(CreateFinancialPlanRequest request, CancellationToken cancellationToken = default)
+        //{
+        //    var createdFP = _createFinancialPlanUseCase.Execute(request);
+        //    var response = new ApiSingleResponseV2<FinancialPlanResponse>(createdFP);
 
-            return CreatedAtAction(nameof(GetFinancialPlanById), new { financialPlanId = createdFP.Id}, response);
-        }
+        //    return CreatedAtAction(nameof(GetFinancialPlanById), new { financialPlanId = createdFP.Id}, response);
+        //}
 
-        [HttpGet]
-        [Route("{financialPlanId}")]
-        [MapToApiVersion("2.0")]
-        public async Task<ActionResult<ApiSingleResponseV2<FinancialPlanResponse>>> GetFinancialPlanById(long financialPlanId, CancellationToken cancellationToken = default)
-        {
-            var fp = _getFinancialPlanByIdUseCase.Execute(financialPlanId);
-            var response = new ApiSingleResponseV2<FinancialPlanResponse>(fp);
+        //[HttpGet]
+        //[Route("{financialPlanId}")]
+        //[MapToApiVersion("2.0")]
+        //public async Task<ActionResult<ApiSingleResponseV2<FinancialPlanResponse>>> GetFinancialPlanById(long financialPlanId, CancellationToken cancellationToken = default)
+        //{
+        //    var fp = _getFinancialPlanByIdUseCase.Execute(financialPlanId);
+        //    var response = new ApiSingleResponseV2<FinancialPlanResponse>(fp);
 
-            return Ok(response);
-        }
+        //    return Ok(response);
+        //}
 
         [HttpGet]
         [Route("case/{caseUrn}")]

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Factories/ConcernsCaseResponseFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Factories/ConcernsCaseResponseFactory.cs
@@ -30,7 +30,8 @@ namespace ConcernsCaseWork.API.Factories
                 StatusId = concernsCase.StatusId,
                 RatingId = concernsCase.RatingId,
                 Territory = concernsCase.Territory,
-                TrustCompaniesHouseNumber = concernsCase.TrustCompaniesHouseNumber
+                TrustCompaniesHouseNumber = concernsCase.TrustCompaniesHouseNumber,
+				CaseLastUpdatedAt = concernsCase.CaseLastUpdatedAt
             };
         }
     }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/Create.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/Create.cs
@@ -1,0 +1,97 @@
+﻿using ConcernsCaseWork.API.RequestModels.CaseActions.FinancialPlan;
+using ConcernsCaseWork.Data;
+using ConcernsCaseWork.Data.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using static Azure.Core.HttpHeader;
+
+namespace ConcernsCaseWork.API.Features.FinancialPlan
+{
+	public class Create
+	{
+		public class Command : IRequest<long>
+		{
+			[Required]
+			public int CaseUrn { get; set; }
+
+			[StringLength(300)]
+			public string Name { get; set; }
+			public long? StatusId { get; set; }
+			public DateTime? DatePlanRequested { get; set; }
+			public DateTime? DateViablePlanReceived { get; set; }
+			public DateTime CreatedAt { get; set; }
+
+			[StringLength(300)]
+			public string CreatedBy { get; set; }
+			public DateTime UpdatedAt { get; set; }
+			public DateTime? ClosedAt { get; set; }
+
+			[StringLength(2000)]
+			public string Notes { get; set; }
+		}
+
+		public class CommandHandler : IRequestHandler<Command, long>
+		{
+			private readonly ConcernsDbContext _context;
+			private readonly IMediator _mediator;
+
+			public CommandHandler(ConcernsDbContext context, IMediator mediator)
+			{
+				_context = context;
+				_mediator = mediator;
+			}
+
+			public async Task<long> Handle(Command request, CancellationToken cancellationToken)
+			{
+				FinancialPlanCase fp = new FinancialPlanCase()
+				{
+					CaseUrn = request.CaseUrn,
+					Name = request.Name,
+					ClosedAt = request.ClosedAt,
+					CreatedAt = request.CreatedAt,
+					CreatedBy = request.CreatedBy,
+					DatePlanRequested = request.DatePlanRequested,
+					DateViablePlanReceived = request.DateViablePlanReceived,
+					Notes = request.Notes,
+					StatusId = request.StatusId,
+					UpdatedAt = request.UpdatedAt,
+				};
+
+				_context.FinancialPlanCases.Add(fp);
+
+				await _context.SaveChangesAsync();
+				
+				var createdNotification = new FinancialPlanCreatedNotification() { Id = fp.Id, CaseId = fp.CaseUrn, };
+				await _mediator.Publish(createdNotification);
+
+				return fp.Id;
+			}
+		}
+
+		//ToDo: BB 03/08/2023 Once we have more events decide on specific folder structure to organise events and handles
+		public class FinancialPlanCreatedNotification : INotification
+		{
+			public long Id { get; set; }
+			public int CaseId { get; set; }
+		}
+
+		public class FinancialPlanCreatedCaseUpdatedHandler : INotificationHandler<FinancialPlanCreatedNotification>
+		{
+			private readonly ConcernsDbContext _context;
+			public FinancialPlanCreatedCaseUpdatedHandler(ConcernsDbContext context)
+			{
+				_context = context;
+			}
+
+			public async Task Handle(FinancialPlanCreatedNotification notification, CancellationToken cancellationToken)
+			{
+				ConcernsCase cc = await _context.ConcernsCase.SingleOrDefaultAsync(f => f.Id == notification.CaseId, cancellationToken: cancellationToken);
+				FinancialPlanCase cr = await _context.FinancialPlanCases.SingleOrDefaultAsync(f => f.Id == notification.Id, cancellationToken: cancellationToken);
+				cc.CaseLastUpdatedAt = cr.CreatedAt;
+				await _context.SaveChangesAsync();
+			}
+		}
+
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/FinancialPlanController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/FinancialPlanController.cs
@@ -41,5 +41,17 @@ namespace ConcernsCaseWork.API.Features.FinancialPlan
 			var model = await _mediator.Send(new GetByID.Query() { Id = commandResult });
 			return CreatedAtAction(nameof(GetByID), new { Id = model.Id }, new ApiSingleResponseV2<GetByID.Result>(model));
 		}
+
+
+		[HttpPatch]
+		[MapToApiVersion("2.0")]
+		[ProducesResponseType((int)HttpStatusCode.Created)]
+		[ProducesResponseType((int)HttpStatusCode.BadRequest)]
+		public async Task<IActionResult> Update([FromBody] Update.Command command, CancellationToken cancellationToken = default)
+		{
+			var commandResult = await _mediator.Send(command);
+			var model = await _mediator.Send(new GetByID.Query() { Id = commandResult });
+			return Ok(new ApiSingleResponseV2<GetByID.Result>(model));
+		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/FinancialPlanController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/FinancialPlanController.cs
@@ -1,0 +1,45 @@
+﻿using ConcernsCaseWork.API.ResponseModels;
+using ConcernsCaseWork.API.ResponseModels.CaseActions.FinancialPlan;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace ConcernsCaseWork.API.Features.FinancialPlan
+{
+	[ApiVersion("2.0")]
+	[Route("v{version:apiVersion}/case-actions/financial-plan")]
+	[ApiController]
+	public class FinancialPlanController : Controller
+	{
+		private readonly IMediator _mediator;
+		public FinancialPlanController(IMediator mediator)
+		{
+			_mediator = mediator;
+		}
+
+		[HttpGet("{Id}")]
+		[ProducesResponseType((int)HttpStatusCode.OK)]
+		[ProducesResponseType((int)HttpStatusCode.NotFound)]
+		public async Task<IActionResult> GetByID([FromRoute]GetByID.Query query)
+		{
+			var model = await _mediator.Send(query);
+			if (model == null)
+			{
+				return NotFound();
+			}
+
+			return Ok(new ApiSingleResponseV2<GetByID.Result>(model));
+		}
+
+		[HttpPost()]
+		[MapToApiVersion("2.0")]
+		[ProducesResponseType((int)HttpStatusCode.Created)]
+		[ProducesResponseType((int)HttpStatusCode.BadRequest)]
+		public async Task<IActionResult> Create([FromBody] Create.Command command, CancellationToken cancellationToken = default)
+		{
+			var commandResult = await _mediator.Send(command);
+			var model = await _mediator.Send(new GetByID.Query() { Id = commandResult });
+			return CreatedAtAction(nameof(GetByID), new { Id = model.Id }, new ApiSingleResponseV2<GetByID.Result>(model));
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/GetByID.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/GetByID.cs
@@ -1,0 +1,65 @@
+﻿using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using ConcernsCaseWork.Data;
+using ConcernsCaseWork.Data.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcernsCaseWork.API.Features.FinancialPlan
+{
+	public class GetByID
+	{
+		public class Query : IRequest<Result>
+		{
+			public long Id { get; set; }
+		}
+
+		public class Result
+		{
+			public long Id { get; set; }
+			public int CaseUrn { get; set; }
+			public string Name { get; set; }
+			public long? StatusId { get; set; }
+			public DateTime? DatePlanRequested { get; set; }
+			public DateTime? DateViablePlanReceived { get; set; }
+			public DateTime CreatedAt { get; set; }
+			public string CreatedBy { get; set; }
+			public DateTime UpdatedAt { get; set; }
+			public DateTime? ClosedAt { get; set; }
+			public string Notes { get; set; }
+
+			public StatusModel Status { get; set; }
+
+		}
+
+		public class StatusModel
+		{
+			public long Id { get; set; }
+			public string Name { get; set; }
+			public string Description { get; set; }
+			public DateTime CreatedAt { get; set; }
+			public DateTime UpdatedAt { get; set; }
+			public bool IsClosedStatus { get; set; }
+		}
+
+		public class Handler : IRequestHandler<Query, Result>
+		{
+			private readonly ConcernsDbContext _context;
+			private readonly MapperConfiguration _mapperConfiguration;
+
+			public Handler(ConcernsDbContext context, MapperConfiguration mapperConfiguration)
+			{
+				_context = context;
+				_mapperConfiguration = mapperConfiguration;
+			}
+
+			public async Task<Result> Handle(Query request, CancellationToken cancellationToken)
+			{
+				Result result = await _context.FinancialPlanCases.Include(fp => fp.Status).ProjectTo<Result>(_mapperConfiguration).SingleOrDefaultAsync(fp => fp.Id == request.Id);
+
+				return result;
+			}
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/MappingProfile.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/MappingProfile.cs
@@ -1,0 +1,14 @@
+﻿using AutoMapper;
+using ConcernsCaseWork.Data.Models;
+
+namespace ConcernsCaseWork.API.Features.FinancialPlan
+{
+	public class MappingProfile : Profile
+	{
+		public MappingProfile()
+		{
+			CreateMap<FinancialPlanCase, GetByID.Result>();
+			CreateMap<FinancialPlanStatus, GetByID.StatusModel>();
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/Update.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/FinancialPlan/Update.cs
@@ -1,0 +1,101 @@
+﻿using ConcernsCaseWork.API.RequestModels.CaseActions.FinancialPlan;
+using ConcernsCaseWork.API.UseCases.CaseActions.FinancialPlan;
+using ConcernsCaseWork.Data;
+using ConcernsCaseWork.Data.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using static ConcernsCaseWork.API.Features.ConcernsRecord.Update;
+
+namespace ConcernsCaseWork.API.Features.FinancialPlan
+{
+	public class Update
+	{
+
+		public class Command : IRequest<long>
+		{
+			[Required]
+			public long Id { get; set; }
+			[Required]
+			public int CaseUrn { get; set; }
+
+			[StringLength(300)]
+			public string Name { get; set; }
+			public long? StatusId { get; set; }
+			public DateTime? DatePlanRequested { get; set; }
+			public DateTime? DateViablePlanReceived { get; set; }
+			public DateTime CreatedAt { get; set; }
+
+			[StringLength(300)]
+			public string CreatedBy { get; set; }
+			public DateTime UpdatedAt { get; set; }
+			public DateTime? ClosedAt { get; set; }
+
+			[StringLength(2000)]
+			public string Notes { get; set; }
+		}
+
+		public class CommandHandler : IRequestHandler<Command, long>
+		{
+			private readonly ConcernsDbContext _context;
+			private readonly IMediator _mediator;
+
+			public CommandHandler(ConcernsDbContext context, IMediator mediator)
+			{
+				_context = context;
+				_mediator = mediator;
+			}
+
+			public async Task<long> Handle(Command request, CancellationToken cancellationToken)
+			{
+				var fp = new FinancialPlanCase
+				{
+					Id = request.Id,
+					CaseUrn = request.CaseUrn,
+					Name = request.Name,
+					ClosedAt = request.ClosedAt,
+					CreatedAt = request.CreatedAt,
+					CreatedBy = request.CreatedBy,
+					DatePlanRequested = request.DatePlanRequested,
+					DateViablePlanReceived = request.DateViablePlanReceived,
+					Notes = request.Notes,
+					StatusId = request.StatusId,
+					UpdatedAt = request.UpdatedAt,
+				};
+
+				var tracked = _context.Update<FinancialPlanCase>(fp);
+				await _context.SaveChangesAsync();
+
+				var updatedNotification = new FinancialPlanUpdatedNotification() { Id = fp.Id, CaseId = fp.CaseUrn, };
+				await _mediator.Publish(updatedNotification);
+
+				return fp.Id;
+			}
+		}
+
+
+		//ToDo: BB 03/08/2023 Once we have more events decide on specific folder structure to organise events and handles
+		public class FinancialPlanUpdatedNotification : INotification
+		{
+			public long Id { get; set; }
+			public int CaseId { get; set; }
+		}
+
+		public class FinancialPlanCreatedCaseUpdatedHandler : INotificationHandler<FinancialPlanUpdatedNotification>
+		{
+			private readonly ConcernsDbContext _context;
+			public FinancialPlanCreatedCaseUpdatedHandler(ConcernsDbContext context)
+			{
+				_context = context;
+			}
+
+			public async Task Handle(FinancialPlanUpdatedNotification notification, CancellationToken cancellationToken)
+			{
+				ConcernsCase cc = await _context.ConcernsCase.SingleOrDefaultAsync(f => f.Id == notification.CaseId, cancellationToken: cancellationToken);
+				FinancialPlanCase cr = await _context.FinancialPlanCases.SingleOrDefaultAsync(f => f.Id == notification.Id, cancellationToken: cancellationToken);
+				cc.CaseLastUpdatedAt = cr.UpdatedAt;
+				await _context.SaveChangesAsync();
+			}
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.API/ResponseModels/ConcernsCaseResponse.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/ResponseModels/ConcernsCaseResponse.cs
@@ -26,5 +26,6 @@ namespace ConcernsCaseWork.API.ResponseModels
         public int RatingId { get; set; }
         public Territory? Territory { get; set; }
         public string TrustCompaniesHouseNumber { get; set; }
-    }
+		public DateTime? CaseLastUpdatedAt { get; set; }
+	}
 }


### PR DESCRIPTION
**What is the change?**
Add ability to update CaseLastUpdatedAt field on a case when financial plans are created and update

**Why do we need the change?**
CaseLastUpdatedAt field is display to users on team/active casework page and user by team leaders to understand progress on a case.

**What is the impact?**
Changes to Api and Integration tests. UI is already wired up in another ticket.

**Azure DevOps Ticket**
[136089](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/136089)