### PR TITLE
improve decision integration tests

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/DatabaseModels/Concerns/DecisionTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/DatabaseModels/Concerns/DecisionTests.cs
@@ -36,40 +36,6 @@ namespace ConcernsCaseWork.API.Tests.DatabaseModels.Concerns
         }
 
         [Theory]
-        [InlineData(-1000, "caseNumber", "notes", "link", "totalAmountRequested")]
-        [InlineData(1000, "_maxString_", "notes", "link", "crmCaseNumber")]
-        [InlineData(1000, "caseNumber", "_maxString_", "link", "supportingNotes")]
-        [InlineData(1000, "caseNumber", "notes", "_maxString_", "submissionDocumentLink")]
-        public void CreateNew_With_Invalid_Arguments_Throws_Exception(decimal amountRequested, string crmCaseNumber, string supportingNotes, string submissionDocumentLink, string expectedParamName)
-        {
-            var fixture = new Fixture();
-            crmCaseNumber = crmCaseNumber == "_maxString_" ? CreateFixedLengthString(fixture, Decision.MaxCaseNumberLength + 1) : crmCaseNumber;
-            supportingNotes = supportingNotes == "_maxString_" ? CreateFixedLengthString(fixture, Decision.MaxSupportingNotesLength + 1) : supportingNotes;
-            submissionDocumentLink = submissionDocumentLink == "_maxString_" ? CreateFixedLengthString(fixture, Decision.MaxUrlLength + 1) : submissionDocumentLink;
-
-			Action act = () => Decision.CreateNew(new DecisionParameters()
-				{
-					CrmCaseNumber = crmCaseNumber,
-					RetrospectiveApproval = null,
-					SubmissionRequired = null,
-					SubmissionDocumentLink = submissionDocumentLink,
-					ReceivedRequestDate = DateTimeOffset.UtcNow,
-					DecisionTypes = Array.Empty<DecisionType>(),
-					TotalAmountRequested = amountRequested,
-					SupportingNotes = supportingNotes,
-					Now = DateTimeOffset.Now
-				}
-			);
-
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be(expectedParamName);
-        }
-
-        private string CreateFixedLengthString(Fixture fixture, int size)
-        {
-            return new string(fixture.CreateMany<char>(size).ToArray());
-        }
-
-        [Theory]
         [InlineData("caseNumber", "notes", "link")]
         [InlineData(null, null, null)]
         public void CreateNew_Sets_Properties(string caseNumber, string notes, string link)

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Decisions/Decision.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Models/Decisions/Decision.cs
@@ -37,8 +37,6 @@ namespace ConcernsCaseWork.Data.Models.Decisions
 		public static Decision CreateNew(
 			DecisionParameters parameters)
 		{
-			ValidateDecisionModel(parameters.CrmCaseNumber, parameters.SubmissionDocumentLink, parameters.TotalAmountRequested, parameters.SupportingNotes);
-
 			return new Decision
 			{
 				DecisionTypes = parameters.DecisionTypes?.ToList() ?? new List<DecisionType>(),
@@ -54,40 +52,6 @@ namespace ConcernsCaseWork.Data.Models.Decisions
 				CreatedAt = parameters.Now,
 				UpdatedAt = parameters.Now
 			};
-		}
-
-		/// <summary>
-		/// Validates that the properties of a decision are valid, and should be called before creation/update is made.
-		/// If invalid properties are found an exception is thrown. In future it might be better to return an exceptions collection.
-		/// Some of these validations are good candidates for turning into value types
-		/// </summary>
-		/// <param name="crmCaseNumber"></param>
-		/// <param name="submissionDocumentLink"></param>
-		/// <param name="totalAmountRequested"></param>
-		/// <param name="supportingNotes"></param>
-		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		/// <exception cref="ArgumentException"></exception>
-		private static void ValidateDecisionModel(string crmCaseNumber, string submissionDocumentLink,
-			decimal totalAmountRequested, string supportingNotes)
-		{
-			// some of these validations are good candidates for turning into value types
-			_ = totalAmountRequested >= 0
-				? totalAmountRequested
-				: throw new ArgumentOutOfRangeException(nameof(totalAmountRequested),
-					"The total amount requested cannot be a negative value");
-
-			if (crmCaseNumber?.Length > MaxCaseNumberLength)
-				throw new ArgumentException($"{nameof(crmCaseNumber)} can be a maximum of {MaxCaseNumberLength} characters",
-					nameof(crmCaseNumber));
-
-			if (supportingNotes?.Length > MaxSupportingNotesLength)
-				throw new ArgumentException(
-					$"{nameof(supportingNotes)} can be a maximum of {MaxSupportingNotesLength} characters",
-					nameof(supportingNotes));
-
-			if (submissionDocumentLink?.Length > MaxUrlLength)
-				throw new ArgumentException($"{nameof(submissionDocumentLink)} can be a maximum of {MaxUrlLength} characters",
-					nameof(submissionDocumentLink));
 		}
 
 		public const int MaxUrlLength = 2048;
@@ -153,9 +117,6 @@ namespace ConcernsCaseWork.Data.Models.Decisions
 		/// <param name="now"></param>
 		public void Update(Decision updatedDecision, DateTimeOffset now)
 		{
-			_ = updatedDecision ?? throw new ArgumentNullException(nameof(updatedDecision));
-			ValidateDecisionModel(updatedDecision.CrmCaseNumber, updatedDecision.SubmissionDocumentLink, updatedDecision.TotalAmountRequested, updatedDecision.SupportingNotes);
-
 			DecisionTypes = updatedDecision.DecisionTypes ?? Array.Empty<DecisionType>();
 			TotalAmountRequested = updatedDecision.TotalAmountRequested;
 			SupportingNotes = updatedDecision.SupportingNotes;


### PR DESCRIPTION
**What is the change?**

the decision integration tests were using database entries to create decisions, this causes maintenance problems

changed the tests to use the api to create decisions and made the post and put apis check all properties

removed the validation from the decision model as it will always get caught by the api

**Why do we need the change?**

tech debt

**What is the impact?**

**Azure DevOps Ticket**
