### PR TITLE
141117: fixed accessibility rules on reassign

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.ts
@@ -72,9 +72,9 @@ Cypress.Commands.add("excuteAccessibilityTests", () => {
 				label: { enabled: false }, // Create case failed
 				listitem: { enabled: false }, // homepage
 				"page-has-heading-one": { enabled: false }, // homepage
-				"aria-input-field-name": { enabled: false }, // reassign
-				"aria-required-children": { enabled: false }, // reassign
-				"label-title-only": { enabled: false }, // reassign
+				// "aria-input-field-name": { enabled: false }, // reassign
+				// "aria-required-children": { enabled: false }, // reassign
+				// "label-title-only": { enabled: false }, // reassign
 				"aria-allowed-attr": { enabled: false }, // smoke
 				"duplicate-id-aria": { enabled: false }, // smoke
 				"empty-table-header": { enabled: false }, // smoke

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/EditOwner.cshtml
@@ -40,13 +40,10 @@
 
                         <partial name="Components/_ValidationErrorDetail" model="@errors" />
 
+                        <label for="case-owner-input" class="govuk-visually-hidden">Enter the email address of the person you want to assign the case to</label>
                         <div id="autocomplete-container" class="@inputErrorClass"></div>
 
                         <div class="ccms-loader govuk-!-display-none"></div>
-
-                        <ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="case-owner-options" role="listbox">
-                            <li class="autocomplete__option autocomplete__option--no-results">No results found.</li>
-                        </ul>
 
                         <input type="hidden" id="selected-owner" name="selectedOwner" required />
                         <input type="hidden" id="current-owner" name="currentOwner" value="@Model.CurrentCaseOwner" />

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_FindTrust.cshtml
@@ -47,9 +47,6 @@
     <label for="search" class="govuk-visually-hidden">Enter a UKPRN (UK provider reference number) or Companies House number for a trust</label>
     <div id="container-SelectedTrustUkprn" class="govuk-!-margin-top-3 @inputErrorClass"></div>
     <div class="ccms-loader govuk-!-display-none"></div>
-    <ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="trustsearch__listbox" role="listbox">
-        <li class="autocomplete__option autocomplete__option--no-results">No results found.</li>
-    </ul>
     <input type="hidden" id="selectedTrustUkprn" name="selectedTrustUkprn" required />
 </div>
 


### PR DESCRIPTION
**What is the change?**

fixed rules:
aria-input-field-name
aria-required-children
label-title-only

added an aria label to the reassign text box so it reads out the instructions upon clicking with a screen reader

**Why do we need the change?**

fix accessibility violations on reassign

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/141117
