### PR TITLE
136086: Update CaseLastUpdatedAt date when creating and updating a NTI

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NoticeToImproveIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/NoticeToImproveIntegrationTests.cs
@@ -1,21 +1,34 @@
 ﻿using AutoFixture;
+using ConcernsCaseWork.API.Contracts.RequestModels.TrustFinancialForecasts;
 using ConcernsCaseWork.API.RequestModels;
 using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.NoticeToImprove;
-using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.WarningLetter;
 using ConcernsCaseWork.API.ResponseModels;
+using ConcernsCaseWork.API.ResponseModels.CaseActions.NTI.NoticeToImprove;
 using ConcernsCaseWork.API.Tests.Fixtures;
 using ConcernsCaseWork.API.Tests.Helpers;
+using ConcernsCaseWork.Data.Models;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Xunit;
+using static ConcernsCaseWork.API.Tests.Integration.TrustFinancialForecastIntegrationTests;
 
 namespace ConcernsCaseWork.API.Tests.Integration
 {
+	public static class FixtureExtensions
+	{
+		public static int CreateInt(this IFixture fixture, int min, int max)
+		{
+			return fixture.Create<int>() % (max - min + 1) + min;
+		}
+	}
+
 	[Collection(ApiTestCollection.ApiTestCollectionName)]
 	public class NoticeToImproveIntegrationTests
 	{
@@ -28,6 +41,43 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			_client = apiTestFixture.Client;
 			_fixture = new();
 			_randomGenerator = new RandomGenerator();
+		}
+
+		[Fact]
+		public async Task When_Post_Returns_201Response()
+		{
+			//Arrange
+			var createdCase = await CreateCase();
+			//var statusList = await GetStatusListAsync();
+
+			var request = CreateNoticeToImproveRequestForCase(createdCase.Urn);
+
+			//Arrange and Act
+			var createdTFF = await CreateAndGetNTI(request);
+
+			//Assert
+			createdTFF.Should().BeEquivalentTo(request);
+			createdTFF.NoticeToImproveConditionsMapping.Should().HaveCount(2);
+			createdTFF.NoticeToImproveReasonsMapping.Should().HaveCount(3);
+		}
+
+		[Fact]
+		public async Task When_Patch_UpdateNti_ReturnOK()
+		{
+			//Arrange
+			var createdConcern = await CreateCase();
+			var createdNTI = await CreateNTIforCase(createdConcern.Urn);
+			var request = CreateNTIUpdateRequest(createdConcern, createdNTI);
+
+			//Act
+			var result = await _client.PatchAsync(Patch.Update(), request.ConvertToJson());
+			var response = await result.Content.ReadFromJsonAsync<ApiSingleResponseV2<NoticeToImproveResponse>>();
+			var updatedNTI = await GetNTI(Get.ItemById(request.Id));
+
+			//Assert
+			result.StatusCode.Should().Be(HttpStatusCode.OK);
+			response.Data.Should().NotBeNull();
+			updatedNTI.Should().BeEquivalentTo(request, options => options.ExcludingMissingMembers());
 		}
 
 		[Fact]
@@ -132,6 +182,159 @@ namespace ConcernsCaseWork.API.Tests.Integration
 			//check it is not returned
 			var getResponseNotFound = await _client.GetAsync(createdNoticeToImproveUri);
 			getResponseNotFound.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		}
