### PR TITLE
142904: removed back buttons from case division and case type

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseDivision.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseDivision.cshtml
@@ -6,12 +6,6 @@
 	ViewData["Title"] = "New case";
 }
 
-@section BeforeMain {
-	<div class="govuk-width-container">
-		<back-link url="/case/create"></back-link>
-	</div>
-}
-
 <div class="govuk-width-container" id="choosecasedivision">
 	
 	<partial name="_BannerError"/>
@@ -48,6 +42,9 @@
 				        value="continue">
 					Continue
 				</button>
+                <a data-prevent-double-click="true" class="govuk-link" href="/" data-module="govuk-button" role="button">
+                    Cancel
+                </a>
 			</div>
 		</form>
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseType.cshtml
@@ -6,12 +6,6 @@
 	ViewData["Title"] = "Case type";
 }
 
-@section BeforeMain {
-	<div class="govuk-width-container">
-		<back-link url="/case/create"></back-link>
-	</div>
-}
-
 <div class="govuk-width-container" id="choosecasetype">
 	
 	<partial name="_BannerError"/>
@@ -49,6 +43,9 @@
 				        value="continue">
 					Continue
 				</button>
+                <a data-prevent-double-click="true" class="govuk-link" href="/" data-module="govuk-button" role="button">
+                    Cancel
+                </a>
 			</div>
 		</form>
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Details.cshtml
@@ -30,9 +30,9 @@
         <!-- Trust summary and records -->
         <dl class="govuk-summary-list">
             <partial name="_TrustSummary" model="Model.TrustDetailsModel" />
+            <partial name="_ManagedBySummary" model="Model.CreateCaseModel" />
             <partial name="_RecordsSummary" model="Model.CreateRecordsModel" />
             <partial name="_RatingSummary" model="Model.CreateCaseModel" />
-            <partial name="_ManagedBySummary" model="Model.CreateCaseModel" />
         </dl>
 
         <div class="govuk-grid-row">


### PR DESCRIPTION
**What is the change?**

switched to cancel buttons to exit the wizard, browser 
back buttons still work 
moved managed by on concern details to match the order of the journey

**Why do we need the change?**

keep consistency with the other pages in the wizard

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/142904
