### PR TITLE
143426: updated summer to autumn on forecasting tool ran at

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Enums/TrustFinancialForecast/ForecastingToolRanAt.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Enums/TrustFinancialForecast/ForecastingToolRanAt.cs
@@ -6,10 +6,18 @@ public enum ForecastingToolRanAt
 {
 	[Description("Current year - Spring")]
 	CurrentYearSpring = 1,
-	[Description("Current year - Summer")]
+
+	// Description does not match enum
+	// We can't change this because the string CurrentYearSummer is the value
+	// Only the display name can change
+	[Description("Current year - Autumn")]
 	CurrentYearSummer = 2,
 	[Description("Previous year - Spring")]
 	PreviousYearSpring = 3,
-	[Description("Previous year - Summer")]
+
+	// Description does not match enum
+	// We can't change this because the string PreviousYearSummer is the value
+	// Only the display name can change
+	[Description("Previous year - Autumn")]
 	PreviousYearSummer = 4
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/trust-financial-forecast.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/CaseActions/trust-financial-forecast.cy.ts
@@ -173,7 +173,7 @@ describe("User can add trust financial forecast to an existing case", () => {
 	it("Close a TFF", function () {
 		Logger.Log("Create a TFF with populated values");
 		editTFFPage
-			.withForecastingTool("Previous year - Spring")
+			.withForecastingTool("Previous year - Autumn")
 			.withDayReviewHappened("14")
 			.withMonthReviewHappened("02")
 			.withYearReviewHappened("2022")
@@ -225,7 +225,7 @@ describe("User can add trust financial forecast to an existing case", () => {
 		viewTFFPage
 			.hasDateOpened(toDisplayDate(now))
 			.hasDateClosed(toDisplayDate(now))
-			.hasForecastingTool("Previous year - Spring")
+			.hasForecastingTool("Previous year - Autumn")
 			.hasInitialReviewDate("14 February 2022")
 			.hasTrustRespondedDate("15 March 2024")
 			.hasTrustResponse("Not satisfactory")


### PR DESCRIPTION
**What is the change?**

a school term is autumn and spring not spring and summer

**Why do we need the change?**

school term is incorrectly labelled

**What is the impact?**

no impact, but the database value will still say "summer" this has been agreed with the reporting team

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/143426
