### PR TITLE
145082: return no content if ctc by uk prn does not match

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/CityTechnologyCollegesIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/CityTechnologyCollegesIntegrationTests.cs
@@ -137,7 +137,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 		{
 			string urkprn = "123465789";
 			var result = await _client.GetAsync($"/v2/citytechnologycolleges/ukprn/{urkprn}");
-			result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+			result.StatusCode.Should().Be(HttpStatusCode.NoContent);
 		}
 
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/CityTechnologyCollegesIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/CityTechnologyCollegesIntegrationTests.cs
@@ -133,7 +133,7 @@ namespace ConcernsCaseWork.API.Tests.Integration
 
 
 		[Fact]
-		public async Task When_Get_IndividualItem_WhenNoneExist_Return_OK()
+		public async Task When_Get_IndividualItem_WhenNoneExist_Return_NoContent()
 		{
 			string urkprn = "123465789";
 			var result = await _client.GetAsync($"/v2/citytechnologycolleges/ukprn/{urkprn}");

--- a/ConcernsCaseWork/ConcernsCaseWork.API/Features/CityTechnicalCollege/CityTechnologyCollegeController.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/Features/CityTechnicalCollege/CityTechnologyCollegeController.cs
@@ -37,15 +37,14 @@ namespace ConcernsCaseWork.API.Features.CityTechnicalCollege
 		/// <returns>A city technology college containing the ID, Name, UKPRN, Companies House Number and Address</returns>
 		[HttpGet("ukprn/{ukprn}", Name = nameof(GetByUKPRN))]
 		[ProducesResponseType((int)HttpStatusCode.OK)]
-		[ProducesResponseType((int)HttpStatusCode.NotFound)]
+		[ProducesResponseType((int)HttpStatusCode.NoContent)]
 		public async Task<IActionResult> GetByUKPRN([FromRoute]GetByUKPRN.Query query)
 		{
 			var model = await _mediator.Send(query);
-			if (model == null)
-			{
-				return NotFound();
-			}
 
+			// Our caller does not know if the UKPRN exists
+			// We need to return a 204 instead of 404 in the case of null and let the client decide
+			// Otherwise our logs will get a large amount of errors raised
 			return Ok(model);
 		}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/CityTechnologyCollegeService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/CityTechnologyCollegeService.cs
@@ -63,6 +63,9 @@ namespace ConcernsCaseWork.Service.Trusts
 			// Check status code
 			response.EnsureSuccessStatusCode();
 
+			// If null is returned it means there was no match
+			// This happens because we don't know if a UK PRN is a CTC or not
+			// This is expected because we are using this API as a blind check if the UK PRN is a CTC
 			if (response.StatusCode == HttpStatusCode.NoContent)
 			{
 				return null;

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/CityTechnologyCollegeService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/CityTechnologyCollegeService.cs
@@ -3,6 +3,7 @@ using ConcernsCaseWork.Logging;
 using ConcernsCaseWork.Service.Base;
 using ConcernsCaseWork.UserContext;
 using Microsoft.Extensions.Logging;
+using System.Net;
 using System.Net.Http.Json;
 
 namespace ConcernsCaseWork.Service.Trusts
@@ -43,7 +44,6 @@ namespace ConcernsCaseWork.Service.Trusts
 			// Read response content
 			var result = await response.Content.ReadFromJsonAsync<List<CityTechnologyCollege>>();
 
-
 			List<TrustSearchDto> trustObjectList = result.Select(f => new TrustSearchDto(f.UKPRN, string.Empty, f.Name, f.CompaniesHouseNumber, _defaultGroupTypeName, new GroupContactAddressDto(f.AddressLine1, f.AddressLine2, String.Empty, f.Town, f.County, f.Postcode))).ToList();
 
 			return new TrustSearchResponseDto { NumberOfMatches = trustObjectList.Count, Trusts = trustObjectList };
@@ -62,6 +62,11 @@ namespace ConcernsCaseWork.Service.Trusts
 
 			// Check status code
 			response.EnsureSuccessStatusCode();
+
+			if (response.StatusCode == HttpStatusCode.NoContent)
+			{
+				return null;
+			}
 
 			// Read response content
 			var result = await response.Content.ReadFromJsonAsync<CityTechnologyCollege>();

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
@@ -111,11 +111,10 @@ namespace ConcernsCaseWork.Service.Trusts
 		{
 			TrustDetailsDto cityTechnologyCollege = null;
 
-			bool ShouldCTCBeIncludedInTrustSearch = await _featureManager.IsEnabledAsync(FeatureFlags.IsCTCInTrustSearchEnabled); ;
+			bool ShouldCTCBeIncludedInTrustSearch = await _featureManager.IsEnabledAsync(FeatureFlags.IsCTCInTrustSearchEnabled);
 			if (ShouldCTCBeIncludedInTrustSearch)
 			{
 				_logger.LogInformation($"TrustService::GetTrustByUkPrn Feature Flag ShouldCTCBeAddedToTrustSearch True. Starting Search for CTCs");
-
 
 				try
 				{
@@ -127,17 +126,6 @@ namespace ConcernsCaseWork.Service.Trusts
 				}
 				catch (Exception ex)
 				{
-					if (ex is HttpRequestException)
-					{
-						// We can't determine if a 404 is an issue, because we don't know if the uk prn is a technical college
-						// Otherwise we get a large amount of errors raised in the logs
-						var httpRequestException = ex as HttpRequestException;
-						if (httpRequestException.StatusCode == HttpStatusCode.NotFound)
-						{
-							return null;
-						}
-					}
-
 					_logger.LogInformation($"TrustService::GetTrustByUkPrn An error occured searching for CTCs. Containing search from Trust List");
 					_logger.LogError("TrustService::GetTrustByUkPrn::Exception message::{Message}", ex.Message);
 				}


### PR DESCRIPTION
**What is the change?**

our caller does not know if the UKPRN exists
we need to return a 204 instead of 404 in the case of null and let the client decide otherwise our logs will get a large amount of errors raised

**Why do we need the change?**

prevent large amounts of errors being logged in production

**What is the impact?**

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/145082