+
+		private async Task<ConcernsCaseResponse> CreateCase()
+		{
+			ConcernCaseRequest createRequest = Builder<ConcernCaseRequest>.CreateNew()
+				.With(c => c.CreatedBy = _randomGenerator.NextString(3, 10))
+				.With(c => c.Description = "")
+				.With(c => c.CrmEnquiry = "")
+				.With(c => c.TrustUkprn = DatabaseModelBuilder.CreateUkPrn())
+				.With(c => c.ReasonAtReview = "")
+				.With(c => c.DeEscalation = new DateTime(2022, 04, 01))
+				.With(c => c.Issue = "Here is the issue")
+				.With(c => c.CurrentStatus = "Case status")
+				.With(c => c.CaseAim = "Here is the aim")
+				.With(c => c.DeEscalationPoint = "Point of de-escalation")
+				.With(c => c.CaseHistory = "Case history")
+				.With(c => c.NextSteps = "Here are the next steps")
+				.With(c => c.DirectionOfTravel = "Up")
+				.With(c => c.StatusId = 1)
+				.With(c => c.RatingId = 2)
+				.With(c => c.TrustCompaniesHouseNumber = DatabaseModelBuilder.CreateUkPrn())
+				.Build();
+
+
+			HttpRequestMessage httpRequestMessage = new()
+			{
+				Method = HttpMethod.Post,
+				RequestUri = new Uri("https://notarealdomain.com/v2/concerns-cases"),
+				Content = JsonContent.Create(createRequest)
+			};
+
+			var response = await _client.SendAsync(httpRequestMessage);
+
+			response.StatusCode.Should().Be(HttpStatusCode.Created);
+			ApiSingleResponseV2<ConcernsCaseResponse> result = await response.Content.ReadFromJsonAsync<ApiSingleResponseV2<ConcernsCaseResponse>>();
+			return result.Data;
+		}
+
+		protected CreateNoticeToImproveRequest CreateNoticeToImproveRequestForCase(Int32 caseUrn)
+		{
+			var request = new CreateNoticeToImproveRequest()
+			{
+				CaseUrn = caseUrn,
+				StatusId = 1,
+				DateStarted = _fixture.Create<DateTime>(),
+				Notes = _fixture.Create<String>(),
+				CreatedAt = _fixture.Create<DateTime>(),
+				UpdatedAt = _fixture.Create<DateTime>()
+			};
+			request.NoticeToImproveConditionsMapping = new List<int>();
+			request.NoticeToImproveConditionsMapping.Add(1);
+			request.NoticeToImproveConditionsMapping.Add(2);
+			request.NoticeToImproveReasonsMapping = new List<int>();
+			request.NoticeToImproveReasonsMapping.Add(1);
+			request.NoticeToImproveReasonsMapping.Add(2);
+			request.NoticeToImproveReasonsMapping.Add(3);
+
+			return request;
+		}
+		private async Task<NoticeToImproveResponse> CreateNTIforCase(Int32 caseUrn)
+		{
+			var request = CreateNoticeToImproveRequestForCase(caseUrn);
+			return await CreateAndGetNTI(request);
+		}
+
+		private async Task<NoticeToImproveResponse> CreateAndGetNTI(CreateNoticeToImproveRequest request)
+		{
+			var result = await _client.PostAsync(Post.Create(), request.ConvertToJson());
+			var resultContent = await result.Content.ReadFromJsonAsync<ApiSingleResponseV2<NoticeToImproveResponse>>();
+			var createdEntityUrl = result.Headers.Location;
+
+			result.StatusCode.Should().Be(HttpStatusCode.Created);
+			resultContent.Should().NotBeNull();
+			createdEntityUrl.Should().NotBeNull();
+
+			var getResponse = await _client.GetAsync(createdEntityUrl);
+			var getResponseContent = await getResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<NoticeToImproveResponse>>();
+
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+			getResponseContent.Data.Should().NotBeNull();
+
+			return getResponseContent.Data;
+		}
+
+		protected async Task<NoticeToImproveResponse> GetNTI(string url)
+		{
+			var getResponse = await _client.GetAsync(url);
+			var getResponseContent = await getResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<NoticeToImproveResponse>>();
+
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+			getResponseContent.Data.Should().NotBeNull();
+
+			return getResponseContent.Data;
+		}
+
+		protected PatchNoticeToImproveRequest CreateNTIUpdateRequest(ConcernsCaseResponse createdConcern, NoticeToImproveResponse createdNTI)
+		{
+			var request = new PatchNoticeToImproveRequest();
+			request.CaseUrn = createdConcern.Urn;
+			request.Id = createdNTI.Id;
+
+			request.StatusId = 2;
+			request.NoticeToImproveConditionsMapping = new List<int>(createdNTI.NoticeToImproveConditionsMapping);
+			request.NoticeToImproveConditionsMapping.Remove(1);
+			request.NoticeToImproveReasonsMapping = new List<int>(createdNTI.NoticeToImproveReasonsMapping);
+			request.NoticeToImproveReasonsMapping.Clear();
+
+			request.ClosedStatusId = 9;
+			request.SumissionDecisionId = _fixture.Create<String>();
+			request.DateNTILifted = _fixture.Create<DateTime>();
+			request.DateNTIClosed = _fixture.Create<DateTime>();
+			request.UpdatedAt = _fixture.Create<DateTime>();
+			return request;
+		}
+
+		protected async Task<List<NoticeToImproveStatus>> GetStatusListAsync()
+		{
+			var getResponse = await _client.GetAsync(Get.StatusList());
+			var getResponseContent = await getResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<List<NoticeToImproveStatus>>>();
+
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+			getResponseContent.Data.Should().NotBeNull();
+
+			return getResponseContent.Data;
+		}
+
+		public static class Get
+		{
+			public static string ItemById(long id)
+			{
+				return $"/v2/case-actions/notice-to-improve/{id}";
+			}
+
+			public static string StatusList()
+			{
+				return $"/v2/case-actions/notice-to-improve/all-statuses";
+			}
+		}
+
+		public static class Post
+		{
+			public static string Create()
+			{
+				return $"/v2/case-actions/notice-to-improve";
+			}
+		}
+
+		public static class Patch
+		{
+			public static string Update()
+			{
+				return $"/v2/case-actions/notice-to-improve";
+			}
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CreateNoticeToImproveTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/CreateNoticeToImproveTests.cs
@@ -74,10 +74,13 @@ namespace ConcernsCaseWork.API.Tests.UseCases
 			};
 			
 			var mockGateway = new Mock<INoticeToImproveGateway>();
