### PR TITLE
Split username and password in github secrets in ACR action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Azure Container Registry login
         uses: docker/login-action@v3
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          username: ${{ secrets.AZURE_ACR_SP_USERNAME }}
+          password: ${{ secrets.AZURE_ACR_SP_PASSWORD }}
           registry: ${{ secrets.AZURE_NEW_ACR_URL }}
 
       - name: Get IP Address


### PR DESCRIPTION


**What is the change?**
Creds isn't a valid name therefore, will need to use username and password. Also, had to split out the secrets for SP as it cannot read the JSON value.
**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**
