### PR TITLE
Rational for closure character limit increase

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Case/ConcernCaseRequest.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Case/ConcernCaseRequest.cs
@@ -26,7 +26,7 @@ namespace ConcernsCaseWork.API.Contracts.Case
         [StringLength(12)]
         public string TrustUkprn { get; set; }
 
-        [StringLength(200)]
+        [StringLength(1250)]
         public string ReasonAtReview { get; set; }
         public DateTime? DeEscalation { get; set; }
 

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsCaseIntegrationTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Tests/Integration/ConcernsCaseIntegrationTests.cs
@@ -484,7 +484,7 @@ public class ConcernsCaseIntegrationTests : IDisposable
 		request.NextSteps = new string('a', 4001);
 		request.CaseHistory = new string('a', 4301);
 		request.DirectionOfTravel = new string('a', 101);
-		request.ReasonAtReview = new string('a', 201);
+		request.ReasonAtReview = new string('a', 1251);
 		request.CreatedBy = new string('a', 255);
 		request.TrustCompaniesHouseNumber = new string('1', 9);
 		request.Division = 0;
@@ -502,7 +502,7 @@ public class ConcernsCaseIntegrationTests : IDisposable
 		error.Should().Contain("The field NextSteps must be a string with a maximum length of 4000.");
 		error.Should().Contain("The field CaseHistory must be a string with a maximum length of 4300.");
 		error.Should().Contain("The field DirectionOfTravel must be a string with a maximum length of 100.");
-		error.Should().Contain("The field ReasonAtReview must be a string with a maximum length of 200.");
+		error.Should().Contain("The field ReasonAtReview must be a string with a maximum length of 1250.");
 		error.Should().Contain("The field CreatedBy must be a string with a maximum length of 254.");
 		error.Should().Contain("The field TrustCompaniesHouseNumber must be a string with a maximum length of 8.");
 	}

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Closure.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Closure.cshtml.cs
@@ -122,7 +122,7 @@ namespace ConcernsCaseWork.Pages.Case.Management
 		{
 			Text = new ValidateableString()
 			{
-				MaxLength = 200,
+				MaxLength = 1250,
 				StringContents = contents,
 				DisplayName = "Rationale for closure",
 				Required = true


### PR DESCRIPTION
**What is the change?**
We increased the character limit of the Rational for closure.
No migration

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/System%20Sustainability/Stories?workitem=285540