-            
-            mockGateway.Setup(g => g.CreateNoticeToImprove(It.IsAny<NoticeToImprove>())).Returns(Task.FromResult(noticeToImproveDbModel));
-            
-            var useCase = new CreateNoticeToImprove(mockGateway.Object);
+			var mockCaseGateway = new Mock<IConcernsCaseGateway>();
+
+
+			mockGateway.Setup(g => g.CreateNoticeToImprove(It.IsAny<NoticeToImprove>())).Returns(Task.FromResult(noticeToImproveDbModel));
+			mockCaseGateway.Setup(x => x.GetConcernsCaseByUrn(caseUrn, It.IsAny<bool>())).Returns(Builder<ConcernsCase>.CreateNew().Build());
+
+			var useCase = new CreateNoticeToImprove(mockGateway.Object, mockCaseGateway.Object);
             
             var result = useCase.Execute(createNoticeToImproveRequest);
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/PatchNoticeToImproveTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/UseCases/PatchNoticeToImproveTests.cs
@@ -74,9 +74,13 @@ namespace ConcernsCaseWork.API.Tests.UseCases
             };
 
             var mockGateway = new Mock<INoticeToImproveGateway>();
-            mockGateway.Setup(g => g.PatchNoticeToImprove(It.IsAny<NoticeToImprove>())).Returns(Task.FromResult(noticeToImproveDbModel));
+			var mockCaseGateway = new Mock<IConcernsCaseGateway>();
 
-            var useCase = new PatchNoticeToImprove(mockGateway.Object);
+			mockCaseGateway.Setup(x => x.GetConcernsCaseByUrn(caseUrn, It.IsAny<bool>())).Returns(Builder<ConcernsCase>.CreateNew().Build());
+
+			mockGateway.Setup(g => g.PatchNoticeToImprove(It.IsAny<NoticeToImprove>())).Returns(Task.FromResult(noticeToImproveDbModel));
+
+            var useCase = new PatchNoticeToImprove(mockGateway.Object, mockCaseGateway.Object);
             var result = useCase.Execute(patchNoticeToImproveRequest);
 
             result.Should().NotBeNull();

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/CreateNoticeToImprove.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/CreateNoticeToImprove.cs
@@ -1,17 +1,21 @@
-﻿using ConcernsCaseWork.API.Factories.CaseActionFactories;
+﻿using ConcernsCaseWork.API.Exceptions;
+using ConcernsCaseWork.API.Factories.CaseActionFactories;
 using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.NoticeToImprove;
 using ConcernsCaseWork.API.ResponseModels.CaseActions.NTI.NoticeToImprove;
 using ConcernsCaseWork.Data.Gateways;
