### PR TITLE
150272: fixed issue where user could not remove narrative field text after it had been set

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
@@ -264,7 +264,7 @@ describe("Editing a case", () => {
 
 	});
 
-	it.only("Should raise a validation error if do not select a case action", () => {
+	it("Should raise a validation error if do not select a case action", () => {
 		cy.basicCreateCase();
 
 		CaseManagementPage.getAddToCaseBtn().click();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/edit-case.cy.ts
@@ -228,7 +228,7 @@ describe("Editing a case", () => {
 
 		editCaseHistoryPage.withCaseHistory("New case history").apply();
 
-		Logger.log("Verify detailes have been changed");
+		Logger.log("Verify details have been changed");
 		caseManagementPage
 			.hasRiskToTrust("Red")
 			.hasDirectionOfTravel("Improving")
@@ -240,9 +240,31 @@ describe("Editing a case", () => {
 			.hasDeEscalationPoint("New de-descalation point")
 			.hasNextSteps("New next step")
 			.hasCaseHistory("New case history");
+
+		Logger.log("Ensure that we can remove all optional information");
+		caseManagementPage.editCurrentStatus();
+		editCurrentStatusPage.withCurrentStatus("").apply();
+		caseManagementPage.editCaseAim();
+		editCaseAimPage.withCaseAim("").apply();
+		caseManagementPage.editDeEscalationPoint();
+		editDeEscalationPage.withDeescalationPoint("").apply();
+		caseManagementPage.editNextSteps();
+		editNextStepsPage.withNextSteps("").apply();
+		caseManagementPage.editCaseHistory();
+		editCaseHistoryPage.withCaseHistory("").apply();
+
+		Logger.log("Verify details have been changed");
+		caseManagementPage
+			.hasIssue("New Issue")
+			.hasEmptyCurrentStatus()
+			.hasEmptyCaseAim()
+			.hasEmptyDeEscalationPoint()
+			.hasEmptyNextSteps()
+			.hasEmptyCaseHistory();
+
 	});
 
-	it("Should raise a validation error if do not select a case action", () => {
+	it.only("Should raise a validation error if do not select a case action", () => {
 		cy.basicCreateCase();
 
 		CaseManagementPage.getAddToCaseBtn().click();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -31,7 +31,7 @@ class CaseManagementPage {
 
 	public hasCaseHistory(value: string): this {
 		Logger.log(`Has case history ${value}`);
-		cy.getByTestId("case-history").should("contain.text", value);
+		this.getCaseHistory().should("contain.text", value);
 
 		return this;
 	}
@@ -446,7 +446,6 @@ class CaseManagementPage {
 		return this;
 	}
 
-	// has methods
 	public hasTrust(value: string): this {
 		Logger.log(`Has trust ${value}`);
 
@@ -455,7 +454,6 @@ class CaseManagementPage {
 		return this;
 	}
 
-	// has methods
 	public hasTrustContain(value: string): this {
 		Logger.log(`Has trust ${value}`);
 
@@ -528,7 +526,7 @@ class CaseManagementPage {
 	public hasCurrentStatus(value: string): this {
 		Logger.log(`Has status ${value}`);
 
-		cy.getByTestId(`status`).should("contain.text", value);
+		this.getCurrentStatus().should("contain.text", value);
 
 		return this;
 	}
@@ -536,7 +534,7 @@ class CaseManagementPage {
 	public hasCaseAim(value: string): this {
 		Logger.log(`Has caseAim ${value}`);
 
-		cy.getByTestId(`case-aim`).should("contain.text", value);
+		this.getCaseAim().should("contain.text", value);
 
 		return this;
 	}
@@ -544,7 +542,7 @@ class CaseManagementPage {
 	public hasDeEscalationPoint(value: string): this {
 		Logger.log(`Has deEscalationPoint ${value}`);
 
-		cy.getByTestId(`de-escalation-point`).should("contain.text", value);
+		this.getDeEscalationPoint().should("contain.text", value);
 
 		return this;
 	}
@@ -552,37 +550,37 @@ class CaseManagementPage {
 	public hasNextSteps(value: string): this {
 		Logger.log(`Has nextSteps ${value}`);
 
-		cy.getByTestId(`next-steps`).should("contain.text", value);
+		this.getNextSteps().should("contain.text", value);
 
 		return this;
 	}
 
 	public hasEmptyCurrentStatus(): this {
-		this.hasCurrentStatus("");
+		this.getCurrentStatus().should("be.empty");
 
 		return this;
 	}
 
 	public hasEmptyCaseAim(): this {
-		this.hasCaseAim("");
+		this.getCaseAim().should("be.be.empty");
 
 		return this;
 	}
 
 	public hasEmptyDeEscalationPoint(): this {
-		this.hasDeEscalationPoint("");
+		this.getDeEscalationPoint().should("be.empty");
 
 		return this;
 	}
 
 	public hasEmptyNextSteps(): this {
-		this.hasNextSteps("");
+		this.getNextSteps().should("be.empty");
 
 		return this;
 	}
 
 	public hasEmptyCaseHistory(): this {
-		this.hasCaseHistory("");
+		this.getCaseHistory().should("be.empty");
 
 		return this;
 	}
@@ -592,6 +590,26 @@ class CaseManagementPage {
 		cy.getByTestId("case-narritive-fields-container").should("not.exist");
 
 		return this;
+	}
+
+	private getCurrentStatus() {
+		return cy.getByTestId(`status`);
+	}
+
+	private getCaseAim() {
+		return cy.getByTestId(`case-aim`);
+	}
+
+	private getDeEscalationPoint() {
+		return cy.getByTestId(`de-escalation-point`);
+	}
+
+	private getNextSteps() {
+		return cy.getByTestId(`next-steps`);
+	}
+
+	private getCaseHistory() {
+		return cy.getByTestId("case-history");
 	}
 }
 

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editCaseAimPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editCaseAimPage.ts
@@ -30,6 +30,12 @@ export default class EditCaseAimPage {
     {
         Logger.log(`With Case aim ${value}`);
 
+        if (value.length == 0)
+        {
+            cy.getByTestId(`case-aim`).clear({ force: true });
+            return this;
+        }
+
         cy.getByTestId(`case-aim`).clear({ force: true }).type(value);
 
         return this;

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editCaseHistoryPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editCaseHistoryPage.ts
@@ -30,6 +30,12 @@ export default class EditCaseHistoryPage {
     {
         Logger.log(`With Case history ${value}`);
 
+        if (value.length == 0)
+        {
+            cy.getByTestId(`case-history`).clear({ force: true });
+            return this;
+        }
+
         cy.getByTestId(`case-history`).clear({ force: true }).type(value);
 
         return this;

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editCurrentStatusPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editCurrentStatusPage.ts
@@ -30,6 +30,12 @@ export default class EditCurrentStatusPage {
     {
         Logger.log(`With Current status ${value}`);
 
+        if (value.length == 0)
+        {
+            cy.getByTestId(`current-status`).clear({ force: true });
+            return this;
+        }
+
         cy.getByTestId(`current-status`).clear({ force: true }).type(value);
 
         return this;

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editDeescalationPointPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editDeescalationPointPage.ts
@@ -30,6 +30,12 @@ export default class EditDeEscalationPointPage {
     {
         Logger.log(`With Deescalation point ${value}`);
 
+        if (value.length == 0)
+        {
+            cy.getByTestId(`de-escalation-point`).clear({ force: true });
+            return this;
+        }
+
         cy.getByTestId(`de-escalation-point`).clear().type(value);
 
         return this;

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editNextStepsPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/createCase/editNextStepsPage.ts
@@ -30,6 +30,12 @@ export default class EditNextStepsPage {
     {
         Logger.log(`With Deescalation point ${value}`);
 
+        if (value.length == 0)
+        {
+            cy.getByTestId(`next-steps`).clear({ force: true });
+            return this;
+        }
+
         cy.getByTestId(`next-steps`).clear({ force: true }).type(value);
 
         return this;

--- a/ConcernsCaseWork/ConcernsCaseWork/Models/TextAreaUiComponent.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Models/TextAreaUiComponent.cs
@@ -11,6 +11,7 @@ public record TextAreaUiComponent(string ElementRootId, string Name, string Head
 
 public class ValidateableString : IValidatableObject
 {
+	[DisplayFormat(ConvertEmptyStringToNull = false)]
 	public string StringContents { get; set; }
 	
 	public int MaxLength { get; set; }


### PR DESCRIPTION
**What is the change?**

fixed issue where user could not remove narrative field text after it had been set
when submitting a value from the text area component, set it to empty rather than null

**Why do we need the change?**

users set narrative fields to empty, on occasion when they are closing off a case or steps on a case

**What is the impact?**

wide reaching as it has been done on the component, but all the tests are passing, and its a very small change

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/150272


