### PR TITLE
Release-27 notes and version increment

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -5,7 +5,7 @@
 		<CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
 		<UserSecretsId>ac20b61d-9280-4be5-bbad-ad27aaff2f24</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-		<Version>26.0.0</Version>
+		<Version>27.0.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Label="custom">

--- a/ConcernsCaseWork/release-notes.md
+++ b/ConcernsCaseWork/release-notes.md
@@ -1,3 +1,10 @@
+## 27.0.0
+* Display sub questions for three deicsion types to capture information on related funding
+* Your/Team casework Last Updated field reflects the date of most recent change when creating or updating a concern and any case action.
+* Enhanced Pagination with the use of Ellipsis
+* Amends to risk rating hint text
+* Amends to Find Trust and Create Case text
+
 ## 26.0.0
 * Ability to add Cases to CTCs
 * Remove redundant code replace by components


### PR DESCRIPTION
**What is the change?**
Increment application version number and add release notes for version 27

**Why do we need the change?**
Maintain information on changes in each release and ensure version numbers can be tracked

**What is the impact?**
Changes to release notes mark down and vs proj file

**Azure DevOps Ticket**
NA