+using ConcernsCaseWork.Data.Models;
 
 namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.NoticeToImprove
 {
     public class CreateNoticeToImprove : IUseCase<CreateNoticeToImproveRequest, NoticeToImproveResponse>
     {
+		private readonly IConcernsCaseGateway _concernsCaseGateway;
         private readonly INoticeToImproveGateway _gateway;
 
-        public CreateNoticeToImprove(INoticeToImproveGateway gateway)
+        public CreateNoticeToImprove(INoticeToImproveGateway gateway, IConcernsCaseGateway concernsCaseGateway)
         {
             _gateway = gateway;
+			_concernsCaseGateway = concernsCaseGateway;
         }
 
         public NoticeToImproveResponse Execute(CreateNoticeToImproveRequest request)
@@ -21,11 +25,26 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.NoticeToImprove
 
         public async Task<NoticeToImproveResponse> ExecuteAsync(CreateNoticeToImproveRequest request)
         {
-            var dbModel = NoticeToImproveFactory.CreateDBModel(request);
+			var cc = GetCase(request.CaseUrn);
+			var dbModel = NoticeToImproveFactory.CreateDBModel(request);
 
             var createdNoticeToImprove = await _gateway.CreateNoticeToImprove(dbModel);
 
-            return NoticeToImproveFactory.CreateResponse(createdNoticeToImprove);
+			cc.CaseLastUpdatedAt = dbModel.CreatedAt;
+
+			await _concernsCaseGateway.UpdateExistingAsync(cc);
+
+			return NoticeToImproveFactory.CreateResponse(createdNoticeToImprove);
         }
-    }
+
+		private ConcernsCase GetCase(int caseUrn)
+		{
+			var cc = _concernsCaseGateway.GetConcernsCaseByUrn(caseUrn);
+			if (cc == null)
+			{
+				throw new NotFoundException($"Concerns Case {caseUrn} not found");
+			}
+			return cc;
+		}
+	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/PatchNoticeToImprove.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/UseCases/CaseActions/NTI/NoticeToImprove/PatchNoticeToImprove.cs
@@ -1,18 +1,22 @@
-﻿using ConcernsCaseWork.API.Factories.CaseActionFactories;
+﻿using ConcernsCaseWork.API.Exceptions;
+using ConcernsCaseWork.API.Factories.CaseActionFactories;
 using ConcernsCaseWork.API.RequestModels.CaseActions.NTI.NoticeToImprove;
 using ConcernsCaseWork.API.ResponseModels.CaseActions.NTI.NoticeToImprove;
 using ConcernsCaseWork.Data.Gateways;
+using ConcernsCaseWork.Data.Models;
 
 namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.NoticeToImprove
 {
     public class PatchNoticeToImprove : IUseCase<PatchNoticeToImproveRequest, NoticeToImproveResponse>
     {
-        private readonly INoticeToImproveGateway _gateway;
+		private readonly IConcernsCaseGateway _concernsCaseGateway;
+		private readonly INoticeToImproveGateway _gateway;
 
-        public PatchNoticeToImprove(INoticeToImproveGateway gateway)
+		public PatchNoticeToImprove(INoticeToImproveGateway gateway, IConcernsCaseGateway concernsCaseGateway)
         {
-            _gateway = gateway;
-        }
+			_gateway = gateway;
+			_concernsCaseGateway = concernsCaseGateway;
+		}
 
         public NoticeToImproveResponse Execute(PatchNoticeToImproveRequest request)
         {
@@ -21,8 +25,25 @@ namespace ConcernsCaseWork.API.UseCases.CaseActions.NTI.NoticeToImprove
 
         public async Task<NoticeToImproveResponse> ExecuteAsync(PatchNoticeToImproveRequest request)
         {
-            var patchedNoticeToImprove = await _gateway.PatchNoticeToImprove(NoticeToImproveFactory.CreateDBModel(request));
-            return NoticeToImproveFactory.CreateResponse(patchedNoticeToImprove);
+			var cc = GetCase(request.CaseUrn);
+
+			var patchedNoticeToImprove = await _gateway.PatchNoticeToImprove(NoticeToImproveFactory.CreateDBModel(request));
+
+			cc.CaseLastUpdatedAt = patchedNoticeToImprove.UpdatedAt;
+
+			await _concernsCaseGateway.UpdateExistingAsync(cc);
+
+			return NoticeToImproveFactory.CreateResponse(patchedNoticeToImprove);
         }
-    }
+
+		private ConcernsCase GetCase(int caseUrn)
+		{
+			var cc = _concernsCaseGateway.GetConcernsCaseByUrn(caseUrn);
+			if (cc == null)
+			{
+				throw new NotFoundException($"Concerns Case {caseUrn} not found");
+			}
+			return cc;
+		}
+	}
 }


### PR DESCRIPTION
**What is the change?**
Update CaseLastUpdatedDateAt field when creating and updating and NTI

**Why do we need the change?**
Amend CaseLastUpdatedDateAt field so Team Leads can see when progress on cases.

**What is the impact?**
Changes to Create and Update operations in Api.

**Azure DevOps Ticket**
[136086](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/136086)
