### PR TITLE
Enabled retry logic on failure to connect to SQL database

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DatabaseConfigurationExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API/StartupConfiguration/DatabaseConfigurationExtensions.cs
@@ -7,8 +7,9 @@ public static class DatabaseConfigurationExtensions
 	public static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration configuration)
 	{
 		var connectionString = configuration.GetConnectionString("DefaultConnection");
+		var isEnabled = configuration.GetValue("ConcernsCasework:EnableSQLRetryOnFailure", false);
 		services.AddDbContext<ConcernsDbContext>(options =>
-			options.UseConcernsSqlServer(connectionString)
+			options.UseConcernsSqlServer(connectionString, isEnabled)
 		);
 		services.AddHealthChecks()
 			.AddDbContextCheck<ConcernsDbContext>("Concerns Database");

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/DbContextExtensionsTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/DbContextExtensionsTests.cs
@@ -1,0 +1,56 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcernsCaseWork.Data.Tests
+{
+	[TestFixture]
+    public class DbContextOptionsBuilderExtensionsTests
+    {
+        private DatabaseTestFixture _fixture;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = new DatabaseTestFixture();
+        }
+
+        [Test]
+        public void UseConcernsSqlServer_ShouldConfigureSqlServerWithoutRetry()
+        {
+            // Arrange  
+            var builder = new DbContextOptionsBuilder();
+            var connectionString = _fixture.CreateContext().Database.GetDbConnection().ConnectionString;
+
+            // Act  
+            builder.UseConcernsSqlServer(connectionString, enableRetryOnFailure: false);
+
+            // Assert  
+            var options = builder.Options;
+			AssertExtensions(options, false);
+		}
+
+        [Test]
+        public void UseConcernsSqlServer_ShouldConfigureSqlServerWithRetry()
+        {
+			// Arrange  
+			var builder = new DbContextOptionsBuilder();
+			var connectionString = _fixture.CreateContext().Database.GetDbConnection().ConnectionString;
+
+			// Act  
+			builder.UseConcernsSqlServer(connectionString, enableRetryOnFailure: true);
+
+			// Assert  
+			var options = builder.Options;
+			AssertExtensions(options, true);
+		}
+
+		private static void AssertExtensions(DbContextOptions options, bool expectedEnableRetryOnFailure)
+		{
+			options.Should().NotBeNull();
+			var sqlServerOptionExtension = options.Extensions.SingleOrDefault(e => e.GetType().Name == "SqlServerOptionsExtension");
+			sqlServerOptionExtension.Should().NotBeNull();
+			sqlServerOptionExtension!.GetType().GetProperty("MigrationsHistoryTable")?.GetValue(sqlServerOptionExtension).Should().Be("__EfMigrationsHistory");
+			sqlServerOptionExtension.GetType().GetProperty("EnableRetryOnFailure")?.GetValue(sqlServerOptionExtension).Should().Be(expectedEnableRetryOnFailure);
+		} 
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/DbContextExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/DbContextExtensions.cs
@@ -4,11 +4,21 @@ namespace ConcernsCaseWork.Data;
 
 public static class DbContextExtensions
 {
-	public static DbContextOptionsBuilder UseConcernsSqlServer(this DbContextOptionsBuilder optionsBuilder, string connectionString)
+	public static DbContextOptionsBuilder UseConcernsSqlServer(this DbContextOptionsBuilder optionsBuilder, string connectionString, bool enableRetryOnFailure = false)
 	{
 		optionsBuilder.UseSqlServer(
 			connectionString,
-			opt => opt.MigrationsHistoryTable("__EfMigrationsHistory", "concerns"));
+			opt =>
+			{
+				opt.MigrationsHistoryTable("__EfMigrationsHistory", "concerns");
+				if (enableRetryOnFailure)
+				{
+					opt.EnableRetryOnFailure(
+						maxRetryCount: 2,
+						maxRetryDelay: TimeSpan.FromSeconds(5),
+						errorNumbersToAdd: null);
+				}
+			});
 		return optionsBuilder;
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
@@ -33,7 +33,8 @@
 		"ApiKey": "app-key",
 		"ReleaseTag": "insert-a-unique-release-tag-here-during-CD",
 		"CaseArchivePassword": "insert-case-archive-password",
-		"NotificationBannerMessage": ""
+		"NotificationBannerMessage": "",
+		"EnableSQLRetryOnFailure": "true"
 	},
 	"ConcernsCaseworkApi": {
 		"ApiKeys": "app-key"


### PR DESCRIPTION
**What is the change?**
Added database retry logic for stopping to generate db timeout healthcheck alert
**Why do we need the change?**
Transient network issues that occasionally cause the healthcheck to report a timeout
**What is the impact?**
No impact on user
**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/225653
