### PR TITLE
145338: caching issue converting non concern to concerns case

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -2,7 +2,7 @@ name: Continuous Integration / Terraform
 
 on:
   push:
-    branches: main
+    branches: [ main, release/** ]
     paths:
       - 'terraform/**.tf'
   pull_request:

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
@@ -188,6 +188,7 @@ describe("Creating a case", () => {
 			.hasTrust("Ashton West End Primary Academy")
 			.hasRiskToTrust("Red Plus")
 			.hasConcerns("Deficit", ["Red", "Amber"])
+			.hasNumberOfConcerns(1)
 			.hasManagedBy("SFSO", "North and UTC - North East")
 			.hasIssue("This is an issue")
 			.hasCurrentStatus("This is the current status")
@@ -372,6 +373,7 @@ describe("Creating a case", () => {
 		caseManagementPage
 			.hasConcerns("Suspected fraud", ["Red Plus"])
 			.hasConcerns("Financial compliance", ["Amber", "Green"])
-			.hasConcerns("Irregularity", ["Red", "Amber"]);
+			.hasConcerns("Irregularity", ["Red", "Amber"])
+			.hasNumberOfConcerns(3);
 	});
 });

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case.cy.ts
@@ -120,6 +120,12 @@ describe("Creating a case", () => {
 		Logger.Log("Checking accessibility on risk to trust");
 		cy.excuteAccessibilityTests();
 
+		createCaseSummary
+			.hasTrustSummaryDetails("Ashton West End Primary Academy")
+			.hasManagedBy("SFSO", "North and UTC - North East")
+			.hasConcernType("Deficit")
+			.hasConcernRiskRating("Red Amber");
+
 		Logger.Log("Populate risk to trust");
 		addDetailsPage.withRiskToTrust("Red-Plus").nextStep();
 

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
@@ -10,7 +10,6 @@ import AddToCasePage from "../../pages/caseActions/addToCasePage";
 import { EditSrmaPage } from "cypress/pages/caseActions/srma/editSrmaPage";
 import { ViewSrmaPage } from "cypress/pages/caseActions/srma/viewSrmaPage";
 import actionSummaryTable from "cypress/pages/caseActions/summary/actionSummaryTable";
-import HomePage from "../../pages/homePage";
 import ClosedCasePage from "../../pages/closedCasePage";
 import caseworkTable from "cypress/pages/caseRows/caseworkTable";
 import { toDisplayDate } from "cypress/support/formatDate";
@@ -23,6 +22,9 @@ import {
 	SourceOfConcernInternal,
 } from "cypress/constants/selectorConstants";
 import selectCaseDivisionPage from "cypress/pages/createCase/selectCaseDivisionPage";
+import createCaseSummary from "cypress/pages/createCase/createCaseSummary";
+import homePage from "../../pages/homePage";
+import headerComponent from "cypress/pages/header";
 
 describe("Creating a non concerns case", () => {
 	let email: string;
@@ -37,13 +39,13 @@ describe("Creating a non concerns case", () => {
 	const createConcernPage = new CreateConcernPage();
 
 	const trustName = "Ashton West End Primary Academy";
+	const alternativeTrustName = "Denton West End Primary School";
 	const territory = "North and UTC - North East";
 
 	let now: Date;
 
 	beforeEach(() => {
 		cy.login();
-		cy.visit(Cypress.env("url") + "/case/create");
 		email = Cypress.env(EnvUsername);
 		name = email.split("@")[0];
 		now = new Date();
@@ -51,7 +53,7 @@ describe("Creating a non concerns case", () => {
 
 	it("Should validate adding a case", () => {
 		Logger.Log("Create a case");
-		createCasePage.withTrustName(trustName).selectOption().confirmOption();
+		createCasePage.createCase().withTrustName(trustName).selectOption().confirmOption();
 
 		Logger.Log("You must select a division error");
         selectCaseDivisionPage
@@ -144,116 +146,209 @@ describe("Creating a non concerns case", () => {
 		});
 	});
 
-	it("Converting non conern to concern case", () => {
-		Logger.Log("Create a case");
-		createCasePage.withTrustName(trustName).selectOption().confirmOption();
+	describe("Converting non conern to concern case", () =>
+	{
+		it("Should make the case a concerns case", () => {
+			Logger.Log("Create a case");
+			createCasePage.createCase().withTrustName(trustName).selectOption().confirmOption();
+	
+			Logger.Log("Create a valid case division");
+			selectCaseDivisionPage
+				.withCaseDivision("SFSO")
+				.continue();
+	
+			Logger.Log("Populate territory");
+			addTerritoryPage.withTerritory(territory).nextStep();
+	
+			Logger.Log("Create a valid Non-concern case type");
+			selectCaseTypePage.withCaseType("NonConcerns").continue();
+	
+			Logger.Log("Add non concerns case");
+			addConcernDetailsPage.createCase();
+	
+			Logger.Log("Add another concern after case creation");
+			caseManagementPage.addAnotherConcernForNonConcern();
+	
+			Logger.Log("Checking accessibility on adding concern page");
+			cy.excuteAccessibilityTests();
+	
+			Logger.Log("Attempt to create an invalid concern");
+			createConcernPage
+				.addConcern()
+				.hasValidationError("Select concern type")
+				.hasValidationError("Select concern risk rating")
+				.hasValidationError("Select means of referral");
+	
+			Logger.Log("Create an invalid sub concern");
+			createConcernPage
+				.withConcernType("Deficit")
+				.withConcernRating("Red-Amber")
+				.withMeansOfReferral(SourceOfConcernExternal)
+				.addConcern();
+	
+			Logger.Log("Adding another concern during case creation");
+			createConcernPage
+				.addAnotherConcern()
+				.withConcernType("Financial compliance")
+				.withConcernRating("Amber-Green")
+				.withMeansOfReferral(SourceOfConcernInternal)
+				.addConcern()
+				.nextStep();
+	
+			Logger.Log("Check unpopulated risk to trust throws validation error");
+			addConcernDetailsPage
+				.nextStep()
+				.hasValidationError("Select risk to trust rating");
+	
+			createConcernPage.withConcernRating("Red-Plus").nextStep();
+	
+			Logger.Log("Checking accessibility on create case concern page");
+			cy.excuteAccessibilityTests();
+	
+			Logger.Log("Validate unpopulated concern details");
+			addConcernDetailsPage
+				.withIssueExceedingLimit()
+				.withCurrentStatusExceedingLimit()
+				.withCaseAimExceedingLimit()
+				.withDeEscalationPointExceedingLimit()
+				.withNextStepsExceedingLimit()
+				.withCaseHistoryExceedingLimit()
+				.createCase()
+				.hasValidationError("Issue must be 2000 characters or less")
+				.hasValidationError("Current status must be 4000 characters or less")
+				.hasValidationError("Next steps must be 4000 characters or less")
+				.hasValidationError("De-escalation point must be 1000 characters or less")
+				.hasValidationError("Case aim must be 1000 characters or less")
+				.hasValidationError("Case notes must be 4300 characters or less");
+	
+			Logger.Log("Checking accessibility on concerns case confirmation");
+			cy.excuteAccessibilityTests();
+	
+			Logger.Log("Add concern details with valid text limit");
+			addConcernDetailsPage
+				.withIssue("This is an issue")
+				.withCurrentStatus("This is the current status")
+				.withCaseAim("This is the case aim")
+				.withDeEscalationPoint("This is the de-escalation point")
+				.withNextSteps("This is the next steps")
+				.withCaseHistory("This is the case history")
+				.createCase();
+	
+			Logger.Log("Verify case details");
+			caseManagementPage
+				.hasTrust("Ashton West End Primary Academy")
+				.hasRiskToTrust("Red Plus")
+				.hasConcerns("Financial compliance", ["Amber", "Green"])
+				.hasConcerns("Deficit", ["Red", "Amber"])
+				.hasManagedBy("SFSO", "North and UTC - North East")
+				.hasIssue("This is an issue")
+				.hasCurrentStatus("This is the current status")
+				.hasCaseAim("This is the case aim")
+				.hasDeEscalationPoint("This is the de-escalation point")
+				.hasNextSteps("This is the next steps")
+				.hasCaseHistory("This is the case history");
+	
+			Logger.Log("Verify the means of referral is set");
+			caseManagementPage.getCaseIDText().then((caseId) => {
+				concernsApi.get(parseInt(caseId)).then((response) => {
+					var ids = response.map((r) => r.meansOfReferralId);
+					expect(ids).to.contain(1);
+					expect(ids).to.contain(2);
+				});
+			});
+		});
 
-        Logger.Log("Create a valid case division");
-        selectCaseDivisionPage
-            .withCaseDivision("SFSO")
-            .continue();
+		describe("When we cancel case creation of a different case in the middle", () =>
+		{
+			it("Should create the concern against the correct case and trust", () =>
+			{
+				Logger.Log("Create a case");
+				createCasePage.createCase().withTrustName(trustName).selectOption().confirmOption();
+		
+				selectCaseDivisionPage
+					.withCaseDivision("SFSO")
+					.continue();
+		
+				addTerritoryPage.withTerritory(territory).nextStep();
+				selectCaseTypePage.withCaseType("NonConcerns").continue();
+				addConcernDetailsPage.createCase();
 
-		Logger.Log("Populate territory");
-		addTerritoryPage.withTerritory(territory).nextStep();
+				caseManagementPage.getCaseIDText()
+				.then((caseId: string) =>
+				{
+					headerComponent.goToHome();
 
-		Logger.Log("Create a valid Non-concern case type");
-		selectCaseTypePage.withCaseType("NonConcerns").continue();
+					Logger.Log("Create a case for an alternative trust");
+					createCasePage.createCase().withTrustName(alternativeTrustName).selectOption().confirmOption();
+					
+					Logger.Log("Create a concerns case for our original trust ensuring the data is correct");
+					cy.visit(`/case/${caseId}/management`);
+					caseManagementPage.addAnotherConcernForNonConcern();
 
-		Logger.Log("Add non concerns case");
-		addConcernDetailsPage.createCase();
+					createCaseSummary
+						.hasTrustSummaryDetails(trustName)
+						.hasManagedBy("SFSO", "North and UTC - North East");
 
-		Logger.Log("Add another concern after case creation");
-		caseManagementPage.addAnotherConcernForNonConcern();
+					createConcernPage
+						.withConcernType("Viability")
+						.withConcernRating("Amber-Green")
+						.withMeansOfReferral(SourceOfConcernExternal)
+						.addConcern();
 
-		Logger.Log("Checking accessibility on adding concern page");
-		cy.excuteAccessibilityTests();
+					Logger.Log("Exit early again and create another concern");
 
-		Logger.Log("Attempt to create an invalid concern");
-		createConcernPage
-			.addConcern()
-			.hasValidationError("Select concern type")
-			.hasValidationError("Select concern risk rating")
-			.hasValidationError("Select means of referral");
+					cy.visit(`/case/${caseId}/management`);
+					caseManagementPage.addAnotherConcernForNonConcern();
 
-		Logger.Log("Create an invalid sub concern");
-		createConcernPage
-			.withConcernType("Deficit")
-			.withConcernRating("Red-Amber")
-			.withMeansOfReferral(SourceOfConcernExternal)
-			.addConcern();
+					Logger.Log("It should show us the trust for the case we are on");
 
-		Logger.Log("Adding another concern during case creation");
-		createConcernPage
-			.addAnotherConcern()
-			.withConcernType("Financial compliance")
-			.withConcernRating("Amber-Green")
-			.withMeansOfReferral(SourceOfConcernInternal)
-			.addConcern()
-			.nextStep();
+					createCaseSummary
+						.hasTrustSummaryDetails(trustName)
+						.hasManagedBy("SFSO", "North and UTC - North East");
 
-		Logger.Log("Check unpopulated risk to trust throws validation error");
-		addConcernDetailsPage
-			.nextStep()
-			.hasValidationError("Select risk to trust rating");
+					createConcernPage
+						.withConcernType("Deficit")
+						.withConcernRating("Red-Amber")
+						.withMeansOfReferral(SourceOfConcernExternal)
+						.addConcern();
 
-		createConcernPage.withConcernRating("Red-Plus");
+					createCaseSummary
+						.hasTrustSummaryDetails(trustName)
+						.hasManagedBy("SFSO", "North and UTC - North East")
+						.hasConcernType("Deficit")
+						.hasConcernRiskRating("Red Amber");
 
-		addConcernDetailsPage.nextStep();
-		Logger.Log("Checking accessibility on create case concern page");
-		cy.excuteAccessibilityTests();
+					createConcernPage.nextStep();
 
-		Logger.Log("Validate unpopulated concern details");
-		addConcernDetailsPage
-			.withIssueExceedingLimit()
-			.withCurrentStatusExceedingLimit()
-			.withCaseAimExceedingLimit()
-			.withDeEscalationPointExceedingLimit()
-			.withNextStepsExceedingLimit()
-			.withCaseHistoryExceedingLimit()
-			.createCase()
-			.hasValidationError("Issue must be 2000 characters or less")
-			.hasValidationError("Current status must be 4000 characters or less")
-			.hasValidationError("Next steps must be 4000 characters or less")
-			.hasValidationError("De-escalation point must be 1000 characters or less")
-			.hasValidationError("Case aim must be 1000 characters or less")
-			.hasValidationError("Case notes must be 4300 characters or less");
+					createCaseSummary
+						.hasTrustSummaryDetails(trustName)
+						.hasManagedBy("SFSO", "North and UTC - North East")
+						.hasConcernType("Deficit")
+						.hasConcernRiskRating("Red Amber");
 
-		Logger.Log("Checking accessibility on concerns case confirmation");
-		cy.excuteAccessibilityTests();
+					createConcernPage.withConcernRating("Red-Plus").nextStep();
 
-		Logger.Log("Add concern details with valid text limit");
-		addConcernDetailsPage
-			.withIssue("This is an issue")
-			.withCurrentStatus("This is the current status")
-			.withCaseAim("This is the case aim")
-			.withDeEscalationPoint("This is the de-escalation point")
-			.withNextSteps("This is the next steps")
-			.withCaseHistory("This is the case history")
-			.createCase();
+					createCaseSummary
+						.hasTrustSummaryDetails(trustName)
+						.hasManagedBy("SFSO", "North and UTC - North East")
+						.hasConcernType("Deficit")
+						.hasConcernRiskRating("Red Amber")
+						.hasRiskToTrust("Red Plus");
 
-		Logger.Log("Verify case details");
-		caseManagementPage
-			.hasTrust("Ashton West End Primary Academy")
-			.hasRiskToTrust("Red Plus")
-			.hasConcerns("Financial compliance", ["Amber", "Green"])
-			.hasConcerns("Deficit", ["Red", "Amber"])
-			.hasManagedBy("SFSO", "North and UTC - North East")
-			.hasIssue("This is an issue")
-			.hasCurrentStatus("This is the current status")
-			.hasCaseAim("This is the case aim")
-			.hasDeEscalationPoint("This is the de-escalation point")
-			.hasNextSteps("This is the next steps")
-			.hasCaseHistory("This is the case history");
+					addConcernDetailsPage
+						.withIssue("This is an issue").createCase();
 
-		Logger.Log("Verify the means of referral is set");
-		caseManagementPage.getCaseIDText().then((caseId) => {
-			concernsApi.get(parseInt(caseId)).then((response) => {
-				var ids = response.map((r) => r.meansOfReferralId);
-				expect(ids).to.contain(1);
-				expect(ids).to.contain(2);
+					Logger.Log("It should create just one concern against the correct trust");
+					caseManagementPage
+						.hasTrust("Ashton West End Primary Academy")
+						.hasRiskToTrust("Red Plus")
+						.hasConcerns("Deficit", ["Red", "Amber"])
+				});
 			});
 		});
 	});
+
+
 
 	function closeCase(caseId: string) {
 		Logger.Log("Closing case");
@@ -263,7 +358,7 @@ describe("Creating a non concerns case", () => {
 		CaseManagementPage.getCloseCaseBtn().click();
 
 		Logger.Log("Viewing case is closed");
-		HomePage.getClosedCasesBtn().click();
+		homePage.getClosedCasesBtn().click();
 		ClosedCasePage.getClosedCase(caseId);
 	}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
@@ -240,6 +240,7 @@ describe("Creating a non concerns case", () => {
 				.hasRiskToTrust("Red Plus")
 				.hasConcerns("Financial compliance", ["Amber", "Green"])
 				.hasConcerns("Deficit", ["Red", "Amber"])
+				.hasNumberOfConcerns(2)
 				.hasManagedBy("SFSO", "North and UTC - North East")
 				.hasIssue("This is an issue")
 				.hasCurrentStatus("This is the current status")
@@ -340,15 +341,14 @@ describe("Creating a non concerns case", () => {
 
 					Logger.Log("It should create just one concern against the correct trust");
 					caseManagementPage
-						.hasTrust("Ashton West End Primary Academy")
+						.hasTrust(trustName)
 						.hasRiskToTrust("Red Plus")
 						.hasConcerns("Deficit", ["Red", "Amber"])
+						.hasNumberOfConcerns(1);
 				});
 			});
 		});
 	});
-
-
 
 	function closeCase(caseId: string) {
 		Logger.Log("Closing case");

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -513,6 +513,13 @@ class CaseManagementPage {
 		return this;
 	}
 
+	public hasNumberOfConcerns(count: number): this {
+		Logger.Log(`Has number of concerns ${count}`);
+		cy.getByTestId("concerns-details-table").find('tr').should("have.length", count);
+
+		return this;
+	}
+
 	public hasManagedBy(division: string, territory: string): this {
 		Logger.Log(`Has managed by ${division} ${territory}`);
 

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/header.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/header.ts
@@ -1,0 +1,16 @@
+import { Logger } from "cypress/common/logger";
+
+class Header
+{
+    public goToHome(): this {
+        Logger.Log("Go back to home");
+
+        cy.getByTestId("go-to-home").click();
+
+        return this;
+    }
+}
+
+const headerComponent = new Header();
+
+export default headerComponent;

--- a/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork/ConcernsCaseWork.csproj
@@ -5,7 +5,7 @@
 		<CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
 		<UserSecretsId>ac20b61d-9280-4be5-bbad-ad27aaff2f24</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-		<Version>29.0.0</Version>
+		<Version>29.1.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Label="custom">

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Add.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Add.cshtml
@@ -57,7 +57,7 @@ else
                     @if (Model?.CaseModel?.Urn > 0)
                     {
 	                    <span class="govuk-!-padding-right-1 govuk-grid-column-two-thirds">
-		                    <a data-prevent-double-click="true" asp-page="index" class="govuk-link" asp-route-urn="@Model.CaseModel.Urn" data-module="govuk-button" role="button" data-testid="add-concern-button">
+		                    <a data-prevent-double-click="true" asp-page="index" class="govuk-link" asp-route-urn="@Model.CaseModel.Urn" asp-route-source-page="add-another-concern" data-module="govuk-button" role="button" data-testid="add-concern-button">
 			                    Add concern
 		                    </a>
 	                    </span>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
@@ -108,12 +108,13 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 			// We need to make sure if we already have an existing case, we clear the cache first
 			// Then set the existing case values and save them before loading the page
 			// Otherwise it will display the values from the previously cached case
-			var userState = await GetUserState();
+			var username = GetUserName();
+			var userState = new UserState(username);
 			userState.TrustUkPrn = caseModel.TrustUkPrn;
 			userState.CreateCaseModel = new CreateCaseModel();
 			userState.CreateCaseModel.Division = caseModel.Division;
 			userState.CreateCaseModel.Territory = caseModel.Territory;
-			await _cachedService.StoreData(GetUserName(), userState);
+			await _cachedService.StoreData(username, userState);
 		}
 
 		public async Task<IActionResult> OnPostAsync()

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Concern/Index.cshtml.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using JsonSerializer = System.Text.Json.JsonSerializer;
@@ -56,6 +55,9 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 		[BindProperty(SupportsGet = true, Name = "Urn")]
 		public int? CaseUrn { get; set; }
 
+		[BindProperty(SupportsGet = true, Name = "source-page")]
+		public string? SourcePage { get; set; }
+
 		public IndexPageModel(ITrustModelService trustModelService,
 			IUserStateCachedService cachedService,
 			IRatingModelService ratingModelService,
@@ -79,6 +81,8 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 				
 			try
 			{
+				await LoadExistingCaseIntoCache();
+
 				await LoadPage();
 			}
 			catch (Exception ex)
@@ -88,7 +92,30 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 			}
 			return Page();
 		}
-		
+
+		private async Task LoadExistingCaseIntoCache()
+		{
+			var caseModel = await GetCaseModel();
+
+			// If we came from the add another concern page we don't want to clear the cache
+			if (caseModel == null || SourcePage == "add-another-concern")
+			{
+				return;
+			}
+
+			// We had an issue where the cache was already populated with data
+			// In non concerns we start on this page
+			// We need to make sure if we already have an existing case, we clear the cache first
+			// Then set the existing case values and save them before loading the page
+			// Otherwise it will display the values from the previously cached case
+			var userState = await GetUserState();
+			userState.TrustUkPrn = caseModel.TrustUkPrn;
+			userState.CreateCaseModel = new CreateCaseModel();
+			userState.CreateCaseModel.Division = caseModel.Division;
+			userState.CreateCaseModel.Territory = caseModel.Territory;
+			await _cachedService.StoreData(GetUserName(), userState);
+		}
+
 		public async Task<IActionResult> OnPostAsync()
 		{
 			try
@@ -101,12 +128,7 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 					return Page();
 				}
 
-				CaseModel caseModel = null;
-
-				if (CaseUrn.HasValue)
-				{
-					caseModel = await _caseModelService.GetCaseByUrn((long)CaseUrn);
-				}
+				CaseModel caseModel = await GetCaseModel();
 				
 				var ragRatingId = (ConcernRating)ConcernRiskRating.SelectedId.Value;
 
@@ -242,6 +264,20 @@ namespace ConcernsCaseWork.Pages.Case.Concern
 				throw new Exception("Cache CaseStateData is null");
 			
 			return userState;
+		}
+
+		private async Task<CaseModel> GetCaseModel()
+		{
+			CaseModel result = null;
+
+			if (!CaseUrn.HasValue)
+			{
+				return result;
+			}
+
+			result = await _caseModelService.GetCaseByUrn((long)CaseUrn);
+
+			return result;
 		}
 		
 		private string GetUserName() => _claimsPrincipalHelper.GetPrincipalName(User);

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -174,7 +174,7 @@
                                 </th>
                                 <td colspan="2" class="govuk-table__cell" data-testid="concerns_Field">
 
-                                    <table class="govuk-table">
+                                    <table class="govuk-table" data-testid="concerns-details-table">
                                         <tbody class="govuk-table__body">
                                             @foreach (var concern in Model.CaseModel.RecordsModel)
                                             {

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Layout.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Layout.cshtml
@@ -65,7 +65,7 @@
                 <a class="dfe-header__link dfe-header__link--service " href="/" aria-label="DfE homepage">
                     <img src="/assets/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
                     <img src="/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
-                    <span class="dfe-header__service-name">
+                    <span class="dfe-header__service-name" data-testid="go-to-home">
                         Record concerns and support for trusts
                     </span>
                 </a>

--- a/ConcernsCaseWork/release-notes.md
+++ b/ConcernsCaseWork/release-notes.md
@@ -1,3 +1,6 @@
+## 29.0.1
+* fixed caching issue with conversion from non concerns to concerns, incorrect trust data was displayed in the summary
+
 ## 29.0.0
 * Content changes to TFF, so the acronym appears first
 * New page for recording the manager of a case


### PR DESCRIPTION
**What is the change?**

The issue here was a stale cache was populating the data for the conversion journey incorrectly, because the pages are reused between the conversion journey and case creation. This was done to reduce the amount of duplication, for what is essentially the same flow of pages. The solution is to clear the cache when the conversion journey starts, need to be aware the loop back to create more concerns also starts from the same point, so we need to identify when that happens and not clear the cache in that instance.

The automation tests have been written to check both of these scenarios

**Why do we need the change?**

fix an issue where the wrong trust information was shown on the conversion from concerns to non concerns
there was also a chance concerns could be duplicated

**What is the impact?**

should fix the bug, the automation tests will check any regressions

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/145338
