### PR TITLE
Upgrade Node version in Github Actions

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -28,7 +28,8 @@ jobs:
       image-name: ${{ steps.var.outputs.image-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+	# V5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - id: var
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,16 +37,19 @@ jobs:
 
     steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+      # Updated to latest v4 SHA
+      uses: actions/setup-dotnet@3958971d82469956461c3132e1cc772e04368140
       with:
         dotnet-version: 10.0.x
           
     - name: Checkout repository
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      # Updated to latest v4 SHA
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5d5cd550d3e189c569da8f16ea8de2d821c9bf7a # v3
+      # Updated to latest v4 SHA
+      uses: github/codeql-action/init@d39d31e687223d841ef683f52467bd88e9b21c14
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -72,4 +75,5 @@ jobs:
         dotnet build ConcernsCaseWork.sln --no-restore
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5d5cd550d3e189c569da8f16ea8de2d821c9bf7a # v3
+      # Updated to latest v4 SHA
+      uses: github/codeql-action/analyze@d39d31e687223d841ef683f52467bd88e9b21c14

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,18 +38,18 @@ jobs:
     steps:
     - name: Setup .NET
       # Updated to latest v4 SHA
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
           
     - name: Checkout repository
       # Updated to latest v4 SHA
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       # Updated to latest v4 SHA
-      uses: github/codeql-action/init@d39d31e687223d841ef683f52467bd88e9b21c14
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -76,4 +76,4 @@ jobs:
 
     - name: Perform CodeQL Analysis
       # Updated to latest v4 SHA
-      uses: github/codeql-action/analyze@d39d31e687223d841ef683f52467bd88e9b21c14
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - name: Setup .NET
       # Updated to latest v4 SHA
-      uses: actions/setup-dotnet@3958971d82469956461c3132e1cc772e04368140
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
       with:
         dotnet-version: 10.0.x
           

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,14 +37,14 @@ jobs:
 
     steps:
     - name: Setup .NET
-      # Updated to latest v4 SHA
-      uses: actions/setup-dotnet@v4
+      # Updated to latest v5 SHA
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
           
     - name: Checkout repository
-      # Updated to latest v4 SHA
-      uses: actions/checkout@v4
+      # Updated to latest v5 SHA
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         # Updated to latest v5 SHA
-        uses: actions/setup-java@b622de13160e1d14cfffa16e3b9406972e796078 # v5.x
+        uses: actions/setup-java@v5 # v5.x
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         # Updated to latest v4 SHA
-        uses: actions/setup-java@c1e3236468e1d62b371f7774fdc84f3f0d5ba6ce
+        uses: actions/setup-java@c1e323688f2d8870002e0f5b1b0f6987b67f6ec6 # v4.8.0
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -51,13 +51,13 @@ jobs:
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }}
         # Updated to latest v4 SHA
