### PR TITLE
Set HTTP User Agent

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Extensions/StartupExtension.cs
@@ -118,6 +118,7 @@ namespace ConcernsCaseWork.Extensions
 				client.BaseAddress = new Uri(tramsApiEndpoint);
 				client.DefaultRequestHeaders.Add("ApiKey", tramsApiKey);
 				client.DefaultRequestHeaders.Add("ContentType", MediaTypeNames.Application.Json);
+				client.DefaultRequestHeaders.Add("User-Agent", "RecordConcernsSupportTrusts/1.0");
 			});
 		}
 


### PR DESCRIPTION
Set a custom User-Agent HTTP Header so that traffic can be segmented when running reports against the downstream APIs