### PR TITLE
Add Cypress lint workflow

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -1,0 +1,21 @@
+name: Cypress test linting
+
+on:
+  pull_request:
+    paths:
+      - ConcernsCaseWork/ConcernsCaseWork.CypressTests
+    types: [opened, synchronize]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      working-directory: ConcernsCaseWork/ConcernsCaseWork.CypressTests
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: lint cypress tests
+        run: |
+          npm ci
+          npm run lint        

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/package.json
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/package.json
@@ -12,7 +12,7 @@
     "combine:reports": "mochawesome-merge  cypress/reports/mocha/*.json> mochareports/report.json",
     "create:html:report": "marge  mochareports/report.json -f report -o mochareports",
     "generate:html:report": "npm run combine:reports && npm run create:html:report",
-    "lint": "eslint . --ext .cy.js,.jsx,.ts,.tsx --ignore-path .gitignore"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore"
   },
   "keywords": [
     "e2e",


### PR DESCRIPTION
**What is the change?**

Adds a workflow for running eslint on the CypressTests directory on any Pull Request with changes in that directory. It will fail the workflow if any errors are raised in the run.

**Why do we need the change?**

This adds functionality that aligns with the RSD testing strategy

**What is the impact?**

There are rules that are currently returning a warning when eslint is run. These will not fail the build, but ideally should be resolved and the rules upgraded to errors in the future.

**Azure DevOps Ticket**

N/a