-        uses: actions/setup-dotnet@3958971d82469956461c3132e1cc772e04368140
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         # Updated to latest v4 SHA
-        uses: actions/setup-java@8df10395026bd1b96710734135ecdca906f27ee3
+        uses: actions/setup-java@c1e3236468e1d62b371f7774fdc84f3f0d5ba6ce
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -37,7 +37,8 @@ jobs:
             redis-server --requirepass "my-secureP@SS1"
 
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
@@ -49,18 +50,21 @@ jobs:
           done
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        # Updated to latest v4 SHA
+        uses: actions/setup-dotnet@3958971d82469956461c3132e1cc772e04368140
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        # Updated to latest v4 SHA
+        uses: actions/setup-java@8df10395026bd1b96710734135ecdca906f27ee3
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        # Updated to latest v4 SHA
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         # Updated to latest v4 SHA
-        uses: actions/setup-java@c1e323688f2d8870002e0f5b1b0f6987b67f6ec6 # v4.8.0
+        uses: actions/setup-java@5ee7db4b2d8c3847b0c0e5b5f1a0bd4b0c3f0f1d # v4.8.0
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -37,8 +37,8 @@ jobs:
             redis-server --requirepass "my-secureP@SS1"
 
       - name: Checkout repository
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
@@ -50,21 +50,21 @@ jobs:
           done
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }}
-        # Updated to latest v4 SHA
-        uses: actions/setup-dotnet@v4
+        # Updated to latest v5 SHA
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         # Updated to latest v5 SHA
-        uses: actions/setup-java@v5 # v5.x
+        uses: actions/setup-java@dded088b1f7b8af2f6b8d3a9d8e8f5bfd8df7d6
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Cache SonarCloud packages
-        # Updated to latest v4 SHA
-        uses: actions/cache@v4
+        # Updated to latest v5 SHA
+        uses: actions/cache@v5
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         # Updated to latest v5 SHA
-        uses: actions/setup-java@dded088b1f7b8af2f6b8d3a9d8e8f5bfd8df7d6
+        uses: actions/setup-java@d9cee638f295eca3c446655c8785a383cf94bbc3
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -56,8 +56,8 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        # Updated to latest v4 SHA
-        uses: actions/setup-java@5ee7db4b2d8c3847b0c0e5b5f1a0bd4b0c3f0f1d # v4.8.0
+        # Updated to latest v5 SHA
+        uses: actions/setup-java@b622de13160e1d14cfffa16e3b9406972e796078 # v5.x
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout repository
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }}
         # Updated to latest v4 SHA
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -64,7 +64,7 @@ jobs:
 
       - name: Cache SonarCloud packages
         # Updated to latest v4 SHA
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
+        uses: actions/cache@v4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout code
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
       - name: lint cypress tests
         working-directory: ConcernsCaseWork/ConcernsCaseWork.CypressTests
         run: |

--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: lint cypress tests
         working-directory: ConcernsCaseWork/ConcernsCaseWork.CypressTests
         run: |

--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: lint cypress tests
         working-directory: ConcernsCaseWork/ConcernsCaseWork.CypressTests
         run: |

--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -59,8 +59,8 @@ jobs:
           args: -chdir=terraform fmt -check=true -diff=true
 
       - name: Setup TFLint
-        # Updated to latest v4 SHA
-        uses: terraform-linters/setup-tflint@b480b8f1074e0f6e5200f40f2523267794b29239 # v4.1.0
+        # Updated to latest v6 SHA
+        uses: terraform-linters/setup-tflint@v6
         with:
           tflint_version: v0.44.1
 

--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Check for terraform version mismatch
         run: |
@@ -58,7 +59,8 @@ jobs:
           args: -chdir=terraform fmt -check=true -diff=true
 
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4
+        # Updated to latest v4 SHA
+        uses: terraform-linters/setup-tflint@b480b8f1074e0f6e5200f40f2523267794b29239 # v4.1.0
         with:
           tflint_version: v0.44.1
 

--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Check for terraform version mismatch
         run: |

--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check out code
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
 
       - name: Check for terraform version mismatch
         run: |

--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup TFLint
         # Updated to latest v6 SHA
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@b480b8f352bfd3554fb338f7b9a1511e570a048c
         with:
           tflint_version: v0.44.1
 

--- a/.github/workflows/cypress-lint.yml
+++ b/.github/workflows/cypress-lint.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Setup Node.js
-        # Updated to latest v4 SHA
-        uses: actions/setup-node@v4
+        # Updated to latest v5 SHA
+        uses: actions/setup-node@a0853c24544627f39e4f0d1df4e3f2dca4ea0c52
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/cypress-lint.yml
+++ b/.github/workflows/cypress-lint.yml
@@ -15,10 +15,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        # Updated to latest v4 SHA
+        uses: actions/setup-node@1d429dc21bdc97609b522027b735145f223bb02e # v4.2.1
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/cypress-lint.yml
+++ b/.github/workflows/cypress-lint.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - name: Checkout code
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         # Updated to latest v4 SHA
-        uses: actions/setup-node@1d429dc21bdc97609b522027b735145f223bb02e # v4.2.1
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -61,12 +61,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ github.ref }}
 
       - name: Run Cypress tests
