### PR TITLE
140947: add a label to the trust search

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.ts
@@ -69,7 +69,7 @@ Cypress.Commands.add("excuteAccessibilityTests", () => {
 			rules: {
 				"aria-allowed-role": { enabled: false },
 				region: { enabled: false },
-				label: { enabled: false }, // Create case failed
+				// label: { enabled: false }, // Create case failed
 				listitem: { enabled: false }, // homepage
 				"page-has-heading-one": { enabled: false }, // homepage
 				"aria-input-field-name": { enabled: false }, // reassign

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -44,6 +44,7 @@
 
     <partial name="Components/_ValidationErrorDetail" model="@errors" />
 
+    <label for="search" class="govuk-visually-hidden">Enter a UKPRN (UK provider reference number) or Companies House number for a trust</label>
     <div id="container-SelectedTrustUkprn" class="govuk-!-margin-top-3 @inputErrorClass"></div>
     <div class="ccms-loader govuk-!-display-none"></div>
     <ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="trustsearch__listbox" role="listbox">


### PR DESCRIPTION
**What is the change?**

needed so an accessible user knows what to do

**Why do we need the change?**

I tested this myself and it is not obvious without the label label is hidden to keep the original design

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/140947
