### PR TITLE
Fix redis connection for unit tests

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -33,7 +33,7 @@ jobs:
             --env GITHUB_ACTIONS=true \
             --env CI=true \
             --name redis \
-            redis:alpine \
+            redis:6-alpine \
             redis-server --requirepass "my-secureP@SS1"
 
       - name: Checkout repository


### PR DESCRIPTION
**What is the change?**
Corrects the connection string used by the Redis multiplexer during `dotnet test` in the dotnet CI workflow.

**Why do we need the change?**
Tests were failing because there was an invalid connection string

**What is the impact?**
None

**Azure DevOps Ticket**
N/A