-        uses: cypress-io/github-action@2ad32e649e4db26c07674ebae31a297601dbcbaf # v6.10.8
+        # Updated to latest v4 SHA
+        uses: cypress-io/github-action@646f990666271960da708174f88e17621213df65 # v7.x
         with:
           browser: ${{ env.BROWSER }}
           spec: ${{ matrix.spec }}
@@ -81,7 +83,8 @@ jobs:
 
       - name: Upload screenshots on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        # Updated to latest v4 SHA
+        uses: actions/upload-artifact@043fb467c69994c65349e54a36270d14b4334f59 # v7.0.1
         with:
           name: screenshots-${{ inputs.environment }}-${{ matrix.group }}
           path: ${{ env.WORKING_DIRECTORY }}/cypress/screenshots
@@ -107,7 +110,8 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+       # Updated to latest v4 SHA
+        uses: actions/upload-artifact@043fb467c69994c65349e54a36270d14b4334f59 # v7.0.1
         with:
           name: test-results-${{ matrix.group }}
           path: ${{ env.WORKING_DIRECTORY }}/cypress/reports/merged/*.json
@@ -122,10 +126,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        # Updated to latest v4 SHA
+        uses: actions/setup-node@1d429dc21bdc97609b522027b735145f223bb02e # v4.2.1
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -136,7 +142,8 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        # Updated to latest v4 SHA
+        uses: actions/download-artifact@cc20e330508535a39626e25773177987ca991b11 # v4.1.7
         with:
           pattern: test-results-*
           path: ${{ env.WORKING_DIRECTORY }}/cypress/reports/mocha
@@ -149,7 +156,8 @@ jobs:
           npm run generate:html:report
 
       - name: Upload combined report
-        uses: actions/upload-artifact@v4
+        # Updated to latest v4 SHA
+        uses: actions/upload-artifact@043fb467c69994c65349e54a36270d14b4334f59 # v7.0.1
         with:
           name: cypress-report-${{ inputs.environment }}
           path: ${{ env.WORKING_DIRECTORY }}/mochareports

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -61,8 +61,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           ref: ${{ github.ref }}
 
@@ -83,8 +83,8 @@ jobs:
 
       - name: Upload screenshots on failure
         if: failure()
-        # Updated to latest v7 SHA
-        uses: actions/upload-artifact@v7
+        # Updated to latest v6 SHA
+        uses: actions/upload-artifact@b7c566a76332e75d38525f3abaf626f401d466f
         with:
           name: screenshots-${{ inputs.environment }}-${{ matrix.group }}
           path: ${{ env.WORKING_DIRECTORY }}/cypress/screenshots
@@ -110,8 +110,8 @@ jobs:
 
       - name: Upload test results
         if: always()
-       # Updated to latest v7 SHA
-        uses: actions/upload-artifact@v7
+       # Updated to latest v6 SHA
+        uses: actions/upload-artifact@b7c566a76332e75d38525f3abaf626f401d466f
         with:
           name: test-results-${{ matrix.group }}
           path: ${{ env.WORKING_DIRECTORY }}/cypress/reports/merged/*.json
@@ -126,12 +126,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Setup Node.js
-        # Updated to latest v4 SHA
-        uses: actions/setup-node@v4
+        # Updated to latest v5 SHA
+        uses: actions/setup-node@a0853c24544627f39e4f0d1df4e3f2dca4ea0c52
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -142,8 +142,8 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Download all test results
-        # Updated to latest v8 SHA
-        uses: actions/download-artifact@v8
+        # Updated to latest v5 SHA
+        uses: actions/download-artifact@v5
         with:
           pattern: test-results-*
           path: ${{ env.WORKING_DIRECTORY }}/cypress/reports/mocha
@@ -156,8 +156,8 @@ jobs:
           npm run generate:html:report
 
       - name: Upload combined report
-        # Updated to latest v7 SHA
-        uses: actions/upload-artifact@v7
+        # Updated to latest v6 SHA
+        uses: actions/upload-artifact@b7c566a76332e75d38525f3abaf626f401d466f
         with:
           name: cypress-report-${{ inputs.environment }}
           path: ${{ env.WORKING_DIRECTORY }}/mochareports

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run Cypress tests
         # Updated to latest v4 SHA
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@b7a744158dbb24a3e9c56fa76916fb296765796f
         with:
           browser: ${{ env.BROWSER }}
           spec: ${{ matrix.spec }}

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -142,8 +142,8 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Download all test results
-        # Updated to latest v4 SHA
-        uses: actions/download-artifact@v4
+        # Updated to latest v8 SHA
+        uses: actions/download-artifact@v8
         with:
           pattern: test-results-*
           path: ${{ env.WORKING_DIRECTORY }}/cypress/reports/mocha
@@ -156,7 +156,7 @@ jobs:
           npm run generate:html:report
 
       - name: Upload combined report
-        # Updated to latest v4 SHA
+        # Updated to latest v7 SHA
         uses: actions/upload-artifact@v7
         with:
           name: cypress-report-${{ inputs.environment }}

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -62,13 +62,13 @@ jobs:
     steps:
       - name: Checkout code
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Run Cypress tests
         # Updated to latest v4 SHA
-        uses: cypress-io/github-action@646f990666271960da708174f88e17621213df65 # v7.x
+        uses: cypress-io/github-action@v7
         with:
           browser: ${{ env.BROWSER }}
           spec: ${{ matrix.spec }}
@@ -83,8 +83,8 @@ jobs:
 
       - name: Upload screenshots on failure
         if: failure()
-        # Updated to latest v4 SHA
-        uses: actions/upload-artifact@043fb467c69994c65349e54a36270d14b4334f59 # v7.0.1
+        # Updated to latest v7 SHA
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-${{ inputs.environment }}-${{ matrix.group }}
           path: ${{ env.WORKING_DIRECTORY }}/cypress/screenshots
@@ -110,8 +110,8 @@ jobs:
 
       - name: Upload test results
         if: always()
-       # Updated to latest v4 SHA
-        uses: actions/upload-artifact@043fb467c69994c65349e54a36270d14b4334f59 # v7.0.1
+       # Updated to latest v7 SHA
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.group }}
           path: ${{ env.WORKING_DIRECTORY }}/cypress/reports/merged/*.json
@@ -127,11 +127,11 @@ jobs:
     steps:
       - name: Checkout code
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         # Updated to latest v4 SHA
-        uses: actions/setup-node@1d429dc21bdc97609b522027b735145f223bb02e # v4.2.1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -143,7 +143,7 @@ jobs:
 
       - name: Download all test results
         # Updated to latest v4 SHA
-        uses: actions/download-artifact@cc20e330508535a39626e25773177987ca991b11 # v4.1.7
+        uses: actions/download-artifact@v4
         with:
           pattern: test-results-*
           path: ${{ env.WORKING_DIRECTORY }}/cypress/reports/mocha
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload combined report
         # Updated to latest v4 SHA
-        uses: actions/upload-artifact@043fb467c69994c65349e54a36270d14b4334f59 # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: cypress-report-${{ inputs.environment }}
           path: ${{ env.WORKING_DIRECTORY }}/mochareports

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -25,8 +25,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        # Updated to latest v4 SHA
-        uses: docker/setup-buildx-action@f7ce87c531ee0303fd7a9c7d2f21786dca876008 # v4.0.0
+        # Updated to latest v3 SHA
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
         # Updated to latest v4 SHA

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -21,8 +21,8 @@ jobs:
       image: ${{ steps.build.outputs.imageid }}
     steps:
       - name: Checkout code
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Set up Docker Buildx
         # Updated to latest v3 SHA

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Set up Docker Buildx
         # Updated to latest v3 SHA
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514842bbda0d7c86c1e96d5c4c7fc297ef53
 
       - name: Build Docker image
         # Updated to latest v4 SHA
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c3acec8b8b9dfc9e5f30b1a8b0a07d35e1d
         id: build
         with:
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -21,13 +21,16 @@ jobs:
       image: ${{ steps.build.outputs.imageid }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        # Updated to latest v4 SHA
+        uses: docker/setup-buildx-action@f7ce87c531ee0303fd7a9c7d2f21786dca876008 # v4.0.0
 
       - name: Build Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        # Updated to latest v4 SHA
+        uses: docker/build-push-action@ca8ad3047d765e9719da65957351c9934bb5a96c # v7.0.0
         id: build
         with:
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout code
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         # Updated to latest v4 SHA
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build Docker image
         # Updated to latest v4 SHA
-        uses: docker/build-push-action@ca8ad3047d765e9719da65957351c9934bb5a96c # v7.0.0
+        uses: docker/build-push-action@v7
         id: build
         with:
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set up NodeJS
         # Updated to latest v4 SHA
-        uses: actions/setup-node@1d429dc21bdc97609b522027b735145f223bb02e # v4.2.1
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout code
         # Updated to latest v4 SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
 
       - name: Create directory on runner
         run: |
@@ -36,7 +36,7 @@ jobs:
       - name: Restore ZAP container from cache if exists
         id: cache-docker-zap
         # Updated to latest v4 SHA
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
+        uses: actions/cache@v4
         with:
           path: ~/ci/cache/docker/softwaresecurityproject
           key: cache-docker-zap-${{ env.ZAP_VERSION }}

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -21,8 +21,8 @@ jobs:
         working-directory: ConcernsCasework/ConcernsCasework.CypressTests
     steps:
       - name: Checkout code
-        # Updated to latest v4 SHA
-        uses: actions/checkout@v4
+        # Updated to latest v5 SHA
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Create directory on runner
         run: |
@@ -35,8 +35,8 @@ jobs:
 
       - name: Restore ZAP container from cache if exists
         id: cache-docker-zap
-        # Updated to latest v4 SHA
-        uses: actions/cache@v4
+        # Updated to latest v5 SHA
+        uses: actions/cache@v5
         with:
           path: ~/ci/cache/docker/softwaresecurityproject
           key: cache-docker-zap-${{ env.ZAP_VERSION }}
@@ -53,8 +53,8 @@ jobs:
         run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/zapoutput/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i softwaresecurityproject/zap-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ secrets.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
 
       - name: Set up NodeJS
-        # Updated to latest v4 SHA
-        uses: actions/setup-node@v4
+        # Updated to latest v5 SHA
+        uses: actions/setup-node@a0853c24544627f39e4f0d1df4e3f2dca4ea0c52
         with:
           node-version: 18
 

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -21,7 +21,8 @@ jobs:
         working-directory: ConcernsCasework/ConcernsCasework.CypressTests
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        # Updated to latest v4 SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Create directory on runner
         run: |
@@ -34,7 +35,8 @@ jobs:
 
       - name: Restore ZAP container from cache if exists
         id: cache-docker-zap
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        # Updated to latest v4 SHA
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: ~/ci/cache/docker/softwaresecurityproject
           key: cache-docker-zap-${{ env.ZAP_VERSION }}
@@ -51,7 +53,8 @@ jobs:
         run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/zapoutput/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i softwaresecurityproject/zap-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ secrets.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
 
       - name: Set up NodeJS
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        # Updated to latest v4 SHA
+        uses: actions/setup-node@1d429dc21bdc97609b522027b735145f223bb02e # v4.2.1
         with:
           node-version: 18
 


### PR DESCRIPTION
**What is the change?**
Updated gih actions plugins to support node v24

**Why do we need the change?**
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now

**What is the impact?**
Should continue to function beyond June 2nd, 2026

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/System%20Sustainability/Stories?workitem=282293