### PR TITLE
141042: fixed page has heading one rule

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/commands.ts
@@ -71,7 +71,7 @@ Cypress.Commands.add("excuteAccessibilityTests", () => {
 				region: { enabled: false },
 				// label: { enabled: false }, // Create case failed
 				// listitem: { enabled: false }, // homepage
-				"page-has-heading-one": { enabled: false }, // homepage
+				// "page-has-heading-one": { enabled: false }, // homepage
 				// "aria-input-field-name": { enabled: false }, // reassign
 				// "aria-required-children": { enabled: false }, // reassign
 				// "label-title-only": { enabled: false }, // reassign

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Closed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Closed.cshtml
@@ -23,9 +23,10 @@
 		}
 		else
 		{
+            <h1 class="govuk-heading-m">Your closed cases</h1>
 			<!-- Your closed cases -->
 			<table class="govuk-table">
-				<caption class="govuk-table__caption govuk-table__caption--m">
+				<caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">
 					Your closed cases
 				</caption>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
@@ -1,7 +1,8 @@
 ﻿@model IList<ConcernsCaseWork.Models.ActiveCaseSummaryModel>
 
+<h1 class="govuk-heading-m">Your active casework</h1>
 <table class="govuk-table">
-	<caption class="govuk-table__caption govuk-table__caption--m">
+	<caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">
 		Your active casework
 	</caption>
 	<thead class="govuk-table__head">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesTeamActive.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesTeamActive.cshtml
@@ -1,6 +1,7 @@
 ﻿@model IList<ConcernsCaseWork.Models.ActiveCaseSummaryModel>
+<h1 class="govuk-heading-m">Your team casework</h1>
 <table class="govuk-table">
-	<caption class="govuk-table__caption govuk-table__caption--m">
+	<caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">
 		Your team casework
 	</caption>
 	<thead class="govuk-table__head">


### PR DESCRIPTION
**What is the change?**

added h1 headers to tables on the homepage and team case work tables

**Why do we need the change?**

h1 should be a part of every page for accessibility

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/141042
