### PR TITLE
144495: team casework pagination

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -98,12 +98,12 @@
         </nav>
 
         <div id="case-overview">
-            <div class="govuk-tabs__panel" id="case-details">
+            <div id="case-details">
 
                 <!-- Case Details -->
                 <table class="govuk-table">
-                    <caption class="govuk-table__caption govuk-table__caption--m"></caption>
-                    <thead>
+                    <caption class="govuk-table__caption govuk-table__caption--m govuk-!-display-none"></caption>
+                    <thead class="govuk-!-display-none">
                         <tr>
                             <th scope="col" class="govuk-!-width-one-quarter"></th>
                             <th scope="col"></th>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
@@ -39,7 +39,7 @@
 		{
 			<tr class="govuk-table__row tr__large" data-testid="row-@activeCase.CaseUrn">
 				<td class="govuk-table__cell" data-testid="case-id">
-					<a class="govuk-link" href="case/@activeCase.CaseUrn/management">@activeCase.CaseUrn</a>
+					<a class="govuk-link" href="/case/@activeCase.CaseUrn/management">@activeCase.CaseUrn</a>
 				</td>
 				<td class="govuk-table__cell" data-testid="updated-at">
 					@activeCase.CaseLastUpdatedAt

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesTeamActive.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesTeamActive.cshtml
@@ -41,7 +41,7 @@
 		{
                 <tr class="govuk-table__row tr__large" data-testid="row-@activeCase.CaseUrn">
 				<td class="govuk-table__cell" data-testid="case-id">
-					<a class="govuk-link" href="case/@activeCase.CaseUrn/management">@activeCase.CaseUrn</a>
+					<a class="govuk-link" href="/case/@activeCase.CaseUrn/management">@activeCase.CaseUrn</a>
 				</td>
 				<td class="govuk-table__cell">
                      @activeCase.CaseLastUpdatedAt


### PR DESCRIPTION
**What is the change?**

team casework pagination

**Why do we need the change?**

when using pagination the team casework case link did not work
use absolute path instead of relative path on the url

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/144495
