### PR TITLE
Add cleanup step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0 AS final
 LABEL org.opencontainers.image.source="https://github.com/DFE-Digital/record-concerns-support-trusts"
 COPY --from=builder /app /app
 COPY --from=frontend /app/wwwroot /app/wwwroot
+RUN find /app/wwwroot -type f -name 'package-lock.json' -delete
 
 # Entrypoint script
 COPY ./script/web-docker-entrypoint.sh /app/docker-entrypoint.sh


### PR DESCRIPTION
Adds a cleanup step to Dockerfile to remove package-lock.json to avoid exposure

[Ticket](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/289896)