### PR TITLE
Display closed concerns with correct status

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Redis/Models/CreateRecordModel.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Redis/Models/CreateRecordModel.cs
@@ -12,12 +12,18 @@ namespace ConcernsCaseWork.Redis.Models
 		public long TypeId { get; set; }
 
 		public long RatingId { get; set; }
-		
+
+		public long StatusId { get; set; }
+
 		public long MeansOfReferralId { get; set; }
 
 		public string GetConcernTypeName()
 		{
 			return ((ConcernType?)TypeId)?.Description();
+		}
+		public bool IsClosed()
+		{
+			return StatusId == (long)ConcernStatus.Close;
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Mappers/RecordMapping.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Mappers/RecordMapping.cs
@@ -68,7 +68,8 @@ namespace ConcernsCaseWork.Mappers
 				{
 					CaseUrn = recordDto.CaseUrn,
 					TypeId = recordDto.TypeId,
-					RatingId = recordDto.RatingId
+					RatingId = recordDto.RatingId,
+					StatusId = recordDto.StatusId
 				};
 
 				return createRecordModel;

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_RecordsSummary.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_RecordsSummary.cshtml
@@ -14,7 +14,16 @@
                             @concern.GetConcernTypeName()
                         </span>
                         <div class="govuk-!-display-inline govuk-label-wrapper govuk-grid-column-two-third" data-testid="concern-risk-rating">
-                            <partial name="_RatingLabel" model="@concern.RatingId" />
+                            @if (concern.IsClosed())
+                            {
+                                <span class="govuk-tag ragtag ragtag__grey">
+                                    Closed
+                                </span>
+                            }
+                            else
+                            {
+                                <partial name="_RatingLabel" model="@concern.RatingId" />
+                            } 
                         </div>
                     </div>
                 }


### PR DESCRIPTION
**What is the change?**
Displaying closed concerns with correct status on to the `Add Concern` page
**Why do we need the change?**
Concerns should display the correct status
**What is the impact?**

**Azure DevOps Ticket**
https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/193980