### PR TITLE
Add Cypress User-agent to config

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress.config.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       json: true,
     },
   },
+	userAgent: 'ConcernsCaseWork/1.0 Cypress',
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.


### PR DESCRIPTION
Adds a User-Agent header to Cypress' config to mitigate Azure's bot traffic rules
