### PR TITLE
147783: move close concern to the case management page

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
@@ -54,6 +54,7 @@ describe("Testing permissions on cases and case actions", () => {
         caseMangementPage
             .showAllConcernDetails()
             .canEditConcern()
+            .canCloseConcern()
             .canEditRiskToTrust()
             .canEditDirectionOfTravel()
             .canEditManagedBy()
@@ -72,6 +73,7 @@ describe("Testing permissions on cases and case actions", () => {
         caseMangementPage
             .showAllConcernDetails()
             .cannotEditConcern()
+            .cannotCloseConcern()
             .cannotEditRiskToTrust()
             .cannotEditDirectionOfTravel()
             .cannotEditManagedBy()

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/case-permissions.cy.ts
@@ -53,38 +53,14 @@ describe("Testing permissions on cases and case actions", () => {
         Logger.log("Check that we can edit if we did create the case");
         caseMangementPage
             .showAllConcernDetails()
-            .canEditConcern()
-            .canCloseConcern()
-            .canEditRiskToTrust()
-            .canEditDirectionOfTravel()
-            .canEditManagedBy()
-            .canEditCaseOwner()
-            .canEditIssue()
-            .canEditCurrentStatus()
-            .canEditCaseAim()
-            .canEditDeEscalationPoint()
-            .canEditNextSteps()
-            .canEditCaseHistory()
-            .canAddCaseAction();
+            .canEditCase();
 
         Logger.log("Check that we cannot edit if we did not create the case");
         updateCaseOwner(caseId);
 
         caseMangementPage
             .showAllConcernDetails()
-            .cannotEditConcern()
-            .cannotCloseConcern()
-            .cannotEditRiskToTrust()
-            .cannotEditDirectionOfTravel()
-            .cannotEditManagedBy()
-            .cannotEditCaseOwner()
-            .cannotEditIssue()
-            .cannotEditCurrentStatus()
-            .cannotEditCaseAim()
-            .cannotEditDeEscalactionPoint()
-            .cannotEditNextSteps()
-            .cannotEditCaseHistory()
-            .cannotAddCaseAction();
+            .cannotEditCase();
     });
 
     it("Should not allow the user to edit an srma that they did not create", () =>

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case-regions-group.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case-regions-group.cy.ts
@@ -165,15 +165,11 @@ describe("Creating a case", () => {
             .cancel();
     
             Logger.log("Close down the concerns");
-            caseManagementPage
-                .getEditConcern().first().click();
-            
-            editConcernPage.closeConcern().confirmCloseConcern();
+            caseManagementPage.closeConcern();
+            editConcernPage.confirmCloseConcern();
     
-            caseManagementPage
-            .getEditConcern().first().click();
-        
-            editConcernPage.closeConcern().confirmCloseConcern();
+            caseManagementPage.closeConcern();
+            editConcernPage.confirmCloseConcern();
     
             caseManagementPage.getCaseIDText()
             .then((caseId =>

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/smoke.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/smoke.cy.ts
@@ -439,8 +439,7 @@ describe("Smoke - Testing closing of cases when there are case actions and conce
 
 	function closeConcern() {
 		Logger.log("Closing concern");
-		CaseManagementPage.editConcern();
-		EditConcernPage.closeConcern();
+		CaseManagementPage.closeConcern();
 
 		Logger.log("Checking accessibility on closing concern");
 		cy.excuteAccessibilityTests();

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -56,6 +56,43 @@ class CaseManagementPage {
 		return this;
 	}
 
+	public canEditCase(): this {
+		this.getEditConcern();
+		this.getCloseConcern();
+		this.getEditRiskToTrust();
+		this.getEditDirectionOfTravel();
+		this.getManagedBy();
+		this.getEditCaseOwner();
+		this.getEditIssue();
+		this.getEditCurrentStatus();
+		this.getEditCaseAim();
+		this.getEditDeEscalationPoint();
+		this.getEditNextSteps();
+		this.getEditCaseHistory();
+		this.getAddCaseAction();
+
+		return this;
+	}
+
+	public cannotEditCase(): this {
+
+		this.getEditConcern().should("not.exist");
+		this.getCloseConcern().should("not.exist");
+		this.getEditRiskToTrust().should("not.exist");
+		this.getEditDirectionOfTravel().should("not.exist");
+		this.getManagedBy().should("not.exist");
+		this.getEditCaseOwner().should("not.exist");
+		this.getEditIssue().should("not.exist");
+		this.getEditCurrentStatus().should("not.exist");
+		this.getEditCaseAim().should("not.exist");
+		this.getEditDeEscalationPoint().should("not.exist");
+		this.getEditNextSteps().should("not.exist");
+		this.getEditCaseHistory().should("not.exist");
+		this.getAddCaseAction().should("not.exist");
+
+		return this;
+	}
+
 	public editConcern(): this {
 		Logger.log("Editing the concern");
 		this.getEditConcern().click();
@@ -63,32 +100,9 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public canEditConcern(): this {
-		Logger.log("Can edit the concern");
-		this.getEditConcern();
-
-		return this;
-	}
-	public cannotEditConcern(): this {
-		Logger.log("Cannot edit the concern");
-		this.getEditConcern().should("not.exist");
-
-		return this;
-	}
-
 	public closeConcern(): this {
 		this.getCloseConcern().first().click();
 
-		return this;
-	}
-
-	public canCloseConcern(): this {
-		this.getCloseConcern();
-		return this;
-	}
-
-	public cannotCloseConcern(): this {
-		this.getCloseConcern().should("not.exist");
 		return this;
 	}
 
@@ -111,20 +125,6 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public canEditRiskToTrust(): this {
-		Logger.log("Can edit the risk to trust");
-		this.getEditRiskToTrust();
-
-		return this;
-	}
-
-	public cannotEditRiskToTrust(): this {
-		Logger.log("Cannot edit the risk to trust");
-		this.getEditRiskToTrust().should("not.exist");
-
-		return this;
-	}
-
 	public editDirectionOfTravel(): this {
 		Logger.log("Editing the direction of travel");
 		this.getEditDirectionOfTravel().click();
@@ -132,37 +132,9 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public canEditDirectionOfTravel(): this {
-		Logger.log("Can edit the direction of travel");
-		this.getEditDirectionOfTravel();
-
-		return this;
-	}
-
-	public cannotEditDirectionOfTravel(): this {
-		Logger.log("Cannot edit the direction of travel");
-		this.getEditDirectionOfTravel().should("not.exist");
-
-		return this;
-	}
-
 	public editManagedBy(): this {
 		Logger.log("Editing managed by");
-		this.getEditTerritory().click();
-
-		return this;
-	}
-
-	public canEditManagedBy(): this {
-		Logger.log("Can edit managed by");
-		this.getEditTerritory();
-
-		return this;
-	}
-
-	public cannotEditManagedBy(): this {
-		Logger.log("Cannot edit managed by");
-		this.getEditTerritory().should("not.exist");
+		this.getManagedBy().click();
 
 		return this;
 	}
@@ -182,21 +154,6 @@ class CaseManagementPage {
 		Logger.log("Editing case owner");
 
 		this.getEditCaseOwner().click();
-
-		return this;
-	}
-
-	public canEditCaseOwner(): this {
-		Logger.log("Can edit case owner");
-
-		this.getEditCaseOwner();
-
-		return this;
-	}
-
-	public cannotEditCaseOwner(): this {
-		Logger.log("Cannot edit case owner");
-		this.getEditCaseOwner().should("not.exist");
 
 		return this;
 	}
@@ -227,37 +184,9 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public canEditIssue() {
-		Logger.log("Can edit the issue");
-		this.getEditIssue();
-
-		return this;
-	}
-
-	public cannotEditIssue() {
-		Logger.log("Cannot edit the issue");
-		this.getEditIssue().should("not.exist");
-
-		return this;
-	}
-
 	public editCurrentStatus(): this {
 		Logger.log("Editing the current status");
 		this.getEditCurrentStatus().click();
-
-		return this;
-	}
-
-	public canEditCurrentStatus() {
-		Logger.log("Can edit the current status");
-		this.getEditCurrentStatus();
-
-		return this;
-	}
-
-	public cannotEditCurrentStatus() {
-		Logger.log("Cannot edit the current status");
-		this.getEditCurrentStatus().should("not.exist");
 
 		return this;
 	}
@@ -269,37 +198,9 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public canEditCaseAim() {
-		Logger.log("Can edit the case aim");
-		this.getEditCaseAim();
-
-		return this;
-	}
-
-	public cannotEditCaseAim() {
-		Logger.log("Cannot edit the case aim");
-		this.getEditCaseAim().should("not.exist");
-
-		return this;
-	}
-
 	public editDeEscalationPoint(): this {
 		Logger.log("Editing the de-escalation point");
 		this.getEditDeEscalationPoint().click();
-
-		return this;
-	}
-
-	public canEditDeEscalationPoint() {
-		Logger.log("Can edit the de-escalation point");
-		this.getEditDeEscalationPoint();
-
-		return this;
-	}
-
-	public cannotEditDeEscalactionPoint() {
-		Logger.log("Cannot edit the de-escalation point");
-		this.getEditDeEscalationPoint().should("not.exist");
 
 		return this;
 	}
@@ -311,37 +212,9 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public canEditNextSteps() {
-		Logger.log("Can edit the next steps");
-		this.getEditNextSteps();
-
-		return this;
-	}
-
-	public cannotEditNextSteps() {
-		Logger.log("Cannot edit the next steps");
-		this.getEditNextSteps().should("not.exist");
-
-		return this;
-	}
-
 	public editCaseHistory(): this {
 		Logger.log("Editing the case history");
 		this.getEditCaseHistory().click();
-
-		return this;
-	}
-
-	public canEditCaseHistory() {
-		Logger.log("Can edit the case history");
-		this.getEditCaseHistory();
-
-		return this;
-	}
-
-	public cannotEditCaseHistory() {
-		Logger.log("Cannot edit the case history");
-		this.getEditCaseHistory().should("not.exist");
 
 		return this;
 	}
@@ -376,20 +249,6 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public canAddCaseAction() {
-		Logger.log("Can add case action");
-		this.getAddCaseAction();
-
-		return this;
-	}
-
-	public cannotAddCaseAction() {
-		Logger.log("Cannot add case action");
-		this.getAddCaseAction().should("not.exist");
-
-		return this;
-	}
-
 	private getEditConcern() {
 		return cy.getByTestId("edit-concern");
 	}
@@ -406,7 +265,7 @@ class CaseManagementPage {
 		return cy.getByTestId("edit-direction-of-travel");
 	}
 
-	private getEditTerritory() {
+	private getManagedBy() {
 		return cy.getByTestId("edit_Button_SFSO");
 	}
 

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/caseMangementPage.ts
@@ -76,6 +76,22 @@ class CaseManagementPage {
 		return this;
 	}
 
+	public closeConcern(): this {
+		this.getCloseConcern().first().click();
+
+		return this;
+	}
+
+	public canCloseConcern(): this {
+		this.getCloseConcern();
+		return this;
+	}
+
+	public cannotCloseConcern(): this {
+		this.getCloseConcern().should("not.exist");
+		return this;
+	}
+
 	public addAnotherConcern(): this {
 		Logger.log("Adding another concern");
 		cy.getByTestId("add-additional-concern").click();
@@ -374,8 +390,12 @@ class CaseManagementPage {
 		return this;
 	}
 
-	public getEditConcern() {
+	private getEditConcern() {
 		return cy.getByTestId("edit-concern");
+	}
+
+	private getCloseConcern() {
+		return cy.getByTestId("close-concern");
 	}
 
 	private getEditRiskToTrust() {

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/editConcernPage.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/pages/editConcernPage.ts
@@ -1,11 +1,4 @@
 class EditConcernPage {
-    closeConcern()
-    {
-        cy.getByTestId("close-concern-button").click();
-
-        return this;
-    }
-
     confirmCloseConcern()
     {
         cy.getByTestId("close-concern-button").click();

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Closure.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Closure.cshtml
@@ -8,11 +8,6 @@
     var nonce = HttpContext.GetNonce();
     var backLink = $"/case/{Model.CaseId}/management";
 }
-@section BeforeMain {
-    <div class="govuk-width-container">
-        <back-link url="@backLink"></back-link>
-    </div>
-}
 
 <div class="govuk-width-container">
     <partial name="_BannerError" />
@@ -28,17 +23,30 @@
             {
                 <partial name="_ValidationErrors" />
 
-                <h1 class="govuk-heading-l"> Close case @Model.CaseId</h1>
-                <h2 class="govuk-heading-s">@Model.TrustDetailsModel.GiasData.GroupNameTitle</h2>
+                <h1 class="govuk-heading-l">
+                    <span class="govuk-caption-m" data-testid="heading-case-id">Case ID @Model.CaseId</span>
+                    Close case
+                </h1>
+
+                <div class="govuk-warning-text">
+                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong class="govuk-warning-text__text">
+                        <span class="govuk-warning-text__assistive">Warning</span>
+                        Cases cannot be reopened after they have been closed.
+                    </strong>
+                </div>
 
                 <form asp-page-handler="closeCase" method="post" id="close-case-form" novalidate>
 
                     <partial name="Components/_TextArea" model="Model.RationaleForClosure" />
 
-                    <!--Close case-->
-                    <button data-prevent-double-click="true" class="govuk-button" id="close-case-button" data-module="govuk-button">
-                        Close case
-                    </button>
+                    <div class="govuk-button-group">
+                        <!--Close case-->
+                        <button data-prevent-double-click="true" class="govuk-button" id="close-case-button" data-module="govuk-button">
+                            Close case
+                        </button>
+                        <partial name="_Cancel" />
+                    </div>
 
                 </form>
             }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Concern/Closure.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Concern/Closure.cshtml
@@ -13,7 +13,7 @@
         <div class="govuk-grid-column">
 
             <h1 class="govuk-heading-l">
-                <span class="govuk-caption-l">Case ID @Model.CaseModel.Urn</span>
+                <span class="govuk-caption-m">Case ID @Model.CaseModel.Urn</span>
                 Close concern
             </h1>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Concern/EditRating.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Concern/EditRating.cshtml
@@ -54,9 +54,6 @@
 
                 <h2 class="govuk-heading-m govuk-!-margin-top-6">
                     Change concern risk rating
-                    <a href="@Request.Path/closure" data-testid="close-concern-button" role="button" class="govuk-button govuk-button--secondary govuk-!-font-weight-bold float__right" data-module="govuk-button">
-                        Close concern
-                    </a>
                 </h2>
 
 				<div tabindex="-1" role="group" id="errorSummary" class="govuk-error-summary moj-hidden" aria-labelledby="error-summary-title" data-module="error-summary"></div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml
@@ -200,6 +200,8 @@
                                                                 <div class="govuk-!-padding-bottom-1">
                                                                     @if (Model.IsEditableCase)
                                                                     {
+                                                                        <a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating/closure" aria-label="Close @concern.GetConcernTypeName() rating" data-testid="close-concern">Close</a>
+                                                                        <span class="govuk-divider">|</span>
                                                                         <a class="govuk-link govuk-link-no-visited-state" href="@Request.Path/record/@concern.Id/edit_rating" aria-label="Change @concern.GetConcernTypeName() rating" data-testid="edit-concern">Change</a>
                                                                     }
                                                                 </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
+++ b/ConcernsCaseWork/ConcernsCaseWork/wwwroot/src/css/_extra.scss
@@ -1735,6 +1735,10 @@ label.govuk-label .govuk-tag {
   color: #505a5f;
 }
 
+.govuk-divider {
+	color: #b1b4b6
+}
+
 /* ==========================================================================
    #Environment Banners
    ========================================================================== */
@@ -1813,6 +1817,7 @@ dt,
 dd,
 tr,
 caption,
-details {
+details,
+strong {
 	font-family: BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif !important;
 }


### PR DESCRIPTION
**What is the change?**

move close concern to the case management page

this is to improve the user experience when closing a case

**Why do we need the change?**

a number of users were unable to close a case, because it was hidden behind the edit page

**What is the impact?**

just moved the function to the case management page

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/147783
